### PR TITLE
DM-2651: Wrote some unit tests and refactored some code

### DIFF
--- a/app/mailers/commontator/subscriptions_mailer.rb
+++ b/app/mailers/commontator/subscriptions_mailer.rb
@@ -18,8 +18,10 @@ class Commontator::SubscriptionsMailer < ActionMailer::Base
     @thread = @comment.thread
     @creator = @comment.creator
     @mail_params = { from: @thread.config.email_from_proc.call(@thread) }
+    practice = Practice.find(@comment.thread.commontable_id)
+    support_network_email = practice.support_network_email || nil
     @recipient_emails = recipients.map do |recipient|
-      Commontator.commontator_email(recipient, self)
+      support_network_email.present? && recipient === support_network_email.downcase ? recipient : Commontator.commontator_email(recipient, self)
     end
     @using_mailgun = Rails.application.config.action_mailer.delivery_method == :mailgun
     if @using_mailgun

--- a/app/models/commontator/subscription.rb
+++ b/app/models/commontator/subscription.rb
@@ -7,7 +7,21 @@ module Commontator
     validates_uniqueness_of :thread_id, :scope => [:subscriber_type, :subscriber_id]
 
     def self.comment_created(comment)
-      recipients = comment.thread.subscribers.reject{|s| s == comment.creator}
+      practice = Practice.find(comment.thread.commontable_id)
+      support_network_email = practice.support_network_email || nil
+      support_network_email_user = support_network_email.present? ? User.find_by(email: support_network_email.downcase) : nil
+      subscribers = comment.thread.subscribers
+
+      if support_network_email.present? && support_network_email_user.nil?
+        subscribers.push(practice.user, support_network_email.downcase)
+      elsif support_network_email.present? && support_network_email_user.present?
+        subscribers.push(practice.user, support_network_email_user)
+      else
+        subscribers.push(practice.user)
+      end
+      # filter out the comment creator and/or any duplicate subscribers
+      recipients = subscribers.reject { |s| s == comment.creator }.compact.uniq
+
       return if recipients.empty?
 
       mail = SubscriptionsMailer.comment_created(comment, recipients)

--- a/spec/features/admin/admin_spec.rb
+++ b/spec/features/admin/admin_spec.rb
@@ -5,9 +5,9 @@ require 'rails_helper'
 
 describe 'The admin dashboard', type: :feature do
   before do
-    @user = User.create!(email: 'spongebob.squarepants@va.gov', password: 'Password123',
+    @user = User.create!(email: 'spongebob.squarepants@va.gov', first_name: 'Spongebob', last_name: 'Squarepants', password: 'Password123',
                          password_confirmation: 'Password123', skip_va_validation: true, confirmed_at: Time.now, accepted_terms: true)
-    @user2 = User.create!(email: 'patrick.star@bikinibottom.net', password: 'Password123',
+    @user2 = User.create!(email: 'patrick.star@va.gov', first_name: 'Patrick', last_name: 'Star', password: 'Password123',
                           password_confirmation: 'Password123', skip_va_validation: true, confirmed_at: Time.now, accepted_terms: true)
     @admin = User.create!(email: 'sandy.cheeks@bikinibottom.net', password: 'Password123',
                           password_confirmation: 'Password123', skip_va_validation: true, confirmed_at: Time.now, accepted_terms: true)
@@ -541,5 +541,40 @@ describe 'The admin dashboard', type: :feature do
 
     # should not navigate away from metrics page
     expect(page).to have_current_path(admin_practice_path(@practice))
+  end
+
+  it 'if the practice user is changed, it should remove the previous practice user from the comment thread subscribers list for that practice, unless they created at least one comment on the thread' do
+    # trigger the create_or_update_practice method in the admin controller
+    login_as(@admin, scope: :user, run_callbacks: false)
+    visit '/admin/practices/the-best-practice-ever/edit'
+    click_button('Update Practice')
+
+    expect(Practice.first.commontator_thread.subscribers.first).to eq(@user)
+
+    # change the practice user
+    visit '/admin/practices/the-best-practice-ever/edit'
+    fill_in('User email', with: '')
+    fill_in('User email', with: @user2.email)
+    click_button('Update Practice')
+
+    expect(Practice.first.commontator_thread.subscribers.first).to_not eq(@user)
+    expect(Practice.first.commontator_thread.subscribers.first).to eq(@user2)
+
+    # create a comment with the current practice user
+    logout(@admin)
+    login_as(@user2, :scope => :user, :run_callbacks => false)
+    visit practice_path(@practice)
+    fill_in('comment[body]', with: 'This is a test comment')
+    click_button('commit')
+
+    # change the practice user back to the original user
+    logout(@user2)
+    login_as(@admin, :scope => :user, :run_callbacks => false)
+    visit '/admin/practices/the-best-practice-ever/edit'
+    fill_in('User email', with: '')
+    fill_in('User email', with: @user.email)
+    click_button('Update Practice')
+
+    expect(Practice.first.commontator_thread.subscribers).to include(@user, @user2)
   end
 end

--- a/spec/features/admin/admin_spec.rb
+++ b/spec/features/admin/admin_spec.rb
@@ -569,7 +569,6 @@ describe 'The admin dashboard', type: :feature do
 
     # change the practice user
     visit '/admin/practices/the-best-practice-ever/edit'
-    fill_in('User email', with: '')
     fill_in('User email', with: @user2.email)
     click_button('Update Practice')
 
@@ -587,7 +586,6 @@ describe 'The admin dashboard', type: :feature do
     logout(@user2)
     login_as(@admin, :scope => :user, :run_callbacks => false)
     visit '/admin/practices/the-best-practice-ever/edit'
-    fill_in('User email', with: '')
     fill_in('User email', with: @user.email)
     click_button('Update Practice')
 


### PR DESCRIPTION
### JIRA issue link
https://agile6.atlassian.net/browse/DM-2651

## Description - what does this code do?
1. Adds the practice owner to the list of email recipients when a comment is created for a practice, unless they are already subscribed to the thread.
2. Adds the practice's `support_network_email` to the list of email recipients when a comment is created for a practice, unless a `user` exists with the same email address AND that user is already subscribed to the thread.

## Testing done - how did you test it/steps on how can another person can test it 
_**Subscribing/Unsubscribing Practice Owner**_
1. Log in as an admin and visit `/admin/practices/new`.
2. Create a new practice with a user that has a `va.gov` email address (ex: test@va.gov).
3. Open up the rails console.
4. Run `Practice.last.commontator_thread.subscribers` and make sure the only subscriber is the `practice.user`.
5. Update the same practice with a new `va.gov` email user that you can actually log in with.
6. Run the same command and make sure the first `practice.user` is no longer a subscriber and the new `practice.user` is now a subscriber.
7. Log out as the admin, log back in with the user you added in step `5`, and visit the practice's show page and add a comment.
8. Now log out again, log back in as an admin, and visit /admin/practices/whatever-your-new-practice-slug-is/edit`.
9. Change the `practice.user` to the same user you used in step `2`, and update the practice.
10. Run `Practice.last.commontator_thread.subscribers` and make both `va.gov` users are now subscribers (because the user from step `5` created a comment, even if they are no longer the `practice.user` they should remain subscribed to the thread).

_**Comment Mailer**_
1. Log in as a valid user and visit the show page of a practice of your choice. Make sure the user is NOT the `practice.user` AND that their email does not match the practice's `support_network_email`.
2. Create either a comment or a reply.
3. **If the practice user's email and `support_network_email` are not the same**, make sure the `practice.user`'s email and the `support_network_email` are cc'd on the created comment email.
4. **If the practice user's email and `support_network_email` are the same**, make sure ONLY the `practice.user`'s email is cc'd on the created comment email.
5. Under no circumstance should the comment creator's email be included in the cc list.

## Screenshots, Gifs, Videos from application (if applicable)

## Link to mock-ups/mock ups (image file if you have it) (if applicable)

## Acceptance criteria
- Practice owner gets email whenever someone comments
- Practice owners gets email every time someone replies to a comment
- Email goes to "Contact" and “Owner” emails

## Definition of done
- [X] Unit tests written (if applicable)
- [X] e2e/accessibility tests written (if applicable)
- [X] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [X] A link has been provided to the originating JIRA issue
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs