### PR TITLE
Dm 2703

### DIFF
--- a/app/controllers/practices_controller.rb
+++ b/app/controllers/practices_controller.rb
@@ -705,7 +705,13 @@ end
 
 def set_initiating_fac_params(params)
   facility_type = params[:practice][:initiating_facility_type]
-  if facility_type == "facility" && params[:practice][:practice_origin_facilities_attributes].present?
+
+  if facility_type == "facility"
+    params[:practice][:practice_origin_facilities_attributes].values.each do |value|
+      if value[:facility_id].nil?
+        params[:practice][:practice_origin_facilities_attributes] = nil
+      end
+    end
     @practice.initiating_facility = ""
     @practice.initiating_department_office_id = ""
   elsif facility_type == "visn"

--- a/app/controllers/practices_controller.rb
+++ b/app/controllers/practices_controller.rb
@@ -692,7 +692,7 @@ class PracticesController < ApplicationController
       end
       pr_params = {practice: @practice, practice_params: practice_params, current_endpoint: current_endpoint}
       updated = SavePracticeService.new(pr_params).save_practice
-      clear_origin_facilities if facility_type != "facility" && current_endpoint == 'introduction'
+      clear_origin_facilities if facility_type != "facility" && current_endpoint == 'introduction' && !updated.is_a?(StandardError)
       updated
     end
   end
@@ -708,16 +708,26 @@ def set_initiating_fac_params(params)
   if facility_type == "facility" && params[:practice][:practice_origin_facilities_attributes].present?
     @practice.initiating_facility = ""
     @practice.initiating_department_office_id = ""
-  elsif facility_type == "visn" && params[:editor_visn_select].present?
-    @practice.initiating_facility = params[:editor_visn_select]
-    @practice.initiating_department_office_id = ""
-  elsif facility_type == "department" && params[:editor_office_state_select].present? && params[:practice][:initiating_department_office_id].present? && params[:practice][:initiating_facility]
-    @practice.initiating_facility = params[:practice][:initiating_facility]
-    @practice.initiating_department_office_id = params[:practice][:initiating_department_office_id]
-  elsif facility_type == "other" && params[:initiating_facility_other].present?
-    @practice.initiating_facility = params[:initiating_facility_other]
-    @practice.initiating_department_office_id = ""
-  else
-    params[:practice][:initiating_facility_type] = ""
+  elsif facility_type == "visn"
+    if params[:editor_visn_select].present?
+      @practice.initiating_facility = params[:editor_visn_select]
+      @practice.initiating_department_office_id = ""
+    else
+      @practice.initiating_facility = ""
+    end
+  elsif facility_type == "department"
+    if params[:editor_office_state_select].present? && params[:practice][:initiating_department_office_id].present? && params[:practice][:initiating_facility]
+      @practice.initiating_facility = params[:practice][:initiating_facility]
+      @practice.initiating_department_office_id = params[:practice][:initiating_department_office_id]
+    else
+      @practice.initiating_facility = ""
+    end
+  elsif facility_type == "other"
+    if params[:initiating_facility_other].present?
+      @practice.initiating_facility = params[:initiating_facility_other]
+      @practice.initiating_department_office_id = ""
+    else
+      @practice.initiating_facility = ""
+    end
   end
 end

--- a/app/models/visn.rb
+++ b/app/models/visn.rb
@@ -39,6 +39,9 @@ class Visn < ApplicationRecord
   end
 
   def get_created_practices(station_numbers)
-    (Practice.published_enabled_approved.load_associations.where(initiating_facility_type: 'facility').get_by_created_facility(station_numbers)).or(Practice.published_enabled_approved.load_associations.joins(:practice_origin_facilities).where(initiating_facility_type: 'visn').where(initiating_facility: id.to_s))
+    facility_created_practices = Practice.published_enabled_approved.load_associations.where(initiating_facility_type: 'facility').get_by_created_facility(station_numbers)
+    visn_created_practices = Practice.published_enabled_approved.load_associations.where(initiating_facility_type: 'visn').where(initiating_facility: id.to_s)
+
+    facility_created_practices + visn_created_practices
   end
 end

--- a/app/services/save_practice_service.rb
+++ b/app/services/save_practice_service.rb
@@ -321,13 +321,15 @@ class SavePracticeService
   def update_initiating_facility
     initiating_facility_type = @practice_params[:initiating_facility_type]
     initiating_facility = @practice.initiating_facility
-    if initiating_facility_type.present? && initiating_facility.present?
-      if initiating_facility_type != 'department'
-        @practice.update_attributes(initiating_department_office_id: nil)
+    if @current_endpoint === 'introduction'
+      if initiating_facility_type.present? && initiating_facility.present?
+        if initiating_facility_type != 'department'
+          @practice.update_attributes(initiating_department_office_id: nil)
+        end
+        @practice.update_attributes({initiating_facility_type: initiating_facility_type, initiating_facility: initiating_facility})
+      elsif initiating_facility.blank? && @practice_params[:practice_origin_facilities_attributes].nil?
+        raise StandardError.new @error_messages[:update_initiating_facility]
       end
-      @practice.update_attributes({initiating_facility_type: initiating_facility_type, initiating_facility: initiating_facility})
-    elsif initiating_facility.blank? && @practice_params[:practice_origin_facilities_attributes].nil?
-      raise StandardError.new @error_messages[:update_initiating_facility]
     end
   end
 

--- a/app/services/save_practice_service.rb
+++ b/app/services/save_practice_service.rb
@@ -47,6 +47,9 @@ class SavePracticeService
       if @practice_params["practice_editors_attributes"].present?
         update_practice_editors
       end
+      if @practice_params["initiating_facility_type"].present?
+        update_initiating_facility
+      end
 
       updated = @practice.update(@practice_params)
       rescue_method(:update_practice_partner_practices)
@@ -317,18 +320,14 @@ class SavePracticeService
 
   def update_initiating_facility
     initiating_facility_type = @practice_params[:initiating_facility_type]
-    initiating_facility = @practice_params[:initiating_facility]
+    initiating_facility = @practice.initiating_facility
     if initiating_facility_type.present? && initiating_facility.present?
       if initiating_facility_type != 'department'
         @practice.update_attributes(initiating_department_office_id: nil)
       end
-      # if @current_endpoint == 'overview'
-      if initiating_facility_type.present? && initiating_facility.present?
-        @practice.update_attributes({initiating_facility_type: initiating_facility_type, initiating_facility: initiating_facility})
-      else
-        raise StandardError.new @error_messages[:update_initiating_facility]
-      end
-      # end
+      @practice.update_attributes({initiating_facility_type: initiating_facility_type, initiating_facility: initiating_facility})
+    elsif initiating_facility.blank? && @practice_params[:practice_origin_facilities_attributes].nil?
+      raise StandardError.new @error_messages[:update_initiating_facility]
     end
   end
 

--- a/spec/features/practice_editor/introduction/image_editor_spec.rb
+++ b/spec/features/practice_editor/introduction/image_editor_spec.rb
@@ -9,7 +9,7 @@ describe 'Diffusion Marketplace image editor', type: :feature, js: true do
     @unacceptable_img_dimension_path = "#{Rails.root}/spec/assets/unacceptable_img_dimension.jpg"
     @unacceptable_img_size_path = "#{Rails.root}/spec/assets/unacceptable_img_size.png"
 
-    @pr_with_thumbnail = Practice.create!(name: 'A practice with a thumbnail', tagline: 'A public tagline',  slug: 'a-thumbnail-practice', summary: 'test summary', date_initiated: Time.now, initiating_facility: 'test facility', approved: true, published: true, main_display_image: File.new(@acceptable_img_path), user: admin)
+    @pr_with_thumbnail = Practice.create!(name: 'A practice with a thumbnail', tagline: 'A public tagline',  slug: 'a-thumbnail-practice', summary: 'test summary', date_initiated: Time.now, initiating_facility: 'test facility', initiating_facility_type: 'other', approved: true, published: true, main_display_image: File.new(@acceptable_img_path), user: admin)
     @pr_without_thumbnail = Practice.create!(name: 'A practice without a thumbnail', tagline: 'A public tagline', slug: 'a-no-thumbnail-practice', summary: 'test summary', date_initiated: Time.now, initiating_facility: 'test facility', initiating_facility_type: 'other', approved: true, published: true, user: admin)
 
     login_as(admin, :scope => :user, :run_callbacks => false)

--- a/spec/features/practice_editor/introduction/introduction_spec.rb
+++ b/spec/features/practice_editor/introduction/introduction_spec.rb
@@ -154,6 +154,30 @@ describe 'Practice editor - introduction', type: :feature, js: true do
         expect(page).to have_no_content('Montgomery Regional Office')
         expect(page).to have_content('Xavier Institute')
       end
+
+      it 'should display an error and revert changes if fields are not populated' do
+        # select the VISN radio option, but do not select a VISN
+        click_origin_type('initiating_facility_type_visn')
+        click_save
+        expect(page).to_not have_content('Practice was successfully updated.')
+        expect(page).to have_content('There was an error updating initiating facility. The practice was not saved.')
+
+        # now change initiating_facility_type to VISN, save, and then choose the Office radio option without choosing a facility
+        click_origin_type('initiating_facility_type_visn')
+        select('VISN-1', :from => 'editor_visn_select')
+        click_save
+        visit_practice_show
+        expect(page).to have_no_content('Birmingham VA Medical Center (Birmingham-Alabama)')
+        expect(page).to have_content('VISN-1')
+
+        visit_practice_edit
+        click_origin_type('initiating_facility_type_department')
+        select('VBA', :from => 'editor_department_select')
+        select('Alabama', :from => 'editor_office_state_select')
+        click_save
+        expect(page).to_not have_content('Practice was successfully updated.')
+        expect(page).to have_content('There was an error updating initiating facility. The practice was not saved.')
+      end
     end
 
     context 'awards and recognition' do

--- a/spec/features/visn_spec.rb
+++ b/spec/features/visn_spec.rb
@@ -449,6 +449,8 @@ describe 'VISN pages', type: :feature do
       it 'should allow users to search for practices that were created or adopted within a given visn' do
         visit '/visns/2'
 
+        debugger
+
         # defaults to created practices
         # make sure 'Load more' feature is working
         expect(practice_cards.count).to eq(6)

--- a/spec/features/visn_spec.rb
+++ b/spec/features/visn_spec.rb
@@ -449,8 +449,6 @@ describe 'VISN pages', type: :feature do
       it 'should allow users to search for practices that were created or adopted within a given visn' do
         visit '/visns/2'
 
-        debugger
-
         # defaults to created practices
         # make sure 'Load more' feature is working
         expect(practice_cards.count).to eq(6)


### PR DESCRIPTION
### JIRA issue link
https://agile6.atlassian.net/browse/DM-2703

## Description - what does this code do?
1. Does not save any changes to `Originating facility` portion of the `Introduction` page of the practice editor if all fields are not filled out properly.
2. Fixes small issue with practices created by a given VISN that have a VISN as their `initiating_facility` not showing up for the search portion of the VISN show page.

## Testing done - how did you test it/steps on how can another person can test it 
_**Originating Facility**_
1. Log in as an admin and visit `/practices/#{whatever practice you want}/edit/introduction`.
2. Scroll down to the `Practice origin` section and keep note of what the practice currently has as far as origin facility/facilities.
3. Now select another facility type option, but do not choose an actual facility(ex: Choose "Office", select an "Administration" and a "State", but not an "Office") and click "Save."
4. Confirm that your changes were not saved and that you were reverted back to the original state.
5. Try this with all four `initiating_facility` types and confirm the behavior is the same for each one.

_**Practices Created In a VISN**_
1. Comment out lines `41-46` of `visn.rb` and add the original `get_practices_created` code:
```
def get_created_practices(station_numbers)
   (Practice.published_enabled_approved.load_associations.where(initiating_facility_type: 
'facility').get_by_created_facility(station_numbers)).or(Practice.published_enabled_approved.load_associations.joins(:practice_origin_facilities).where(initiating_facility_type: 'visn').where(initiating_facility: id.to_s))
end
```
2. If you don't have one, edit a practice so that it's `initiating_facility` is "visn" and assign it a VISN of your choosing.
3. Now visit the show page of the VISN you just assigned as the `initiating_facility` for that practice.
4. Scroll down to the `Search for practices` section and confirm you do not see that practice under the "Practices created in this VISN" option.
5. Now remove the code from step 1 and comment back in the new `get_practices_created` code.
6. Refresh the page and confirm the practice is now there.
_**NOTE:**_ For some reason, this did not affect the unit tests written for the visn pages. In theory, this issue should've been caught there, but the original function did not break the tests.

## Screenshots, Gifs, Videos from application (if applicable)
![](https://media.giphy.com/media/8hXEejJxdvTZ4BtRXn/giphy.gif)

## Link to mock-ups/mock ups (image file if you have it) (if applicable)


## Acceptance criteria
- If not saved correctly, revert back to original state

## Definition of done
- [X] Unit tests written (if applicable)
- [ ] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [X] A link has been provided to the originating JIRA issue
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs