### PR TITLE
DM-2670: Update diffusion map copy

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -12,6 +12,9 @@ class HomeController < ApplicationController
     @vamc_facilities = VaFacility.cached_va_facilities.select(:street_address_state, :official_station_name, :id, :common_name, :station_number, :latitude, :longitude, :slug, :fy17_parent_station_complexity_level, :visn_id, :rurality).order(:street_address_state, :official_station_name)
     @visns = Visn.cached_visns.select(:id, :number)
     @diffusion_histories = DiffusionHistory.get_with_practices.order(Arel.sql("lower(practices.name)"))
+    @successful_ct = @diffusion_histories.get_by_successful_status.size
+    @in_progress_ct = @diffusion_histories.get_by_in_progress_status.size
+    @unsuccessful_ct = @diffusion_histories.get_by_unsuccessful_status.size
 
     @dh_markers = Gmaps4rails.build_markers(@diffusion_histories.group_by(&:facility_id)) do |dhg, marker|
       station_number = dhg[0]

--- a/app/views/maps/diffusion_map.html.erb
+++ b/app/views/maps/diffusion_map.html.erb
@@ -11,10 +11,9 @@
     <% end %>
 
     <h4 class="font-sans-xl margin-bottom-1 margin-top-0 line-height-sans-205">Diffusion map</h4>
-    <p class="font-sans-lg margin-bottom-2">Explore how practices are being adopted across the country.</p>
-    <div class="padding-y-105 padding-x-2 bg-gold radius-md margin-bottom-205">
-      <span class="text-bold">Note:</span>&nbsp;<span>More practices will be added to this map in the next few months.</span>
-    </div>
+    <p class="font-sans-lg margin-bottom-5 line-height-sans-5">
+      Explore how practices are being adopted across the country. There are currently <%= @successful_ct %> completed adoption<%= @successful_ct === 1 ? '' : 's' %>, <%= @in_progress_ct %> in-progress adoption<%= @in_progress_ct === 1 ? '' : 's' %>, and <%= @unsuccessful_ct %> unsuccessful adoption<%= @unsuccessful_ct === 1 ? '' : 's' %>.
+    </p>
     <div class="diffusion-map-container display-none">
       <button id="filterResultsTrigger" class="map-filters-trigger usa-button text-bold display-block margin-bottom-105 padding-2">
         Filter results

--- a/spec/features/home_map_spec.rb
+++ b/spec/features/home_map_spec.rb
@@ -89,6 +89,7 @@ describe 'Map of Diffusion', type: :feature, js: true do
   end
 
   it 'displays and filters the map' do
+    expect(page).to have_content('Explore how practices are being adopted across the country. There are currently 2 completed adoptions, 3 in-progress adoptions, and 1 unsuccessful adoption.')
     expect_marker_ct(3)
 
     # filters button


### PR DESCRIPTION
### JIRA issue link
[DM-2670](https://agile6.atlassian.net/browse/DM-2670)

## Description - what does this code do?
This PR replaces the banner on the diffusion map page with counts of successful, unsuccessful, and in-progress adoptions.

## Testing done - how did you test it/steps on how can another person can test it 
1. Go to `/diffusion-map`
2. You should now see adoptions counts as the copy instead of a gold banner.

## Screenshots, Gifs, Videos from application (if applicable)
<img width="1428" alt="Screen Shot 2021-07-07 at 1 45 57 PM" src="https://user-images.githubusercontent.com/20211771/124812803-b5b31e00-df29-11eb-8a1e-f3f2a5897a83.png">


## Link to mock-ups/mock ups (image file if you have it) (if applicable)
[Figma](https://www.figma.com/file/xjaSwxytWsGGGCcc9f9Yfa/Desktop?node-id=7%3A49)
*Note: This PR only addresses the copy change and NOT the rebranding changes in this Figma.

## Acceptance criteria
- [X] Remove "Note: More practices are being added" banner
- [X] Replace it with running total of Successful, Unsuccessful, and In progress practices
- [X] Build totals to automatically update when adoptions are added
- [ ] Release to Prod

## Definition of done
- [ ] Unit tests written (if applicable)
- [X] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [X] A link has been provided to the originating JIRA issue
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs