### PR TITLE
Dm 2726 - Disable ability to comment for public users.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -265,7 +265,7 @@ GEM
       activesupport (>= 4.2.0)
     jmespath (1.4.0)
     jquery-cropper (2.3.2)
-    jquery-rails (4.3.5)
+    jquery-rails (4.4.0)
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)

--- a/app/views/commontator/comments/_form.html.erb
+++ b/app/views/commontator/comments/_form.html.erb
@@ -33,9 +33,9 @@
   <% end %>
 
   <div class="field <%= comment.parent.nil? && new_record ? 'comment-field' : 'reply-field' %>">
-
+    <% public_user = session[:user_type] === 'public' ? 'disabled' : '' %>
     <%=
-      form.text_area :body, rows: '7', aria: { label: 'comment text area' }, placeholder: "#{comment.parent.nil? && new_record ? 'Type your comment here...' : 'Type your reply here...' }",
+      form.text_area :body, rows: '7', disabled: public_user, aria: { label: 'comment text area' }, placeholder: "#{comment.parent.nil? && new_record ? 'Type your comment here...' : 'Type your reply here...' }",
         class: comment.parent.nil? && new_record ? 'usa-textarea comment-textarea line-height-26' : 'usa-textarea reply-textarea line-height-26', id: new_record ?
         comment.parent.nil? ? "commontator-thread-#{@commontator_thread.id}-new-comment-body" :
                               "commontator-comment-#{comment.parent.id}-reply" :

--- a/app/views/commontator/comments/_form.html.erb
+++ b/app/views/commontator/comments/_form.html.erb
@@ -33,70 +33,72 @@
   <% end %>
 
   <div class="field <%= comment.parent.nil? && new_record ? 'comment-field' : 'reply-field' %>">
-    <% public_user = session[:user_type] === 'public' ? 'disabled' : '' %>
-    <%=
-      form.text_area :body, rows: '7', disabled: public_user, aria: { label: 'comment text area' }, placeholder: "#{comment.parent.nil? && new_record ? 'Type your comment here...' : 'Type your reply here...' }",
-        class: comment.parent.nil? && new_record ? 'usa-textarea comment-textarea line-height-26' : 'usa-textarea reply-textarea line-height-26', id: new_record ?
-        comment.parent.nil? ? "commontator-thread-#{@commontator_thread.id}-new-comment-body" :
-                              "commontator-comment-#{comment.parent.id}-reply" :
-        "commontator-comment-#{comment.id}-edit-body"
-    %>
-    <%= javascript_tag('Commontator.initMentions();') if config.mentions_enabled %>
-  </div>
+    <% is_public_user = session[:user_type] === 'public' ? true : false %>
+    <% if !is_public_user %>
+        <%=
+          form.text_area :body, rows: '7', aria: { label: 'comment text area' }, placeholder: "#{comment.parent.nil? && new_record ? 'Type your comment here...' : 'Type your reply here...' }",
+            class: comment.parent.nil? && new_record ? 'usa-textarea comment-textarea line-height-26' : 'usa-textarea reply-textarea line-height-26', id: new_record ?
+            comment.parent.nil? ? "commontator-thread-#{@commontator_thread.id}-new-comment-body" :
+                                  "commontator-comment-#{comment.parent.id}-reply" :
+            "commontator-comment-#{comment.id}-edit-body"
+        %>
+        <%= javascript_tag('Commontator.initMentions();') if config.mentions_enabled %>
+      </div>
 
-  <div class="submit">
-    <div class="text-left usa-fieldset" role="radiogroup">
-      <%# Radio buttons go here %>
-      <% if comment.parent_id.present? && new_record %>
-        <div class="usa-radio">
-          <%= radio_button_tag 'user_practice_status', :verified_implementer, verified_practice_implementer ? true : false, class: 'usa-radio__input', id: "verified-implementer-#{comment.parent_id}" %>
-          <%= label_tag 'user_practice_status_verified_implementer', 'I am currently adopting this practice', class: 'usa-radio__label implementer-label margin-bottom-1', for: "verified-implementer-#{comment.parent_id}" %>
+      <div class="submit">
+        <div class="text-left usa-fieldset" role="radiogroup">
+          <%# Radio buttons go here %>
+          <% if comment.parent_id.present? && new_record %>
+            <div class="usa-radio">
+              <%= radio_button_tag 'user_practice_status', :verified_implementer, verified_practice_implementer ? true : false, class: 'usa-radio__input', id: "verified-implementer-#{comment.parent_id}" %>
+              <%= label_tag 'user_practice_status_verified_implementer', 'I am currently adopting this practice', class: 'usa-radio__label implementer-label margin-bottom-1', for: "verified-implementer-#{comment.parent_id}" %>
+            </div>
+            <div class="usa-radio">
+              <%= radio_button_tag 'user_practice_status', :team_member, practice_team_member ? true : false, class: 'usa-radio__input', id: "team-member-#{comment.parent_id}" %>
+              <%= label_tag 'user_practice_status_team_member', 'I am a member of this practice team', class: 'usa-radio__label team-member-label', for: "team-member-#{comment.parent_id}" %>
+            </div>
+          <% elsif new_record %>
+            <div class="usa-radio">
+              <%= radio_button_tag 'user_practice_status', :verified_implementer, verified_practice_implementer ? true : false, class: 'usa-radio__input', id: 'verified-implementer' %>
+              <%= label_tag 'user_practice_status_verified_implementer', 'I am currently adopting this practice', class: 'usa-radio__label implementer-label margin-bottom-1', for: 'verified-implementer' %>
+            </div>
+            <div class="usa-radio">
+              <%= radio_button_tag 'user_practice_status', :team_member, practice_team_member ? true : false, class: 'usa-radio__input', id: 'team-member' %>
+              <%= label_tag 'user_practice_status_team_member', 'I am a member of this practice team', class: 'usa-radio__label team-member-label', for: 'team-member' %>
+            </div>
+          <% end %>
+          <% if !new_record %>
+            <div class="usa-radio">
+              <%= radio_button_tag 'user_practice_status', :verified_implementer, verified_practice_implementer ? true : false, class: 'usa-radio__input', id: "verified-implementer-#{comment.id}" %>
+              <%= label_tag 'user_practice_status_verified_implementer', 'I am currently adopting this practice', class: 'usa-radio__label implementer-label margin-bottom-1', for: "verified-implementer-#{comment.id}" %>
+            </div>
+            <div class="usa-radio">
+              <%= radio_button_tag 'user_practice_status', :team_member, practice_team_member ? true : false, class: 'usa-radio__input', id: "team-member-#{comment.id}" %>
+              <%= label_tag 'user_practice_status_team_member', 'I am a member of this practice team', class: 'usa-radio__label team-member-label', for: "team-member-#{comment.id}" %>
+            </div>
+          <% end %>
         </div>
-        <div class="usa-radio">
-          <%= radio_button_tag 'user_practice_status', :team_member, practice_team_member ? true : false, class: 'usa-radio__input', id: "team-member-#{comment.parent_id}" %>
-          <%= label_tag 'user_practice_status_team_member', 'I am a member of this practice team', class: 'usa-radio__label team-member-label', for: "team-member-#{comment.parent_id}" %>
-        </div>
-      <% elsif new_record %>
-        <div class="usa-radio">
-          <%= radio_button_tag 'user_practice_status', :verified_implementer, verified_practice_implementer ? true : false, class: 'usa-radio__input', id: 'verified-implementer' %>
-          <%= label_tag 'user_practice_status_verified_implementer', 'I am currently adopting this practice', class: 'usa-radio__label implementer-label margin-bottom-1', for: 'verified-implementer' %>
-        </div>
-        <div class="usa-radio">
-          <%= radio_button_tag 'user_practice_status', :team_member, practice_team_member ? true : false, class: 'usa-radio__input', id: 'team-member' %>
-          <%= label_tag 'user_practice_status_team_member', 'I am a member of this practice team', class: 'usa-radio__label team-member-label', for: 'team-member' %>
-        </div>
+        <div class="text-left margin-top-2">
+          <% if config.new_comment_style == :t && new_record && comment.parent.nil? %>
+            <%=
+              form.submit(
+                t('commontator.comment.actions.cancel'), name: 'cancel', class: 'comment-cancel usa-button--outline dm-btn-primary',
+                  id: "commontator-thread-#{@commontator_thread.id}-new-comment-submit"
+              )
+            %>
+          <% else %>
+            <%=
+              form.submit(
+                t('commontator.comment.actions.cancel'), name: 'cancel', class: 'usa-button usa-button--outline dm-btn-primary comment-cancel'
+              )
+            %>
+          <% end %>
+            <% if comment.parent %>
+              <%= form.submit t("commontator.comment.actions.#{new_record ? 'create' : 'update'}"), name: 'reply', class: 'comment-submit margin-right-0 usa-button dm-btn-primary', id: "#{comment.parent && new_record ? 'submit-reply' : 'submit-reply-edit'}" %>
+            <% else %>
+              <%= form.submit t("commontator.comment.actions.#{new_record ? 'create' : 'update'}"), class: "comment-submit margin-right-0 usa-button dm-btn-primary", id: "#{new_record ? 'submit-comment' : 'submit-comment-edit'}", value: 'Post' %>
+            <% end %>
       <% end %>
-      <% if !new_record %>
-        <div class="usa-radio">
-          <%= radio_button_tag 'user_practice_status', :verified_implementer, verified_practice_implementer ? true : false, class: 'usa-radio__input', id: "verified-implementer-#{comment.id}" %>
-          <%= label_tag 'user_practice_status_verified_implementer', 'I am currently adopting this practice', class: 'usa-radio__label implementer-label margin-bottom-1', for: "verified-implementer-#{comment.id}" %>
-        </div>
-        <div class="usa-radio">
-          <%= radio_button_tag 'user_practice_status', :team_member, practice_team_member ? true : false, class: 'usa-radio__input', id: "team-member-#{comment.id}" %>
-          <%= label_tag 'user_practice_status_team_member', 'I am a member of this practice team', class: 'usa-radio__label team-member-label', for: "team-member-#{comment.id}" %>
-        </div>
-      <% end %>
-    </div>
-    <div class="text-left margin-top-2">
-      <% if config.new_comment_style == :t && new_record && comment.parent.nil? %>
-        <%=
-          form.submit(
-            t('commontator.comment.actions.cancel'), name: 'cancel', class: 'comment-cancel usa-button--outline dm-btn-primary',
-              id: "commontator-thread-#{@commontator_thread.id}-new-comment-submit"
-          )
-        %>
-      <% else %>
-        <%=
-          form.submit(
-            t('commontator.comment.actions.cancel'), name: 'cancel', class: 'usa-button usa-button--outline dm-btn-primary comment-cancel'
-          )
-        %>
-      <% end %>
-        <% if comment.parent %>
-          <%= form.submit t("commontator.comment.actions.#{new_record ? 'create' : 'update'}"), name: 'reply', class: 'comment-submit margin-right-0 usa-button dm-btn-primary', id: "#{comment.parent && new_record ? 'submit-reply' : 'submit-reply-edit'}" %>
-        <% else %>
-          <%= form.submit t("commontator.comment.actions.#{new_record ? 'create' : 'update'}"), class: "comment-submit margin-right-0 usa-button dm-btn-primary", id: "#{new_record ? 'submit-comment' : 'submit-comment-edit'}", value: 'Post' %>
-        <% end %>
     </div>
   </div>
 <% end %>

--- a/app/views/commontator/comments/_form.html.erb
+++ b/app/views/commontator/comments/_form.html.erb
@@ -33,7 +33,7 @@
   <% end %>
 
   <div class="field <%= comment.parent.nil? && new_record ? 'comment-field' : 'reply-field' %>">
-    <% is_public_user = session[:user_type] === 'public' ? true : false %>
+    <% is_public_user = session[:user_type] === 'public' %>
     <% if !is_public_user %>
         <%=
           form.text_area :body, rows: '7', aria: { label: 'comment text area' }, placeholder: "#{comment.parent.nil? && new_record ? 'Type your comment here...' : 'Type your reply here...' }",

--- a/app/views/commontator/comments/_show.html.erb
+++ b/app/views/commontator/comments/_show.html.erb
@@ -67,7 +67,7 @@
       <% end %>
 
       <span id="commontator-comment-<%= comment.id %>-actions" class="actions text-middle">
-        <% if !@practice.retired %>
+        <% if !@practice.retired && session[:user_type] != 'public' %>
           <%=
             link_to(
                 '',
@@ -84,7 +84,7 @@
           <% if comment.can_be_deleted_by?(user) %>
             <% is_deleted = comment.is_deleted? %>
             <% del_string = is_deleted ? 'undelete' : 'delete' %>
-            <% if !@practice.retired %>
+            <% if !@practice.retired && session[:user_type] != 'public' %>
                 <%= link_to  '',
                              is_deleted ? commontator.undelete_comment_path(comment) : commontator.delete_comment_path(comment),
                              data: is_deleted ? { confirm: "Are you sure you want to restore this #{comment.parent.nil? ? 'comment' : 'reply'}?"} : { confirm: "Are you sure you want to delete this #{comment.parent.nil? ? 'comment' : 'reply'}?" },
@@ -136,7 +136,7 @@
         </span>
         <% if !comment.parent_id? %>
           <% unless comment.is_deleted? %>
-          <% if !@practice.retired %>
+          <% if !@practice.retired && session[:user_type] != 'public' %>
             <span id="commontator-comment-<%= comment.id %>-reply-link" class="reply display-inline-block">
               <%=
                 link_to(

--- a/app/views/commontator/comments/_show.html.erb
+++ b/app/views/commontator/comments/_show.html.erb
@@ -4,6 +4,7 @@
   # comment
   # nested_children or page
   # show_all
+  comments_disabled = @practice.retired || session[:user_type] === 'public'
   thread = comment.thread
   nested_children ||= begin
     children = thread.paginated_comments(page, comment.id, show_all)
@@ -161,8 +162,8 @@
 
       <!-- Replies -->
       <% if nested_children.count > 0 %>
-        <div class="show-hide-buttons-container display-inline-block text-bold position-absolute top-0 left-0" id="comment-<%= comment.id %>-button-container">
-          <button
+        <div class="<% if comments_disabled %>text-bold grid-row flex-align-left<% else %>show-hide-buttons-container display-inline-block text-bold position-absolute top-0 left-0<% end %>" id="comment-<%= comment.id %>-button-container">
+        <button
             id="comments-show-hide-button-<%= comment.id %>"
             data-number-replies="<%= nested_children.count %>"
             <%= 'disabled' if comment.is_deleted? %>

--- a/app/views/commontator/comments/_show.html.erb
+++ b/app/views/commontator/comments/_show.html.erb
@@ -28,7 +28,7 @@
         <% if session[:user_type] != 'public' %>
           <%= link_to "#{name} #{job_title ? '(' + job_title + ')' : ''}", "/users/#{creator.id}", class:'dm-link-title' %>
         <% else %>
-          <b><%= "#{name} #{job_title ? '(' + job_title + ')' : ''}" %></b>
+          <span class="text-bold"><%= "#{name} #{job_title ? '(' + job_title + ')' : ''}" %></span>
         <% end %>
       </span>
       
@@ -94,8 +94,6 @@
                              id: "commontator-comment-#{comment.id}-#{del_string}",
                              class: is_deleted ? "fas fa-trash-restore-alt fa-lg margin-left-1" : "fas fa-trash-alt fa-lg delete-comment-icon margin-left-1",
                              remote: true %>
-            <% else %>
-<!--              <a class="<%#= is_deleted ? 'fas fa-trash-restore-alt fa-lg margin-left-1' : 'fas fa-trash-alt fa-lg delete-comment-icon margin-left-1' %>"></a>-->
              <% end %>
           <% end %>
       </span>
@@ -149,10 +147,6 @@
                 ) if thread.config.comment_reply_style != :n && !thread.is_closed?
               %>
             </span>
-            <% else %>
-<!--              <span>-->
-<!--                <a class="usa-button--unstyled dm-btn-primary reply-link" href="#" onclick="return false">Reply</a>-->
-<!--              </span>-->
             <% end %>
           <% end %>
           <% end %>

--- a/app/views/commontator/comments/_show.html.erb
+++ b/app/views/commontator/comments/_show.html.erb
@@ -28,7 +28,7 @@
         <% if session[:user_type] != 'public' %>
           <%= link_to "#{name} #{job_title ? '(' + job_title + ')' : ''}", "/users/#{creator.id}", class:'dm-link-title' %>
         <% else %>
-            <%= "#{name} #{job_title ? '(' + job_title + ')' : ''}" %>
+          <b><%= "#{name} #{job_title ? '(' + job_title + ')' : ''}" %></b>
         <% end %>
       </span>
       
@@ -81,8 +81,6 @@
                 remote: true
             ) if comment.can_be_edited_by?(user)
           %>
-         <% else %>
-<!--          <a class="fas fa-edit fa-lg edit-comment-icon margin-left-1"></a>-->
         <% end %>
 
           <% if comment.can_be_deleted_by?(user) %>

--- a/app/views/commontator/comments/_show.html.erb
+++ b/app/views/commontator/comments/_show.html.erb
@@ -72,7 +72,7 @@
       <% end %>
 
       <span id="commontator-comment-<%= comment.id %>-actions" class="actions text-middle">
-        <% if !@practice.retired && session[:user_type] != 'public' %>
+        <% if !comments_disabled %>
           <%=
             link_to(
                 '',
@@ -87,7 +87,7 @@
           <% if comment.can_be_deleted_by?(user) %>
             <% is_deleted = comment.is_deleted? %>
             <% del_string = is_deleted ? 'undelete' : 'delete' %>
-            <% if !@practice.retired && session[:user_type] != 'public' %>
+            <% if !comments_disabled %>
                 <%= link_to  '',
                              is_deleted ? commontator.undelete_comment_path(comment) : commontator.delete_comment_path(comment),
                              data: is_deleted ? { confirm: "Are you sure you want to restore this #{comment.parent.nil? ? 'comment' : 'reply'}?"} : { confirm: "Are you sure you want to delete this #{comment.parent.nil? ? 'comment' : 'reply'}?" },
@@ -98,7 +98,7 @@
              <% end %>
           <% end %>
       </span>
-      <% if !@practice.retired && session[:user_type] != 'public' %>
+      <% if !comments_disabled %>
           <% if current_user != creator %>
             <div class="report-comment fas fa-flag text-base padding-x-1 text-middle report-abuse-container" id="comment-<%= comment.id %>-report-abuse-container">
               <div class="report-abuse-modal hidden font-family-sans" id="comment-<%= comment.id %>-report-abuse-modal">
@@ -138,7 +138,7 @@
         </span>
         <% if !comment.parent_id? %>
           <% unless comment.is_deleted? %>
-          <% if !@practice.retired && session[:user_type] != 'public' %>
+          <% if !comments_disabled %>
             <span id="commontator-comment-<%= comment.id %>-reply-link" class="reply display-inline-block">
               <%=
                 link_to(
@@ -190,17 +190,3 @@
     </div>
   </div>
 </div>
-
-
-
-<%#<div id="commontator-comment-<%= comment.id %><%#-pagination" class="comments-pagination">
-  <div id="commontator-comment-<%= comment.id %><%#-will-paginate" class="will-paginate">
-    <%= will_paginate nested_children,
-                      renderer: Commontator::LinkRenderer,
-                      name: t('commontator.comment.status.reply_pages'),
-                      remote: true,
-                      params: { controller: 'commontator/comments',
-                                action: 'show',
-                                id: comment.id } %>
-<%#  </div>
-</div>%>

--- a/app/views/commontator/comments/_show.html.erb
+++ b/app/views/commontator/comments/_show.html.erb
@@ -25,7 +25,11 @@
   <div class="grid-col-fill comment-width-ie">
     <div id="commontator-comment-<%= comment.id %>-section-top" class="section top margin-bottom-1 line-height-26">
       <span id="commontator-comment-<%= comment.id %>-author" class="author line-height-26 text-middle">
-        <%= link_to "#{name} #{job_title ? '(' + job_title + ')' : ''}", "/users/#{creator.id}", class:'dm-link-title' %>
+        <% if session[:user_type] != 'public' %>
+          <%= link_to "#{name} #{job_title ? '(' + job_title + ')' : ''}", "/users/#{creator.id}", class:'dm-link-title' %>
+        <% else %>
+            <%= "#{name} #{job_title ? '(' + job_title + ')' : ''}" %>
+        <% end %>
       </span>
       
       <% if practice_team_member %>
@@ -78,7 +82,7 @@
             ) if comment.can_be_edited_by?(user)
           %>
          <% else %>
-          <a class="fas fa-edit fa-lg edit-comment-icon margin-left-1"></a>
+<!--          <a class="fas fa-edit fa-lg edit-comment-icon margin-left-1"></a>-->
         <% end %>
 
           <% if comment.can_be_deleted_by?(user) %>
@@ -93,33 +97,34 @@
                              class: is_deleted ? "fas fa-trash-restore-alt fa-lg margin-left-1" : "fas fa-trash-alt fa-lg delete-comment-icon margin-left-1",
                              remote: true %>
             <% else %>
-              <a class="<%= is_deleted ? 'fas fa-trash-restore-alt fa-lg margin-left-1' : 'fas fa-trash-alt fa-lg delete-comment-icon margin-left-1' %>"></a>
+<!--              <a class="<%#= is_deleted ? 'fas fa-trash-restore-alt fa-lg margin-left-1' : 'fas fa-trash-alt fa-lg delete-comment-icon margin-left-1' %>"></a>-->
              <% end %>
           <% end %>
       </span>
-
-      <% if current_user != creator %>
-        <div class="report-comment fas fa-flag text-base padding-x-1 text-middle report-abuse-container" id="comment-<%= comment.id %>-report-abuse-container">
-          <div class="report-abuse-modal hidden font-family-sans" id="comment-<%= comment.id %>-report-abuse-modal">
-            <div class="bg-white radius-md report-abuse-modal-content width-tablet">
-              <div class="bg-secondary text-white radius-top-md">
-                  <h2 class="margin-0 padding-3">Report a comment</h2>
-              </div>
-              <div class="padding-3">
-                <p class="font-sans-md text-normal text-black margin-bottom-2">I am reporting the following comment for being inappropriate:</p>
-                <div>
-                  <p class="text-normal text-base dm-word-break-break-word dm-hyphens-auto report-comment-body text-italic">
-                    "<%= comment.body %>"
-                  </p>
-                </div>
-                <div class="text-right">
-                  <button class="usa-button--outline dm-btn-primary margin-0 padding-2 margin-top-5 margin-right-05 report-abuse-cancel">Cancel</button>
-                  <%= link_to 'Submit Report', "/practices/#{practice.id}/comments/#{comment.id}/report", class: 'usa-button dm-btn-primary padding-2 report-abuse-submit', data: {confirm: 'Are you sure you want to report this comment?'} %>
+      <% if !@practice.retired && session[:user_type] != 'public' %>
+          <% if current_user != creator %>
+            <div class="report-comment fas fa-flag text-base padding-x-1 text-middle report-abuse-container" id="comment-<%= comment.id %>-report-abuse-container">
+              <div class="report-abuse-modal hidden font-family-sans" id="comment-<%= comment.id %>-report-abuse-modal">
+                <div class="bg-white radius-md report-abuse-modal-content width-tablet">
+                  <div class="bg-secondary text-white radius-top-md">
+                      <h2 class="margin-0 padding-3">Report a comment</h2>
+                  </div>
+                  <div class="padding-3">
+                    <p class="font-sans-md text-normal text-black margin-bottom-2">I am reporting the following comment for being inappropriate:</p>
+                    <div>
+                      <p class="text-normal text-base dm-word-break-break-word dm-hyphens-auto report-comment-body text-italic">
+                        "<%= comment.body %>"
+                      </p>
+                    </div>
+                    <div class="text-right">
+                      <button class="usa-button--outline dm-btn-primary margin-0 padding-2 margin-top-5 margin-right-05 report-abuse-cancel">Cancel</button>
+                      <%= link_to 'Submit Report', "/practices/#{practice.id}/comments/#{comment.id}/report", class: 'usa-button dm-btn-primary padding-2 report-abuse-submit', data: {confirm: 'Are you sure you want to report this comment?'} %>
+                    </div>
+                  </div>
                 </div>
               </div>
             </div>
-          </div>
-        </div>
+          <% end %>
       <% end %>
     </div>
 
@@ -147,9 +152,9 @@
               %>
             </span>
             <% else %>
-              <span>
-                <a class="usa-button--unstyled dm-btn-primary reply-link" href="#" onclick="return false">Reply</a>
-              </span>
+<!--              <span>-->
+<!--                <a class="usa-button--unstyled dm-btn-primary reply-link" href="#" onclick="return false">Reply</a>-->
+<!--              </span>-->
             <% end %>
           <% end %>
           <% end %>

--- a/app/views/commontator/comments/_votes.html.erb
+++ b/app/views/commontator/comments/_votes.html.erb
@@ -19,21 +19,27 @@
   <% vtype = (comment_voting == :ld) ? 'upvote' : 'like' %>
   <span id="commontator-comment-<%= comment.id %>-<%= vtype %>" class="<%= vtype %>">
     <% if can_vote && (vote.blank? || !vote.vote_flag) %>
-      <%= form_tag commontator.upvote_comment_path(comment),
+      <% if !@practice.retired && session[:user_type] != 'public'  %>
+        <%= form_tag commontator.upvote_comment_path(comment),
             method: :put,
             class: 'vote-form',
             remote: true do %>
-        <%= button_tag '', type: 'submit', class: "fas fa-thumbs-up empty-vote" %>
+            <%= button_tag '', type: 'submit', class: "fas fa-thumbs-up empty-vote" %>
+          <% end %>
       <% end %>
     <% elsif can_vote %>
-      <%= form_tag commontator.unvote_comment_path(comment),
-            method: :put,
-            class: 'vote-form',
-            remote: true do %>
-        <%= button_tag '', type: 'submit', class: "fas fa-thumbs-up voted" %>
+      <% if !@practice.retired && session[:user_type] != 'public'  %>
+        <%= form_tag commontator.unvote_comment_path(comment),
+              method: :put,
+              class: 'vote-form',
+              remote: true do %>
+          <%= button_tag '', type: 'submit', class: "fas fa-thumbs-up voted" %>
+        <% end %>
       <% end %>
     <% else %>
-      <button class="fas fa-thumbs-up vote-disabled" disabled="disabled"></button>
+      <% if !@practice.retired && session[:user_type] != 'public'  %>
+        <button class="fas fa-thumbs-up vote-disabled" disabled="disabled"></button>
+      <% end %>
     <% end %>
   </span>
   <% end %>

--- a/app/views/commontator/threads/_show.html.erb
+++ b/app/views/commontator/threads/_show.html.erb
@@ -11,7 +11,7 @@
   nested_comments = thread.nested_comments_for(user, comments, show_all)
 %>
 
-<% if @practice.present? && !@practice.retired %>
+<% if @practice.present? && !@practice.retired && session[:user_type] != 'public' %>
   <% if thread.config.comment_order != :e %>
     <%= render partial: 'commontator/threads/reply', locals: { thread: thread, user: user } %>
     <h5 class="font-sans-3xs line-height-15px text-bold text-ls-1 text-uppercase">
@@ -77,11 +77,12 @@
                     remote: true %>
       <% end %>
     </span>
-
-    <span id="commontator-thread-<%= thread.id %>-status" class="status">
-      <%= t "commontator.thread.status.#{thread.is_closed? ? 'closed' : 'open'}",
-            closer_name: (thread.is_closed? ? Commontator.commontator_name(thread.closer) : '') %>
-    </span>
+    <% if session[:user_type] != 'public' %>>
+      <span id="commontator-thread-<%= thread.id %>-status" class="status">
+        <%= t "commontator.thread.status.#{thread.is_closed? ? 'closed' : 'open'}",
+              closer_name: (thread.is_closed? ? Commontator.commontator_name(thread.closer) : '') %>
+      </span>
+    <% end %>
   </div>
 
   <% if thread.config.comment_order == :e %>

--- a/app/views/practices/show/contact/_contact.html.erb
+++ b/app/views/practices/show/contact/_contact.html.erb
@@ -11,10 +11,10 @@
             <div class="practice-editor-rect-svg border-top-05 border-primary-dark"></div>
             <h2 id="comments" class="font-sans-lg text-bold margin-top-2 margin-bottom-3">Comment</h2>
           </div>
-          <% if @practice.retired %>
+          <% if @practice.retired || session[:user_type] === 'public' %>
             <div class="usa-alert usa-alert--info margin-bottom-3">
               <div class="usa-alert__body">
-                <p class="usa-alert__text">Comments and replies are disabled for retired practices.</p>
+                <p class="usa-alert__text">Comments and replies are disabled for retired practices and public users.</p>
               </div>
             </div>
           <% end %>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,8 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_02_143652) do
-
+ActiveRecord::Schema.define(version: 2021_06_10_160757) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -215,6 +214,10 @@ ActiveRecord::Schema.define(version: 2021_06_02_143652) do
     t.integer "position"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "clinical_id", id: false, force: :cascade do |t|
+    t.bigint "id"
   end
 
   create_table "clinical_location_practices", force: :cascade do |t|
@@ -959,13 +962,13 @@ ActiveRecord::Schema.define(version: 2021_06_02_143652) do
     t.string "overview_solution"
     t.string "overview_results"
     t.integer "maturity_level"
-    t.datetime "practice_pages_updated"
     t.datetime "date_published"
+    t.datetime "practice_pages_updated"
     t.string "highlight_title"
     t.string "highlight_body"
-    t.boolean "is_public", default: false
     t.boolean "retired", default: false, null: false
     t.string "retired_reason"
+    t.boolean "is_public", default: false
     t.index ["slug"], name: "index_practices_on_slug", unique: true
     t.index ["user_id"], name: "index_practices_on_user_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -216,10 +216,6 @@ ActiveRecord::Schema.define(version: 2021_06_02_143652) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "clinical_id", id: false, force: :cascade do |t|
-    t.bigint "id"
-  end
-
   create_table "clinical_location_practices", force: :cascade do |t|
     t.bigint "clinical_location_id"
     t.bigint "practice_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_10_160757) do
+ActiveRecord::Schema.define(version: 2021_06_02_143652) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"

--- a/spec/features/practice_viewer/contact_spec.rb
+++ b/spec/features/practice_viewer/contact_spec.rb
@@ -97,28 +97,6 @@ describe 'Contact section', type: :feature, js: true do
       expect(page).to have_content('PRACTICE ADOPTER')
     end
 
-    it 'Should show the amount of likes each comment or reply has' do
-      fill_in('comment[body]', with: 'Hello world')
-      click_button('commit')
-      expect(page).to have_selector('.comments-section', visible: true)
-      logout(@user2)
-      visit practice_path(@practice)
-      login_as(@user1, :scope => :user, :run_callbacks => false)
-      visit practice_path(@practice)
-      expect(page).to have_selector('.comments-section', visible: true)
-      find(".like").click
-      expect(page).to have_css('.comment-1-1-vote')
-    end
-
-    it 'Allow the user to view the profile of a commentator if they click on their name next to the comment' do
-      fill_in('comment[body]', with: 'Hello world')
-      click_button('commit')
-      expect(page).to have_selector('#submit-comment', visible: true)
-      click_link('Momo H')
-      expect(page).to have_content('Profile')
-      expect(page).to have_content('momo.hinamori@va.gov')
-    end
-
     describe 'comment mailer' do
       it 'if the practice user is not the comment creator and the practice user\'s email is the same as the practice\'s support network email, it should send an email to the practice user' do
         @practice.update(support_network_email: @user1.email)

--- a/spec/features/retire_practice_spec.rb
+++ b/spec/features/retire_practice_spec.rb
@@ -13,7 +13,7 @@ describe 'retired practices', type: :feature do
     expect(page).to be_accessible.according_to :wcag2a, :section508
     expect(page).to have_content('This practice is no longer being updated.')
     expect(page).to have_content('Was not a good practice')
-    expect(page).to have_content('Comments and replies are disabled for retired practices.')
+    expect(page).to have_content('Comments and replies are disabled for retired practices and public users.')
   end
 
 


### PR DESCRIPTION
### JIRA issue link
https://agile6.atlassian.net/browse/DM-2726

## Description - what does this code do?
This code identifies if the current user is a "public" user and if so disables the ability to comment or reply to the Practice comment's section on the Practice show page.  User can still view previous comments but comments are read only and they can not create new comments on the practice.  Edit and delete links are disabled.

## Testing done - how did you test it/steps on how can another person can test it 
1.  Login to DM as a a non "ntlm" user.  i.e., non-gfe or cag user.  Following method should return nil for user in the application controller.  This will set the current user to a "public" user.
![image](https://user-images.githubusercontent.com/60527788/126236525-66a6213c-afe2-4625-8f1e-c1de5f78fdea.png)
2.  Navigate to a Practice show page that contains comments.  
3. Scroll down to the pages "Contact / Comment" section.  Since you are logged in as a public user you should see the INformation banner stating that "Comments and replies are disabled for retired practices and public users."
![image](https://user-images.githubusercontent.com/60527788/126236846-24bfd768-97a7-4380-b5b9-773aa3526a99.png)
4.  Scroll through the comments.  User should be able to view all comments, and expand or collapse "Replies".
5. Click on the Edit and Delete icons.  These icons should be disabled - i.e., no action occurs when clicking them.
6.  Log off and log back on as an NTLM (VHA network) user.  
7. Navigate to a practice that is not retired.
8. Comment and reply functionality should enabled and all functionality wihin commontator should work correctly.


## Acceptance criteria
Public users don't see comment textbox or role radio button
Comments are read only
Test on Dev when public
Test on STG when public
Release to Prod

## Definition of done
- [ ] Unit tests written (if applicable)
- [ ] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating JIRA issue
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs