### PR TITLE
dm-2765

### DIFF
--- a/app/views/visns/show.html.erb
+++ b/app/views/visns/show.html.erb
@@ -30,7 +30,7 @@
         </p>
         <%= link_to 'Jump to list of VA facilities', va_facilities_path, class: 'dm-external-link' %>
       </div>
-      <% if @primary_visn_liaison.present? && session[:user_type] === "ntlm" %>
+      <% if @primary_visn_liaison.present? %>
         <div class="grid-col-6">
           <div class="visn-liaison-info padding-3 line-height-26 bg-base-lightest">
             <p class="text-bold margin-bottom-2">VISN Marketplace Liaison</p>

--- a/app/views/visns/show.html.erb
+++ b/app/views/visns/show.html.erb
@@ -30,7 +30,7 @@
         </p>
         <%= link_to 'Jump to list of VA facilities', va_facilities_path, class: 'dm-external-link' %>
       </div>
-      <% if @primary_visn_liaison.present? %>
+      <% if @primary_visn_liaison.present? && session[:user_type] === "ntlm" %>
         <div class="grid-col-6">
           <div class="visn-liaison-info padding-3 line-height-26 bg-base-lightest">
             <p class="text-bold margin-bottom-2">VISN Marketplace Liaison</p>

--- a/app/views/visns/show.html.erb
+++ b/app/views/visns/show.html.erb
@@ -30,7 +30,7 @@
         </p>
         <%= link_to 'Jump to list of VA facilities', va_facilities_path, class: 'dm-external-link' %>
       </div>
-      <% if @primary_visn_liaison.present? && session[:user_type] === "ntlm" %>
+      <% if @primary_visn_liaison.present? && session[:user_type] === 'ntlm' %>
         <div class="grid-col-6">
           <div class="visn-liaison-info padding-3 line-height-26 bg-base-lightest">
             <p class="text-bold margin-bottom-2">VISN Marketplace Liaison</p>

--- a/spec/features/visn_spec.rb
+++ b/spec/features/visn_spec.rb
@@ -1,4 +1,5 @@
 require 'rails_helper'
+require 'spec_helper'
 
 describe 'VISN pages', type: :feature do
   before do
@@ -381,6 +382,7 @@ describe 'VISN pages', type: :feature do
     end
 
     it 'should display a brief breakdown of the visn\'s metadata' do
+      page.set_rack_session(:user_type => 'ntlm')
       visit '/visns/2'
 
       expect(page).to have_content('This VISN has 3 facilities and serves Veterans in Florida and Georgia.')

--- a/spec/features/visn_spec.rb
+++ b/spec/features/visn_spec.rb
@@ -273,7 +273,7 @@ describe 'VISN pages', type: :feature do
       hours_note: 'This is a fourth test'
     )
 
-    @user = User.create!(email: 'nobara.kugisaki@va.gov', password: 'Password123', password_confirmation: 'Password123', skip_va_validation: true, confirmed_at: Time.now)
+    @user = User.create!(email: 'nobara.kugisaki@va.gov', password: 'Password123', password_confirmation: 'Password123', skip_va_validation: false, confirmed_at: Time.now, accepted_terms: true)
 
     @practice = Practice.create!(name: 'The Best Practice Ever!', initiating_facility_type: 'facility', tagline: 'Test tagline', date_initiated: 'Sun, 05 Feb 1992 00:00:00 UTC +00:00', summary: 'This is the best practice ever.', overview_problem: 'overview-problem', published: true, enabled: true, approved: true, user: @user)
     PracticeOriginFacility.create!(practice: @practice, facility_type: 0, facility_id: '421')
@@ -385,7 +385,6 @@ describe 'VISN pages', type: :feature do
       login_as(@user, :scope => :user, :run_callbacks => false)
       page.set_rack_session(:user_type => 'ntlm')
       visit '/visns/2'
-
       expect(page).to have_content('This VISN has 3 facilities and serves Veterans in Florida and Georgia.')
       expect(page).to have_content('Collectively, its facilities have created 7 practices and have adopted 3 practices.')
       expect(page).to have_content('Toge Inumaki')

--- a/spec/features/visn_spec.rb
+++ b/spec/features/visn_spec.rb
@@ -382,6 +382,7 @@ describe 'VISN pages', type: :feature do
     end
 
     it 'should display a brief breakdown of the visn\'s metadata' do
+      login_as(@user, :scope => :user, :run_callbacks => false)
       page.set_rack_session(:user_type => 'ntlm')
       visit '/visns/2'
 


### PR DESCRIPTION
### JIRA issue link
https://agile6.atlassian.net/browse/DM-2765

## Description - what does this code do?
Adds a check for ntlm user in order to display VISN Liaison info on the visn show page.

## Testing done - how did you test it/steps on how can another person can test it 
1.  Login to DM as a public user.
2. navigate to /visns/1
3. ensure that the Visn Liaison information is not displayed unless the user is logged in as an 'ntlm' user AND the Visn has a Primary liaison.

If a primary liaison for the Visn exists and the user is logged in as an ntlm user you should see the liaison information
![image](https://user-images.githubusercontent.com/60527788/128403988-7d78aef1-5cad-41cf-aab6-b9de39c81eb9.png)

If a primary liaison does not exist for the user OR the user is not logged in as an 'ntlm' user the liaison information should not display.
![image](https://user-images.githubusercontent.com/60527788/128404293-6df82260-bee2-43c5-a4c1-e39cde338c1f.png)


## Link to mock-ups/mock ups (image file if you have it) (if applicable)
NA

## Acceptance criteria

- Marketplace liaison is hidden from public users
- Liaisons are still visible to internal users
- Only block out that information from the page, the rest should be visible to the public
- Test on Public environment

## Definition of done
- [ ] Unit tests written (if applicable)
- [ ] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating JIRA issue
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs