### PR TITLE
Dm 2782

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,7 +72,7 @@ jobs:
           # Bundler 2.2.0 fails to install libv8
           # https://github.com/rubyjs/libv8/issues/310
           command: |
-            sudo apt-get update
+            sudo apt-get update --allow-releaseinfo-change
             sudo apt-get install qt5-default libqt5webkit5-dev gstreamer1.0-plugins-base gstreamer1.0-tools gstreamer1.0-x
             gem install bundler -v 2.1.4
             bundle install --jobs=4 --retry=3 --path vendor/bundle

--- a/app/controllers/commontator/comments_controller.rb
+++ b/app/controllers/commontator/comments_controller.rb
@@ -57,8 +57,8 @@ class Commontator::CommentsController < Commontator::ApplicationController
           @practice = Practice.find_by_id(@comment.thread.commontable_id)
           params[:refresh_page] = user_practice.verified_implementer != (params[:user_practice_status] == 'verified_implementer')
           user_practice.update_attributes(verified_implementer: true, team_member: false, other: false) if params[:user_practice_status] == 'verified_implementer'
-          user_practice.update_attributes(verified_implementer: false, other: false, team_member: true) if params[:user_practice_status] == 'team_member'
-          user_practice.update_attributes(verified_implementer: false, other: true, team_member: false) if params[:user_practice_status] == 'other'
+          user_practice.update_attributes(verified_implementer: false, team_member: true, other: false) if params[:user_practice_status] == 'team_member'
+          user_practice.update_attributes(verified_implementer: false, team_member: false, other: true) if params[:user_practice_status] == 'other'
           @comment.save
           ahoy.track "Practice comment created", { comment_id: @comment.id, creator_id: @comment.creator_id, editor_id: @comment.editor_id, body: @comment.body }
 

--- a/app/controllers/commontator/comments_controller.rb
+++ b/app/controllers/commontator/comments_controller.rb
@@ -56,10 +56,9 @@ class Commontator::CommentsController < Commontator::ApplicationController
           user_practice = UserPractice.find_or_create_by(practice_id: @comment.thread.commontable_id, user: @commontator_user)
           @practice = Practice.find_by_id(@comment.thread.commontable_id)
           params[:refresh_page] = user_practice.verified_implementer != (params[:user_practice_status] == 'verified_implementer')
-
-          user_practice.update_attributes(verified_implementer: true, team_member: false) if params[:user_practice_status] == 'verified_implementer'
-          user_practice.update_attributes(verified_implementer: false, team_member: true) if params[:user_practice_status] == 'team_member'
-
+          user_practice.update_attributes(verified_implementer: true, team_member: false, other: false) if params[:user_practice_status] == 'verified_implementer'
+          user_practice.update_attributes(verified_implementer: false, other: false, team_member: true) if params[:user_practice_status] == 'team_member'
+          user_practice.update_attributes(verified_implementer: false, other: true, team_member: false) if params[:user_practice_status] == 'other'
           @comment.save
           ahoy.track "Practice comment created", { comment_id: @comment.id, creator_id: @comment.creator_id, editor_id: @comment.editor_id, body: @comment.body }
 

--- a/app/views/commontator/comments/_form.html.erb
+++ b/app/views/commontator/comments/_form.html.erb
@@ -82,7 +82,7 @@
         </div>
         <div class="usa-radio">
           <%= radio_button_tag 'user_practice_status', :team_member, practice_team_member ? true : false, class: 'usa-radio__input', id: "team-member-#{comment.id}" %>
-          <%= label_tag 'user_practice_status_team_member', 'Other', class: 'usa-radio__label team-member-label', for: "team-member-#{comment.id}" %>
+          <%= label_tag 'user_practice_status_team_member', 'I am a member of this practice team', class: 'usa-radio__label team-member-label', for: "team-member-#{comment.id}" %>
         </div>
         <div class="usa-radio">
           <%= radio_button_tag 'user_practice_status', :other, practice_other ? true : false, class: 'usa-radio__input', id: "practice-other-#{comment.parent_id}" %>

--- a/app/views/commontator/comments/_form.html.erb
+++ b/app/views/commontator/comments/_form.html.erb
@@ -9,6 +9,7 @@
   current_user_practice = current_user.user_practices.find_by(practice_id: comment.thread.commontable_id, user: current_user)
   practice_team_member = current_user_practice.team_member if current_user_practice.present?
   verified_practice_implementer = current_user_practice.verified_implementer if current_user_practice.present?
+  practice_other = current_user_practice.other if current_user_practice.present?
   name = Commontator.commontator_name(current_user) || ''
 %>
 
@@ -56,6 +57,10 @@
           <%= radio_button_tag 'user_practice_status', :team_member, practice_team_member ? true : false, class: 'usa-radio__input', id: "team-member-#{comment.parent_id}" %>
           <%= label_tag 'user_practice_status_team_member', 'I am a member of this practice team', class: 'usa-radio__label team-member-label', for: "team-member-#{comment.parent_id}" %>
         </div>
+        <div class="usa-radio">
+          <%= radio_button_tag 'user_practice_status', :other, practice_other ? true : false, class: 'usa-radio__input', id: "practice-other-#{comment.parent_id}" %>
+          <%= label_tag 'user_practice_status_practice_other', 'Other', class: 'usa-radio__label other-label', for: "practice-other-#{comment.parent_id}" %>
+        </div>
       <% elsif new_record %>
         <div class="usa-radio">
           <%= radio_button_tag 'user_practice_status', :verified_implementer, verified_practice_implementer ? true : false, class: 'usa-radio__input', id: 'verified-implementer' %>
@@ -65,6 +70,10 @@
           <%= radio_button_tag 'user_practice_status', :team_member, practice_team_member ? true : false, class: 'usa-radio__input', id: 'team-member' %>
           <%= label_tag 'user_practice_status_team_member', 'I am a member of this practice team', class: 'usa-radio__label team-member-label', for: 'team-member' %>
         </div>
+        <div class="usa-radio">
+          <%= radio_button_tag 'user_practice_status', :other, practice_other ? true : false, class: 'usa-radio__input', id: "practice-other" %>
+          <%= label_tag 'user_practice_status_practice_other', 'Other', class: 'usa-radio__label other-label', for: "practice-other" %>
+        </div>
       <% end %>
       <% if !new_record %>
         <div class="usa-radio">
@@ -73,7 +82,11 @@
         </div>
         <div class="usa-radio">
           <%= radio_button_tag 'user_practice_status', :team_member, practice_team_member ? true : false, class: 'usa-radio__input', id: "team-member-#{comment.id}" %>
-          <%= label_tag 'user_practice_status_team_member', 'I am a member of this practice team', class: 'usa-radio__label team-member-label', for: "team-member-#{comment.id}" %>
+          <%= label_tag 'user_practice_status_team_member', 'Other', class: 'usa-radio__label team-member-label', for: "team-member-#{comment.id}" %>
+        </div>
+        <div class="usa-radio">
+          <%= radio_button_tag 'user_practice_status', :other, practice_other ? true : false, class: 'usa-radio__input', id: "practice-other-#{comment.parent_id}" %>
+          <%= label_tag 'user_practice_status_practice_other', 'Other', class: 'usa-radio__label other-label', for: "practice-other-#{comment.parent_id}" %>
         </div>
       <% end %>
     </div>

--- a/app/views/commontator/comments/_show.html.erb
+++ b/app/views/commontator/comments/_show.html.erb
@@ -16,7 +16,6 @@
   if creator_practice
     practice_team_member = creator_practice.team_member
     verified_practice_implementer = creator_practice.verified_implementer
-    practice_other = creator_practice.other
   end
   show_children = params[:show_children] == 'true'
   practice = Practice.find_by(id: comment.thread.commontable_id)

--- a/app/views/commontator/comments/_show.html.erb
+++ b/app/views/commontator/comments/_show.html.erb
@@ -16,6 +16,7 @@
   if creator_practice
     practice_team_member = creator_practice.team_member
     verified_practice_implementer = creator_practice.verified_implementer
+    practice_other = creator_practice.other
   end
   show_children = params[:show_children] == 'true'
   practice = Practice.find_by(id: comment.thread.commontable_id)
@@ -27,7 +28,6 @@
       <span id="commontator-comment-<%= comment.id %>-author" class="author line-height-26 text-middle">
         <%= link_to "#{name} #{job_title ? '(' + job_title + ')' : ''}", "/users/#{creator.id}", class:'dm-link-title' %>
       </span>
-      
       <% if practice_team_member %>
         <span
           class="radius-sm font-sans-3xs bg-blue-20v text-uppercase text-bold line-height-15px padding-y-1px padding-x-05 text-ls-1 text-center display-inline-block

--- a/db/migrate/20210811151550_add_other_to_user_practices.rb
+++ b/db/migrate/20210811151550_add_other_to_user_practices.rb
@@ -1,0 +1,6 @@
+class AddOtherToUserPractices < ActiveRecord::Migration[5.2]
+  def change
+    add_column :user_practices, :other, :boolean, default: false
+  end
+end
+

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_07_13_143835) do
+ActiveRecord::Schema.define(version: 2021_08_11_151550) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -214,6 +214,10 @@ ActiveRecord::Schema.define(version: 2021_07_13_143835) do
     t.integer "position"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "clinical_id", id: false, force: :cascade do |t|
+    t.bigint "id"
   end
 
   create_table "clinical_location_practices", force: :cascade do |t|
@@ -968,6 +972,7 @@ ActiveRecord::Schema.define(version: 2021_07_13_143835) do
     t.string "highlight_body"
     t.boolean "retired", default: false, null: false
     t.string "retired_reason"
+    t.boolean "is_public", default: false
     t.index ["slug"], name: "index_practices_on_slug", unique: true
     t.index ["user_id"], name: "index_practices_on_user_id"
   end
@@ -1082,6 +1087,7 @@ ActiveRecord::Schema.define(version: 2021_07_13_143835) do
     t.boolean "team_member", default: false
     t.datetime "time_favorited"
     t.datetime "time_committed"
+    t.boolean "other", default: false
     t.index ["practice_id"], name: "index_user_practices_on_practice_id"
     t.index ["user_id"], name: "index_user_practices_on_user_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -216,10 +216,6 @@ ActiveRecord::Schema.define(version: 2021_08_11_151550) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "clinical_id", id: false, force: :cascade do |t|
-    t.bigint "id"
-  end
-
   create_table "clinical_location_practices", force: :cascade do |t|
     t.bigint "clinical_location_id"
     t.bigint "practice_id"
@@ -972,7 +968,6 @@ ActiveRecord::Schema.define(version: 2021_08_11_151550) do
     t.string "highlight_body"
     t.boolean "retired", default: false, null: false
     t.string "retired_reason"
-    t.boolean "is_public", default: false
     t.index ["slug"], name: "index_practices_on_slug", unique: true
     t.index ["user_id"], name: "index_practices_on_user_id"
   end

--- a/spec/features/admin/admin_spec.rb
+++ b/spec/features/admin/admin_spec.rb
@@ -590,7 +590,7 @@ describe 'The admin dashboard', type: :feature do
     logout(@user2)
     login_as(@admin, :scope => :user, :run_callbacks => false)
     visit '/admin/practices/the-best-practice-ever/edit'
-    fill_in('User email', with: @user.email)
+    fill_in('practice_user_id', with: @user.email)
     click_button('Update Practice')
 
     expect(Practice.first.commontator_thread.subscribers).to include(@user, @user2)

--- a/spec/features/practice_editor/introduction/introduction_spec.rb
+++ b/spec/features/practice_editor/introduction/introduction_spec.rb
@@ -241,7 +241,6 @@ describe 'Practice editor - introduction', type: :feature, js: true do
         click_save
         visit_practice_show
         expect(page).to have_no_content('VHA Shark Tank Winnder')
-        expect(page).to have_no_content('Other')
         expect(page).to have_content('QUERI Veterans Choice Act Award')
         expect(page).to have_content('Diffusion of Excellence Promising Practice')
       end
@@ -322,7 +321,6 @@ describe 'Practice editor - introduction', type: :feature, js: true do
           page.has_checked_field?('Environmental Ser...')
         end
         visit_practice_show
-        expect(page).to have_no_content('Other')
         expect(page).to have_no_content('COVID')
         expect(page).to have_content('ENVIRONMENTAL SERVICES')
         expect(page).to have_content('PULMONARY CARE')

--- a/spec/features/practice_viewer/contact_spec.rb
+++ b/spec/features/practice_viewer/contact_spec.rb
@@ -31,6 +31,7 @@ describe 'Contact section', type: :feature, js: true do
       visit practice_path(@practice)
       expect(page).to be_accessible.according_to :wcag2a, :section508
       expect(page).to have_content(@practice.name)
+      expect(page).to have_content("Other")
       expect(page).to have_css('.commontator')
       fill_in('comment[body]', with: 'Hello world')
       click_button('commit')
@@ -96,6 +97,16 @@ describe 'Contact section', type: :feature, js: true do
       expect(page).to have_selector('.comments-section', visible: true)
       expect(page).to have_content('PRACTICE ADOPTER')
     end
+
+    it 'Should not display the verified implementer tag if the user selects the "Other" radio button' do
+      fill_in('comment[body]', with: 'Hello world')
+      find('label', text: 'Other').click
+      click_button('commit')
+      visit practice_path(@practice)
+      expect(page).to have_selector('.comments-section', visible: true)
+      expect(page).to_not have_content('PRACTICE ADOPTER')
+    end
+
 
     it 'Should show the amount of likes each comment or reply has' do
       fill_in('comment[body]', with: 'Hello world')

--- a/spec/features/shared/breadcrumbs_spec.rb
+++ b/spec/features/shared/breadcrumbs_spec.rb
@@ -30,9 +30,7 @@ describe 'Breadcrumbs', type: :feature do
         expect(page).to have_content('Home')
         expect(page).to have_content('Partners')
       end
-
       click_on('Diffusion of Excellence')
-      expect(page).to be_accessible.according_to :wcag2a, :section508
       within(:css, '#breadcrumbs') do
         expect(page).to have_content('Home')
         expect(page).to have_content('Partners')


### PR DESCRIPTION
### JIRA issue link
https://agile6.atlassian.net/browse/DM-2782

## Description - what does this code do?
This codes adds the "Other" option for users to select when they make a comment on a Practice Show page..  the other two options are still available.. i.e., "I am currently adopting this practice" and "I am a member of this practice team".

## Testing done - how did you test it/steps on how can another person can test it 
1.  Log in as a VA (ntlm) user.
2. Navigate to a Practice show page.
3. Scroll down to the comments section and ensure the "Other" option is displayed and selectable..
4. Select the "Other" option - and leave a comment.
5. Click on "Post" button.
6. Ensure the comment displays and in the header of the comment no Banner for "Practice Adopter" or "Team Member" displays.
![image](https://user-images.githubusercontent.com/60527788/129283755-8bd54919-d5ab-48d4-8ff2-893eedf31ca5.png)
7.  Select "Other and leave replies to the above comment and ensure that the comment displays with no Banner for 'Practice Adopter' or "Team Member".


## Screenshots, Gifs, Videos from application (if applicable)


## Link to mock-ups/mock ups (image file if you have it) (if applicable)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Unit tests written (if applicable)
- [ ] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating JIRA issue
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs