### PR TITLE
DM-2797: Add hidden practice feature

### DIFF
--- a/app/admin/practices.rb
+++ b/app/admin/practices.rb
@@ -40,19 +40,22 @@ ActiveAdmin.register Practice do
     column 'Practice Name', :name
     column :support_network_email unless params[:scope] == "get_practice_owner_emails"
     column(:owner_email) {|practice| practice.user&.email}
-    column :enabled unless params[:scope] == "get_practice_owner_emails"
     column :created_at unless params[:scope] == "get_practice_owner_emails"
-    column :highlight
+    column :date_published unless params[:scope] == "get_practice_owner_emails"
+    column :enabled unless params[:scope] == "get_practice_owner_emails"
+    column :hidden unless params[:scope] == "get_practice_owner_emails"
+    column :highlight unless params[:scope] == "get_practice_owner_emails"
     column :retired unless params[:scope] == "get_practice_owner_emails"
     column 'Last Updated', :updated_at unless params[:scope] == "get_practice_owner_emails"
-    column :date_published unless params[:scope] == "get_practice_owner_emails"
     actions do |practice|
       practice_enabled_action_str = practice.enabled ? "Disable" : "Enable"
       item practice_enabled_action_str, enable_practice_admin_practice_path(practice), method: :post
-      practice_highlight_action_str = practice.highlight ? "Unhighlight" : "Highlight"
-      item practice_highlight_action_str, highlight_practice_admin_practice_path(practice), method: :post
+      practice_hidden_action_str = practice.hidden ? "Show" : "Hide"
+      item practice_hidden_action_str, hide_practice_admin_practice_path(practice), method: :post
       practice_retired_action_str = practice.retired ? "Activate" : "Retire"
       item practice_retired_action_str, retire_practice_admin_practice_path(practice), method: :post
+      practice_highlight_action_str = practice.highlight ? "Unhighlight" : "Highlight"
+      item practice_highlight_action_str, highlight_practice_admin_practice_path(practice), method: :post
     end
   end
 
@@ -98,6 +101,16 @@ ActiveAdmin.register Practice do
       resource.save
       redirect_back fallback_location: root_path, notice: message
     end
+  end
+
+  member_action :hide_practice, method: :post do
+    resource.hidden = !resource.hidden
+    message = "\"#{resource.name}\" is hidden from search"
+    unless resource.hidden
+      message = "\"#{resource.name}\" is no longer hidden from search"
+    end
+    resource.save
+    redirect_back fallback_location: root_path, notice: message
   end
 
   member_action :export_practice_adoptions, method: :get do
@@ -217,8 +230,9 @@ ActiveAdmin.register Practice do
     active_admin_comments
   end
 
-  filter :nameYou
+  filter :name
   filter :support_network_email
+  filter :owner_email
 
   controller do
     helper_method :adoption_facility_name

--- a/app/assets/stylesheets/active_admin.scss
+++ b/app/assets/stylesheets/active_admin.scss
@@ -221,6 +221,11 @@
       @include tooltip-icon();
     }
   }
+
+  #practice_retired_reason_input {
+    display: flex;
+    width: 100%;
+  }
 }
 
 .display-none {

--- a/app/models/diffusion_history.rb
+++ b/app/models/diffusion_history.rb
@@ -7,7 +7,7 @@ class DiffusionHistory < ApplicationRecord
 
   attr_accessor :facility_name
 
-  scope :with_published_enabled_approved_practices, -> { joins(:practice).where(practices: { published: true, enabled: true, approved: true }) }
+  scope :with_published_enabled_approved_practices, -> { joins(:practice).where(practices: { published: true, enabled: true, approved: true, hidden: false }) }
   scope :by_status, -> (status) { joins(:diffusion_history_statuses).where(diffusion_history_statuses: {status: status}) }
   scope :get_by_successful_status, -> { (by_status('Completed')).or(by_status('Implemented')).or(by_status('Complete')) }
   scope :get_by_in_progress_status, -> { (by_status('In progress')).or(by_status('Planning')).or(by_status('Implementing')) }

--- a/app/models/practice.rb
+++ b/app/models/practice.rb
@@ -51,7 +51,8 @@ class Practice < ApplicationRecord
         self.overview_solution_changed? ||
         self.overview_results_changed?  ||
         self.retired_changed? ||
-        self.retired_reason_changed?
+        self.retired_reason_changed? ||
+        self.hidden_changed?
       self.reset_searchable_cache = true
     end
   end
@@ -201,7 +202,7 @@ class Practice < ApplicationRecord
   scope :sort_adoptions_ct, -> { order(Arel.sql("COUNT(diffusion_histories) DESC, lower(practices.name) ASC")) }
   scope :sort_added, -> { order(Arel.sql("practices.created_at DESC")) }
   scope :filter_by_category_ids, -> (cat_ids) { where('category_practices.category_id IN (?)', cat_ids)} # cat_ids should be a id number or an array of id numbers
-  scope :published_enabled_approved,   -> { where(published: true, enabled: true, approved: true) }
+  scope :published_enabled_approved,   -> { where(published: true, enabled: true, approved: true, hidden: false) }
   scope :sort_by_retired, -> { order("retired asc") }
   scope :get_by_adopted_facility, -> (facility_id) { left_outer_joins(:diffusion_histories).where(diffusion_histories: {va_facility_id: facility_id}).uniq }
   scope :get_by_created_facility, -> (facility_id) { where(initiating_facility_type: 'facility').joins(:practice_origin_facilities).where(practice_origin_facilities: { va_facility_id: facility_id }) }

--- a/app/views/practices/show/authenticated/_practice_status_banner.html.erb
+++ b/app/views/practices/show/authenticated/_practice_status_banner.html.erb
@@ -1,0 +1,51 @@
+<%
+  published = practice.published
+  approved = practice.approved
+  hidden = practice.hidden
+  retired = practice.retired
+%>
+<% unless published && approved %>
+  <div class="usa-alert usa-alert--warning">
+    <div class="usa-alert__body">
+      <h3 class="usa-alert__heading">This practice will not be shown in the marketplace because it is:</h3>
+      <% unless published %>
+        <div>
+         Unpublished
+        </div>
+      <% end %>
+      <% unless approved %>
+        <div>
+          Not approved
+        </div>
+      <% end %>
+    </div>
+  </div>
+<% end %>
+<% if hidden %>
+  <div class="usa-alert usa-alert--info margin-bottom-3 margin-top-1">
+    <div class="usa-alert__body">
+      <h4 class="usa-alert__heading">Hidden practice</h4>
+      <div class="usa-alert__text">
+        This practice can be viewed but is not included in any search results.
+      </div>
+    </div>
+  </div>
+<% end %>
+<% if retired %>
+  <div class="usa-alert usa-alert--info margin-bottom-3 margin-top-1">
+    <div class="usa-alert__body">
+      <h4 class="usa-alert__heading">Retired practice</h4>
+      <div class="usa-alert__text">
+        This practice is no longer being updated.
+        <% if practice.retired_reason.present? %>
+          <p>
+            <%
+              retired_reason_html = practice.retired_reason.gsub("<p>", "").gsub("</p>", "")
+            %>
+            Reason for retirement: <%= sanitize retired_reason_html.html_safe %>
+          </p>
+        <% end %>
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/app/views/practices/show/authenticated/_show_authenticated.html.erb
+++ b/app/views/practices/show/authenticated/_show_authenticated.html.erb
@@ -6,41 +6,7 @@
     <div class="grid-row grid-gap">
       <div id="practice_show" class="grid-col-12 overview-section practice-section">
         <%= render partial: "shared/messages", locals: {small_text: false} %>
-        <% unless @practice.published && @practice.approved %>
-          <div class="usa-alert usa-alert--warning">
-            <div class="usa-alert__body">
-              <h3 class="usa-alert__heading">This practice will not be shown in the marketplace because it is:</h3>
-              <% unless @practice.published %>
-                <div>
-                  Not Published
-                </div>
-              <% end %>
-              <% unless @practice.approved %>
-                <div>
-                  Not Approved
-                </div>
-              <% end %>
-            </div>
-          </div>
-        <% end %>
-        <% if @practice.retired %>
-          <div class="usa-alert usa-alert--info margin-bottom-3 margin-top-1">
-            <div class="usa-alert__body">
-              <h4 class="usa-alert__heading">Retired Practice</h4>
-              <div class="usa-alert__text">
-                This practice is no longer being updated.
-                <% if @practice.retired_reason.present? %>
-                  <p>
-                    <%
-                      retired_reason_html = @practice.retired_reason.gsub("<p>", "").gsub("</p>", "")
-                    %>
-                    Reason for retirement: <%= sanitize retired_reason_html.html_safe %>
-                  </p>
-                <% end %>
-              </div>
-            </div>
-          </div>
-        <% end %>
+        <%= render partial: "practices/show/authenticated/practice_status_banner", locals: { practice: @practice } %>
       </div>
     </div>
   </div>

--- a/db/migrate/20210817165620_add_hidden_to_practices.rb
+++ b/db/migrate/20210817165620_add_hidden_to_practices.rb
@@ -1,0 +1,5 @@
+class AddHiddenToPractices < ActiveRecord::Migration[5.2]
+  def change
+    add_column :practices, :hidden, :boolean, null: false, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_08_11_151550) do
+ActiveRecord::Schema.define(version: 2021_08_17_165620) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -968,6 +968,7 @@ ActiveRecord::Schema.define(version: 2021_08_11_151550) do
     t.string "highlight_body"
     t.boolean "retired", default: false, null: false
     t.string "retired_reason"
+    t.boolean "hidden", default: false, null: false
     t.index ["slug"], name: "index_practices_on_slug", unique: true
     t.index ["user_id"], name: "index_practices_on_user_id"
   end

--- a/spec/features/admin/admin_spec.rb
+++ b/spec/features/admin/admin_spec.rb
@@ -586,7 +586,8 @@ describe 'The admin dashboard', type: :feature do
     visit '/admin/practices/the-best-practice-ever/edit'
     fill_in('User email', with: @user2.email)
     click_button('Update Practice')
-
+    sleep 0.2
+    expect(page).to have_selector('#practice_user_id')
     expect(Practice.first.commontator_thread.subscribers.first).to_not eq(@user)
     expect(Practice.first.commontator_thread.subscribers.first).to eq(@user2)
 
@@ -602,7 +603,8 @@ describe 'The admin dashboard', type: :feature do
     login_as(@admin, :scope => :user, :run_callbacks => false)
     visit '/admin/practices/the-best-practice-ever/edit'
     sleep 0.2
-    fill_in('practice_user_id', with: @user.email)
+    expect(page).to have_selector('#practice_user_id')
+    fill_in('User email', with: @user.email)
     click_button('Update Practice')
 
     expect(Practice.first.commontator_thread.subscribers).to include(@user, @user2)

--- a/spec/features/admin/admin_spec.rb
+++ b/spec/features/admin/admin_spec.rb
@@ -586,8 +586,6 @@ describe 'The admin dashboard', type: :feature do
     visit '/admin/practices/the-best-practice-ever/edit'
     fill_in('User email', with: @user2.email)
     click_button('Update Practice')
-    sleep 0.2
-    expect(page).to have_selector('#practice_user_id')
     expect(Practice.first.commontator_thread.subscribers.first).to_not eq(@user)
     expect(Practice.first.commontator_thread.subscribers.first).to eq(@user2)
 
@@ -602,7 +600,6 @@ describe 'The admin dashboard', type: :feature do
     logout(@user2)
     login_as(@admin, :scope => :user, :run_callbacks => false)
     visit '/admin/practices/the-best-practice-ever/edit'
-    sleep 0.2
     expect(page).to have_selector('#practice_user_id')
     fill_in('User email', with: @user.email)
     click_button('Update Practice')

--- a/spec/features/admin/admin_spec.rb
+++ b/spec/features/admin/admin_spec.rb
@@ -536,6 +536,17 @@ describe 'The admin dashboard', type: :feature do
     expect(page).to have_content("\"#{pr_2.name}\" was activated")
   end
 
+  it 'should be able to toggle between hidden and visible states from the actions column' do
+    login_as(@admin, scope: :user, run_callbacks: false)
+    visit '/admin'
+    click_link('Practices')
+    expect(page).to have_content('Hide')
+    click_link('Hide', href: hide_practice_admin_practice_path(@practice))
+    expect(page).to have_content("\"#{@practice.name}\" is hidden from search")
+    click_link('Show', href: hide_practice_admin_practice_path(@practice))
+    expect(page).to have_content("\"#{@practice.name}\" is no longer hidden from search")
+  end
+
 
   it 'should only display a button to download adoptions if the practice has any' do
     login_as(@admin, scope: :user, run_callbacks: false)

--- a/spec/features/practice_spec.rb
+++ b/spec/features/practice_spec.rb
@@ -114,6 +114,18 @@ describe 'Practices', type: :feature do
       expect(page).to have_current_path(practice_path(@user_practice))
     end
 
+    it 'should let a user view the practice if it is hidden but not search for it' do
+      login_as(@user2, :scope => :user, :run_callbacks => false)
+      hidden_practice = Practice.create!(name: 'A secret practice', approved: true, published: true, hidden: true, tagline: 'Test secret tagline', date_initiated: Time.now(), user: @user)
+      visit practice_path(hidden_practice)
+      expect(page).to have_content(hidden_practice.name)
+      expect(page).to have_content('Hidden practice')
+      fill_in('search', with: 'A secret practice')
+      find("#dm-navbar-search-button").click
+      expect(page).to have_selector("#search-page")
+      expect(page).to have_content('There are currently no matches for your search on the Marketplace.')
+    end
+
     it 'should display the initiating facility\'s name' do
       login_as(@user, :scope => :user, :run_callbacks => false)
 


### PR DESCRIPTION
### JIRA issue link
[DM-2797](https://agile6.atlassian.net/browse/DM-2797)

## Description - what does this code do?
This adds the ability to hide a practice from search results but let it remain viewable to any user.

## Testing done - how did you test it/steps on how can another person can test it 
1. Go to `/admin/practices`
2. Click "Hide" on a practice
3. Go to that practice's show page and ensure you see the "Hidden" banner
4. Then try to search for that practice in any of the searches (visn, facilities, regular search) and it should not appear as a result
5. Go back to `/admin/practices`
6. "Show" the practice
7. Search for the practice in the different searches and it should appear
8. Go to the practices show page and ensure you no longer see the "Hidden" banner

## Screenshots, Gifs, Videos from application (if applicable)
<img width="1211" alt="Screen Shot 2021-08-18 at 5 18 35 PM" src="https://user-images.githubusercontent.com/20211771/129979955-bf9636d2-c079-42c4-afcf-1958e81b232c.png">


## Link to mock-ups/mock ups (image file if you have it) (if applicable)


## Acceptance criteria
- [X] Practice page is viewable via URL
- [X] Page is not searchable
- [X] This is configurable in Admin panel (e.g. “Hidden Yes/No”)
- [X] Have banner on page that says “Hidden”

## Definition of done
- [ ] Unit tests written (if applicable)
- [X] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [X] A link has been provided to the originating JIRA issue
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs