### PR TITLE
DM-ECR: VAEC only - pull base images from VAEC AWS ECR

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,7 @@
-FROM agilesix/ruby:2.6.3-centos7.6
+# Note: Uncomment this to run docker locally
+#FROM agilesix/ruby:2.6.3-centos7.6
+# Note: Comment out the next line to run docker locally
+FROM 124858472090.dkr.ecr.us-gov-west-1.amazonaws.com/diffusion-marketplace:ruby
 
 RUN useradd -rm -d /home/nginx -s /bin/bash -g root -G wheel -u 1443 nginx
 RUN groupadd -g 1443 nginx

--- a/proxy/Dockerfile
+++ b/proxy/Dockerfile
@@ -1,4 +1,7 @@
-FROM agilesix/centos:7.6
+# Note: Uncomment this to run docker locally
+#FROM agilesix/centos:7.6
+# Note: Comment out the next line to run docker locally
+FROM 124858472090.dkr.ecr.us-gov-west-1.amazonaws.com/diffusion-marketplace:centos
 
 MAINTAINER Agile Six Applications, Inc. <contact@agile6.com>
 


### PR DESCRIPTION
to run the docker images locally, be sure to uncomment the docker public repository FROM lines and then comment out the ECR FROM lines
