### PR TITLE
DM-2801: Add featured topic functionality

### DIFF
--- a/app/admin/topics.rb
+++ b/app/admin/topics.rb
@@ -1,0 +1,76 @@
+ActiveAdmin.register Topic do
+  permit_params :title, :description, :url, :cta_text, :attachment, :featured
+
+  batch_action :destroy, false
+
+  filter :title
+  filter :description
+  filter :url
+
+  index do
+    id_column
+    column :title
+    column :url
+    column :featured
+    actions do |topic|
+      topic_featured_action_str = topic.featured ? "Unfeature" : "Feature"
+      item topic_featured_action_str, feature_admin_topic_path(topic), method: :post
+    end
+  end
+
+  member_action :feature, method: :post do
+    resource.featured = !resource.featured
+    message = "Topic with ID #{resource.id} is now featured."
+    if resource.featured
+      other_topics = Topic.where.not(id: resource.id)
+      if other_topics.present?
+        other_topics.each do |other_topic|
+          other_topic.update_attributes(featured: false)
+        end
+      end
+    else
+      message = "Topic with ID #{resource.id} is now unfeatured."
+    end
+    resource.save
+    redirect_back fallback_location: root_path, notice: message
+  end
+
+  show do
+    attributes_table do
+      row :id
+      row :title
+      row :description
+      row :cta_text
+      row :url
+      row "Attachment" do
+        if topic.attachment.present?
+          div do
+            image_tag(topic.attachment_s3_presigned_url(:thumb))
+          end
+        else
+          div do
+            "None"
+          end
+        end
+      end
+      row :featured
+    end
+  end
+
+ form do |f|
+    f.inputs do
+      f.input :title, as: :string, required: true
+      f.input :description, as: :string, required: true
+      f.input :url, label: "Call to action URL", as: :string, hint: "Can be an internal (e.g. /partners) or external (e.g. https://www.va.gov) URL", required: true
+      f.input :cta_text, label: "Call to action text", as: :string, required: true
+      f.input :attachment, :as => :file, required: true
+      if topic.attachment.exists?
+        div '', style: 'width: 20%', class: 'display-inline-block'
+          div class: 'display-inline-block' do
+            image_tag(topic.attachment_s3_presigned_url(:thumb))
+          end
+        end
+      end
+    f.actions
+  end
+end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -5,6 +5,7 @@ class HomeController < ApplicationController
     @practices = Practice.searchable_practices 'a_to_z'
     @favorite_practices = current_user&.favorite_practices || []
     @highlighted_pr = Practice.where(highlight: true, published: true, enabled: true, approved: true).first
+    @featured_topic = Topic.find_by(featured: true)
   end
 
   def diffusion_map

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -1,0 +1,11 @@
+class Topic < ApplicationRecord
+  has_attached_file :attachment, styles: {thumb: '768x432>'} # TODO: modify thumb size
+  validates :title, :description, :url, :cta_text, presence: true
+  validates_attachment_content_type :attachment, content_type: /\Aimage\/.*\z/
+  validates_with InternalUrlValidator, on: [:create, :update], if: Proc.new { |topic| topic.url.present? && topic.url.chars.first === '/' }
+  validates_with ExternalUrlValidator, on: [:create, :update], if: Proc.new { |topic| topic.url.present? && topic.url.chars.first != '/' }
+
+  def attachment_s3_presigned_url(style = nil)
+    object_presigned_url(attachment, style)
+  end
+end

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -42,23 +42,19 @@
       <%= link_to 'Browse all practices', search_path, class: 'usa-link' %>
     </p>
   </section>
-  <%# TODO: Write conditional to only show this partial if there's a currently selected 'Featured' topic %>
-  <%= render partial: 'home/featured_section', locals: {
-      section_name: 'topic',
-      # TODO: Add topic image source
-      image_source: "",
-      # TODO: Interpolate topic name in front of 'featured topic image' for alt text
-      image_alt_text: 'Featured topic image',
-      # TODO: Add name of topic for h2
-      featured_h2: 'Featured topic name',
-      # TODO: Add topic text for body text
-      featured_body_text: 'Proin blandit felis tincidunt justo luctus, rutrum bibendum ante accumsan. Duis eros lorem, ullamcorper a semper nec, rhoncus eu sapien. Sed tortor nisi, consequat a neque sed,
-          posuere ornare felis. Maecenas rutrum quis orci sed porta. Proin posuere metus in lorem placerat semper. Aenean felis mi, auctor sed pretium fringilla, ornare quis ex.',
-      # TODO: Add topic URL here
-      featured_topic_url: '',
-      featured_link_text: 'View topic page'
-    }
-  %>
+
+  <% if @featured_topic.present? && @featured_topic.title.present? && @featured_topic.description.present? && @featured_topic.url.present? && @featured_topic.cta_text.present? && @featured_topic.attachment.exists?%>
+    <%= render partial: 'home/featured_section', locals: {
+        section_name: 'topic',
+        image_source: "#{@featured_topic.attachment_s3_presigned_url}",
+        image_alt_text: "#{@featured_topic.title} featured topic image",
+        featured_h2: "#{@featured_topic.title}",
+        featured_body_text: "#{@featured_topic.description}",
+        featured_topic_url: "#{@featured_topic.url}",
+        featured_link_text: "#{@featured_topic.cta_text}"
+      }
+    %>
+  <% end %>
 
   <% if @highlighted_pr.present? && @highlighted_pr.name.present? && @highlighted_pr.highlight_body.present? && @highlighted_pr.slug.present? && @highlighted_pr.highlight_attachment.exists? %>
     <%= render partial: 'home/featured_section', locals: {

--- a/db/migrate/20210910151628_create_topics.rb
+++ b/db/migrate/20210910151628_create_topics.rb
@@ -1,0 +1,13 @@
+class CreateTopics < ActiveRecord::Migration[5.2]
+  def change
+    create_table :topics do |t|
+      t.string :title
+      t.string :description
+      t.string :url
+      t.string :cta_text
+      t.boolean :featured, default: false, null: false
+      t.timestamps
+    end
+    add_attachment :topics, :attachment
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_08_25_174729) do
+ActiveRecord::Schema.define(version: 2021_09_10_151628) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -1073,6 +1073,20 @@ ActiveRecord::Schema.define(version: 2021_08_25_174729) do
     t.integer "attachment_file_size"
     t.datetime "attachment_updated_at"
     t.index ["practice_id"], name: "index_toolkit_files_on_practice_id"
+  end
+
+  create_table "topics", force: :cascade do |t|
+    t.string "title"
+    t.string "description"
+    t.string "url"
+    t.string "cta_text"
+    t.boolean "featured", default: false, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "attachment_file_name"
+    t.string "attachment_content_type"
+    t.integer "attachment_file_size"
+    t.datetime "attachment_updated_at"
   end
 
   create_table "user_practices", force: :cascade do |t|

--- a/spec/features/admin/admin_topics_spec.rb
+++ b/spec/features/admin/admin_topics_spec.rb
@@ -1,0 +1,87 @@
+require 'rails_helper'
+
+describe 'Admin Topics Tab', type: :feature do
+  before do
+    @admin = User.create!(email: 'admin-fake-user-1231231123@va.gov', password: 'Password123',
+                          password_confirmation: 'Password123', skip_va_validation: true, confirmed_at: Time.now, accepted_terms: true)
+    @admin.add_role(:admin)
+    @img_path_1 = "#{Rails.root}/spec/assets/acceptable_img.jpg"
+    @img_path_2 = "#{Rails.root}/spec/assets/charmander.png"
+    @img_path_3 = "#{Rails.root}/spec/assets/SpongeBob.png"
+    Topic.create(title: "Mock topic one", description: "Description for mock topic 1", url: '/diffusion-map', cta_text: "Click here for diffusion map", attachment: File.new(@img_path_1))
+    Topic.create(title: "Mock topic two", description: "Description for mock topic 2", url: 'https://www.va.gov', cta_text: "Click here for Veterans Affairs website", attachment: File.new(@img_path_2), featured: true)
+    login_as(@admin, scope: :user, run_callbacks: false)
+  end
+
+  it 'should display existing topics' do
+    visit '/admin'
+    click_link 'Topics'
+    featured_col_values = find_all('.status_tag')
+    expect(page).to have_content('Mock topic two')
+    expect(page).to have_content('https://www.va.gov')
+    expect(featured_col_values.first.text).to eq "YES"
+    expect(page).to have_content('Mock topic one')
+    expect(page).to have_content('/diffusion-map')
+    expect(featured_col_values.last.text).to eq "NO"
+    visit '/'
+    expect(page).to have_content('FEATURED TOPIC')
+    expect(page).to have_content('Mock topic two')
+    expect(page).to have_content('Description for mock topic 2')
+    expect(page).to have_link('Click here for Veterans Affairs website', href: 'https://www.va.gov')
+  end
+
+  it 'allow adding and featuring a new topic' do
+    visit '/admin'
+    click_link 'Topics'
+    click_link('New Topic')
+    fill_in('Title', with: 'Mock topic three')
+    fill_in('Description', with: "Description for mock topic 3")
+    fill_in('Call to action URL', with: "/visns")
+    fill_in('Call to action text', with: "Go see VISNs here")
+    find('#topic_attachment').attach_file(@img_path_3)
+    click_button('Create Topic')
+    expect(page).to have_content('Topic was successfully created.')
+    visit '/admin/topics'
+    expect(page).to have_content('Mock topic three')
+    expect(page).to have_content('/visns')
+    featured_col_values = find_all('.status_tag')
+    expect(featured_col_values.first.text).to eq "NO"
+    find("a[href='/admin/topics/3/feature']").click
+    featured_col_values = find_all('.status_tag')
+    expect(page).to have_content("Topic with ID 3 is now featured.")
+    expect(featured_col_values.first.text).to eq "YES"
+    expect(featured_col_values[1].text).to eq "NO"
+    visit '/'
+    expect(page).to have_content('FEATURED TOPIC')
+    expect(page).to have_content('Mock topic three')
+    expect(page).to have_content('Description for mock topic 3')
+    expect(page).to have_link('Go see VISNs here', href: visns_path)
+    visit '/admin/topics'
+    find("a[href='/admin/topics/3/feature']").click
+    featured_col_values = find_all('.status_tag')
+    expect(page).to have_content("Topic with ID 3 is now unfeatured.")
+    expect(featured_col_values.first.text).to eq "NO"
+    visit '/'
+    expect(page).to have_no_content('FEATURED TOPIC')
+  end
+
+  it 'allow editing and deleting an existing topic' do
+    visit '/admin'
+    click_link 'Topics'
+    find_all('.edit_link').first.click
+    fill_in('Title', with: 'Mock updated topic two')
+    find('#topic_attachment').attach_file(@img_path_3)
+    click_button('Update Topic')
+    expect(page).to have_content('Topic was successfully updated.')
+    visit '/'
+    expect(page).to have_content('FEATURED TOPIC')
+    expect(page).to have_content('Mock updated topic two')
+    visit '/admin'
+    click_link 'Topics'
+    find_all('.delete_link').first.click
+    page.accept_alert
+    expect(page).to have_content('Topic was successfully destroyed.')
+    visit '/'
+    expect(page).to have_no_content('FEATURED TOPIC')
+  end
+end


### PR DESCRIPTION
### JIRA issue link
[DM-2801](https://agile6.atlassian.net/browse/DM-2801)

## Description - what does this code do?
- adds ability to add featured topics via the admin panel
- dynamically displays topic on homepage

## Testing done - how did you test it/steps on how can another person can test it 
- Ensure you do not see featured topic section on homepage
- Go to `/admin/topics`
- Add a new topic and feature it
- Check the homepage to see the topic is featured
- Add a new topic again and feature it -- it should automatically unfeature the previous featured topic
- Check the homepage to see the topic is featured
- Make sure editing the topic works
- Make sure internal and external url works

## Screenshots, Gifs, Videos from application (if applicable)
<img width="1258" alt="Screen Shot 2021-09-10 at 10 29 36 AM" src="https://user-images.githubusercontent.com/20211771/132882670-63e3aaf0-7eff-4ca5-85fb-7e067c33a40f.png">


## Link to mock-ups/mock ups (image file if you have it) (if applicable)


## Acceptance criteria
- [X] Add Featured Topic section
- [X] Add description
- [X] Make picture configurable
- [X] Make Header configurable
- [X] Make text description configurable
- [X] Make CTA text configurable
- [X] All things configurable in Admin panel
- [X] Ability to select “Featured”
- [] Once selected as “Featured” they are prompted with above info
- [X] Can be about anything

## Definition of done
- [X] Unit tests written (if applicable)
- [] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [X] A link has been provided to the originating JIRA issue
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs