### PR TITLE
DM-2923: Prevent users from seeing other users' profiles

### DIFF
--- a/spec/features/users/user_profile_spec.rb
+++ b/spec/features/users/user_profile_spec.rb
@@ -11,15 +11,17 @@ describe 'The user index', type: :feature do
                          password_confirmation: 'Password123', skip_va_validation: true, confirmed_at: Time.now, accepted_terms: true)
   end
 
-  it 'should not show edit profile button for a different users show page' do
+  it 'should not show the profile page of a different user and redirect them to the home page' do
     visit "/users/#{@user.id}"
 
     expect(page).to be_accessible.according_to :wcag2a, :section508
     expect(page).to_not have_content('Edit profile')
+    expect(page.current_path).to eq root_path
 
     login_as(@user2, scope: :user, run_callbacks: false)
     visit "/users/#{@user.id}"
     expect(page).to_not have_content('Edit profile')
+    expect(page.current_path).to eq root_path
   end
 
   it 'should have edit profile button for logged in user' do
@@ -41,7 +43,7 @@ describe 'The user index', type: :feature do
 
     expect(page).to be_accessible.according_to :wcag2a, :section508
     expect(page).to have_content('Diffusion Marketplace')
-    expect(page.current_path).to eq user_session_path
+    expect(page.current_path).to eq root_path
   end
 
   it 'should show the current users email' do


### PR DESCRIPTION
### JIRA issue link
[DM-2923](https://agile6.atlassian.net/browse/DM-2923)

## Description - what does this code do?
This PR prevents users from seeing other users' profiles. When a user navigates to another user's profile, they will be redirected to the home page.

## Testing done - how did you test it/steps on how can another person can test it 
**Not signed in user**
1. Go to `/edit-profile` be redirected to the home page
2. Go to a user's profile (e.g. `/users/1`) and be redirected to home page

**Signed in user A**
user B here means a user that's not the one you are signed in as (user A)
1. Go to `/users/user B Id` and be redirected to the home page
2. Go to `/edit-profile` and it should allow you to edit your own profile
3. Go to `/users/user A id` and you should be redirected to your profile show page

Other
1. Make sure `/admin/users` editing, viewing users still works as intended

NOTE:
We probably need a separate story to address instances of users and non-logged in users being redirected to the user sign in page when hitting devise routes

## Screenshots, Gifs, Videos from application (if applicable)


## Link to mock-ups/mock ups (image file if you have it) (if applicable)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Unit tests written (if applicable)
- [X] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [X] A link has been provided to the originating JIRA issue
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs