### PR TITLE
DM-2924: Sanitize session timeout URLs

### DIFF
--- a/app/controllers/session_timeout_controller.rb
+++ b/app/controllers/session_timeout_controller.rb
@@ -1,5 +1,6 @@
 # implementation source: https://medium.com/codex/user-session-inactivity-timeout-with-rails-and-devise-7269ac3a8213
 class SessionTimeoutController < Devise::SessionsController
+  include InternalUrlUtils
   prepend_before_action :skip_timeout, only: [:check_session_timeout, :render_timeout]
 
   def check_session_timeout
@@ -11,11 +12,21 @@ class SessionTimeoutController < Devise::SessionsController
     redirect_pathname = params[:path]
     reset_session
     sign_out(current_user)
-    url_text = redirect_pathname === '/' ? nil : 'Return to where you left off.'
-    redirect_to root_path, :flash => { alert: 'Your session has expired.', url: redirect_pathname, url_text: url_text }
+    hide_redirect_path = redirect_pathname === '/' || !is_valid_path(redirect_pathname)
+    url_text = hide_redirect_path ? nil : 'Return to where you left off.'
+    url = hide_redirect_path ? nil : redirect_pathname
+    redirect_to root_path, :flash => { alert: 'Your session has expired.', url: url, url_text: url_text }
   end
 
   private
+  def is_valid_path(path)
+    begin
+      return true if validate_url(path)
+    rescue
+      return false
+    end
+  end
+
   def ttl_to_timeout
     return 0 if user_session.blank?
     Devise.timeout_in - (Time.now.utc - last_request_time).to_i

--- a/app/models/concerns/internal_url_validator.rb
+++ b/app/models/concerns/internal_url_validator.rb
@@ -1,23 +1,11 @@
 class InternalUrlValidator < ActiveModel::Validator
+  include InternalUrlUtils
+
   def validate(record)
     url = record.url
     begin
       if url.present?
-        # checks if url begins with a "/"
-        if url.chars.first != '/'
-          raise StandardError.new 'must begin with a "/"'
-        end
-
-        route = Rails.application.routes.recognize_path(record.url)
-
-        # checks if the record exists with the specified id
-        if route.present? && route[:id].present?
-          model = route[:controller].classify
-          db_record = model.constantize.find_by(slug: route[:id])
-          if db_record.nil?
-            raise StandardError.new 'not a valid URL'
-          end
-        end
+        validate_url(url)
       end
     rescue => e
       record.errors.add(:url, e.message)

--- a/config/initializers/active_admin.rb
+++ b/config/initializers/active_admin.rb
@@ -211,7 +211,7 @@ ActiveAdmin.setup do |config|
   #   config.register_stylesheet 'my_print_stylesheet.css', media: :print
   #
   # To load a javascript file:
-  #   config.register_javascript 'my_javascript.js'
+  config.register_javascript 'session_timeout_poller.js'
 
   # == CSV options
   #

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -13,7 +13,7 @@ en:
       locked: "Your account is locked."
       last_attempt: "You have one more attempt before your account is locked."
       not_found_in_database: "Invalid %{authentication_keys} or password."
-      timeout: "Your session expired. Please sign in again to continue."
+      timeout: "Your session has expired."
       unauthenticated: "You need to sign in or sign up before continuing."
       unconfirmed: "You have to confirm your email address before continuing."
     mailer:

--- a/lib/modules/internal_url_utils.rb
+++ b/lib/modules/internal_url_utils.rb
@@ -40,8 +40,11 @@ module InternalUrlUtils
     # admin routes
     if route[:controller].include?('admin')
       model_str = route[:controller].split("/")[1]
-      model = get_model(model_str)
-      if route[:action].present? && is_admin_action(route[:action])
+      # admin dashboard
+      if model_str == 'dashboard' && route[:action] == 'index'
+        db_record = true
+      elsif route[:action].present? && is_admin_action(route[:action])
+        model = get_model(model_str)
         if model_str === 'practices'
           db_record = model.find_by(slug: route[:id])
         else

--- a/lib/modules/internal_url_utils.rb
+++ b/lib/modules/internal_url_utils.rb
@@ -1,0 +1,73 @@
+module InternalUrlUtils
+  def validate_url(url)
+    # checks if url begins with a "/"
+    if url.chars.first != '/'
+      raise StandardError.new 'must begin with a "/"'
+    end
+
+    route = Rails.application.routes.recognize_path(url)
+
+    if route.present?
+      db_rec = get_record(route)
+      return db_rec.present? ? true : throw_invalid_err
+    else
+      throw_invalid_err
+    end
+  end
+
+  private
+
+  def is_practice_edit_action(action)
+    pr_edit_actions = ['metrics', 'instructions', 'editors', 'introduction', 'adoptions', 'overview', 'implementation', 'contact', 'about']
+    pr_edit_actions.include?(action)
+  end
+
+  def is_admin_action(action)
+    admin_actions = ['show', 'edit']
+    admin_actions.include?(action)
+  end
+
+  def throw_invalid_err
+    raise StandardError.new 'not a valid URL'
+  end
+
+  def get_model(controller)
+    controller.classify.constantize
+  end
+
+  def get_record(route)
+    db_record = nil
+    # admin routes
+    if route[:controller].include?('admin')
+      model_str = route[:controller].split("/")[1]
+      model = get_model(model_str)
+      if route[:action].present? && is_admin_action(route[:action])
+        if model_str === 'practices'
+          db_record = model.find_by(slug: route[:id])
+        else
+          db_record = model.find_by(id: route[:id])
+        end
+      else
+        db_record = true
+      end
+    else
+      # practice edit routes
+      if route[:practice_id].present? && route[:action]
+        model = get_model(route[:controller])
+        db_record = model.find_by(slug: route[:practice_id]) if is_practice_edit_action(route[:action])
+      # visn show routes
+      elsif route[:number].present?
+        number = route[:number].to_i
+        is_number = number.to_s === route[:number]
+        model = get_model(route[:controller])
+        db_record = model.find_by(number: number) if is_number
+      elsif route[:id].present?
+        model = get_model(route[:controller])
+        db_record = model.find_by(slug: route[:id])
+      else
+        db_record = true
+      end
+    end
+    return db_record
+  end
+end

--- a/spec/models/concerns/internal_url_validator_spec.rb
+++ b/spec/models/concerns/internal_url_validator_spec.rb
@@ -98,6 +98,22 @@ RSpec.describe InternalUrlValidator do
       end
     end
 
+    context 'given the admin route' do
+      it 'should have no errors' do
+        component = PageSubpageHyperlinkComponent.new(url: '/admin')
+        component.valid?
+        expect(component.errors[:url]).to eq([])
+      end
+    end
+
+    context 'given the admin dashboard route' do
+      it 'should have no errors' do
+        component = PageSubpageHyperlinkComponent.new(url: '/admin/dashboard')
+        component.valid?
+        expect(component.errors[:url]).to eq([])
+      end
+    end
+
     context 'given an admin practice show page that exists' do
       it 'should have no errors' do
         component = PageSubpageHyperlinkComponent.new(url: '/admin/practices/a-public-practice')

--- a/spec/models/concerns/internal_url_validator_spec.rb
+++ b/spec/models/concerns/internal_url_validator_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe InternalUrlValidator do
       Practice.create!(name: 'A public practice', slug: 'a-public-practice', approved: true, published: true, tagline: 'Test tagline', user: user)
       page_group = PageGroup.create(name: 'programming', slug: 'programming', description: 'Pages about programming go in this group.')
       Page.create(page_group: page_group, title: 'ruby', description: 'what a gem', slug: 'ruby-rocks', created_at: Time.now)
+      Visn.create!(id: 2, name: "New York/New Jersey VA Health Care Network", number: 2)
     end
 
     context 'given a non-existant URL' do
@@ -19,7 +20,7 @@ RSpec.describe InternalUrlValidator do
 
     context 'given a URL with no "/" in the beginning' do
       it 'should add an error message' do
-        component = PageSubpageHyperlinkComponent.new(url: 'practices/vione')
+        component = PageSubpageHyperlinkComponent.new(url: 'innovations/vione')
         component.valid?
         expect(component.errors[:url][0]).to eq("must begin with a \"/\"")
       end
@@ -30,6 +31,22 @@ RSpec.describe InternalUrlValidator do
         component = PageSubpageHyperlinkComponent.new(url: '/innovations/a-private-practice')
         component.valid?
         expect(component.errors[:url][0]).to eq("not a valid URL")
+      end
+    end
+
+    context 'given the diffusion map page path' do
+      it 'should have no errors' do
+        component = PageSubpageHyperlinkComponent.new(url: '/diffusion-map')
+        component.valid?
+        expect(component.errors[:url]).to eq([])
+      end
+    end
+
+    context 'given the home page path' do
+      it 'should have no errors' do
+        component = PageSubpageHyperlinkComponent.new(url: '/')
+        component.valid?
+        expect(component.errors[:url]).to eq([])
       end
     end
 
@@ -46,6 +63,78 @@ RSpec.describe InternalUrlValidator do
         component = PageSubpageHyperlinkComponent.new(url: '/programming/ruby-rocks')
         component.valid?
         expect(component.errors[:url]).to eq([])
+      end
+    end
+
+    context 'given the visn directory page that exists' do
+      it 'should have no errors' do
+        component = PageSubpageHyperlinkComponent.new(url: '/visns')
+        component.valid?
+        expect(component.errors[:url]).to eq([])
+      end
+    end
+
+    context 'given the visn show page that exists' do
+      it 'should have no errors' do
+        component = PageSubpageHyperlinkComponent.new(url: '/visns/2')
+        component.valid?
+        expect(component.errors[:url]).to eq([])
+      end
+    end
+
+    context 'given the visn show page that does not exist' do
+      it 'should add an error message' do
+        component = PageSubpageHyperlinkComponent.new(url: '/visns/14')
+        component.valid?
+        expect(component.errors[:url][0]).to eq("not a valid URL")
+      end
+    end
+
+    context 'given the visn show page that does not exist' do
+      it 'should add an error message' do
+        component = PageSubpageHyperlinkComponent.new(url: '/visns/fake-visn')
+        component.valid?
+        expect(component.errors[:url][0]).to eq("not a valid URL")
+      end
+    end
+
+    context 'given an admin practice show page that exists' do
+      it 'should have no errors' do
+        component = PageSubpageHyperlinkComponent.new(url: '/admin/practices/a-public-practice')
+        component.valid?
+        expect(component.errors[:url]).to eq([])
+      end
+    end
+
+    context 'given an admin practice edit page that exists' do
+      it 'should have no errors' do
+        component = PageSubpageHyperlinkComponent.new(url: '/admin/practices/a-public-practice/edit')
+        component.valid?
+        expect(component.errors[:url]).to eq([])
+      end
+    end
+
+    context 'given an admin page that does not exist' do
+      it 'should add an error message' do
+        component = PageSubpageHyperlinkComponent.new(url: '/admin/fake-url')
+        component.valid?
+        expect(component.errors[:url][0]).to eq("No route matches \"/admin/fake-url\"")
+      end
+    end
+
+    context 'given an admin practice show page that does not exist' do
+      it 'should add an error message' do
+        component = PageSubpageHyperlinkComponent.new(url: '/admin/practices/a-fake-practice')
+        component.valid?
+        expect(component.errors[:url][0]).to eq("not a valid URL")
+      end
+    end
+
+    context 'given an admin practice edit page that does not exit' do
+      it 'should add an error message' do
+        component = PageSubpageHyperlinkComponent.new(url: '/admin/practices/a-fake-practice/edit')
+        component.valid?
+        expect(component.errors[:url][0]).to eq("not a valid URL")
       end
     end
   end


### PR DESCRIPTION
### JIRA issue link
[DM-2924](https://agile6.atlassian.net/browse/DM-2924)

## Description - what does this code do?
This PR accomplishes the following:
1. sanitizes the session timeout URLs before displaying it to the users
2. Ensures internal url validations are more robust
3. Runs the session timeout poller in the /admin routes

## Testing done - how did you test it/steps on how can another person can test it 
**Page Builder Component**
1. Log in as an admin user
2. Go to edit a Page component
3. Add the "Subpage Hyperlink" component and save the page (try `/`, `/diffusion-map`, `/innovations/flow3`, `/admin/users/1/edit`, `/visns/1`, page builder pages etc... try a bunch of valid links)
4. It should save successfully
5. Edit the "Subpage Hyperlink" component with invalid links (try `/non-existant-url`, `/visns/3`, `path-name-with-no-forward-slash`, `/innovations/fake-innovation` etc...)
6. This should throw an error

**Admin Session timeout**
1. Log in as an admin user
2. In your browser's dev tools go to the network tab and check that every 30 seconds without a call to the DB or mouse movement that a call to checking the session time is made
3. After 15 minutes of inactivity, you should be redirected to the homepage with a "Return to where you left off" link that takes you back to where you were

**Session timeout URL sanitizing**
1. In the browser go to `/session_timeout?path=PUT_PATH_HERE` put a combination of valid and invalid paths
2. For valid paths you should see a return to where you left off and it should work
3. For invalid paths you should just see the session timeout alert


## Screenshots, Gifs, Videos from application (if applicable)


## Link to mock-ups/mock ups (image file if you have it) (if applicable)


## Acceptance criteria
- [ ]

## Definition of done
- [X] Unit tests written (if applicable)
- [ ] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [X] A link has been provided to the originating JIRA issue
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs