### PR TITLE
DM-2927: Strip potentially forgeable headers in middleware

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -40,7 +40,7 @@ module DiffusionMarketplace
 
     config.active_job.queue_adapter = :sidekiq
 
-    config.middleware.use HeadersFilter
+    config.middleware.use HeadersFilter if ENV['RAILS_ENV'] == 'production'
     config.middleware.use NTLMAuthentication if ENV['USE_NTLM'] == 'true'
   end
 end

--- a/lib/middleware/headers-filter.rb
+++ b/lib/middleware/headers-filter.rb
@@ -19,7 +19,7 @@ class HeadersFilter
 
   def call(env)
     @remove_headers.each { |header| env.delete(header) }
-    env["HTTP_HOST"] = ENV['RAILS_ENV'] == 'production' ? ENV.fetch('HOSTNAME').split('//')[1] : 'localhost:3200'
+    env["HTTP_HOST"] = ENV.fetch('HOSTNAME').split('//')[1]
     @app.call(env)
   end
 end


### PR DESCRIPTION
### JIRA issue link
[DM-2927](https://agile6.atlassian.net/browse/DM-2927)

## Description - what does this code do?
This PR removes potentially forgeable headers in a new middleware. The middleware was modified from the [Rack Headers Filter](https://rubygems.org/gems/rack-headers_filter) gem. The gem was built for a heroku app and since we aren't using Heroku, I modified that gem into our own middleware to sanitize the potential headers we may run into.

Reference: https://github.com/rails/rails/issues/29893#issuecomment-319768403

Apparently this is fixed in Rails 6 😅 

## Testing done - how did you test it/steps on how can another person can test it 
**On `master`**
1. start the app
2. in your terminal run
```
curl 'http://localhost:3200/' -H 'Accept-Encoding: gzip, deflate, br' -H 'Accept-Language: en-GB,en-US;q=0.8,en;q=0.6' -H 'User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.115 Safari/537.36' -H 'Accept: text/html, application/xhtml+xml' --compressed -H 'X-Forwarded-Host: evil.com'
```
3. In the resulting output, you should see instances  of `localhost:3200` being replaced with `evil.com`

**On this branch**
follow steps 1. and 2. above
3. In the resulting output, you should NOT see instances  of `localhost:3200` being replaced with `evil.com`

## Screenshots, Gifs, Videos from application (if applicable)


## Link to mock-ups/mock ups (image file if you have it) (if applicable)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Unit tests written (if applicable)
- [ ] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating JIRA issue
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs