### PR TITLE
DM-2918: Changed publish modal header background color to red

### DIFF
--- a/app/assets/stylesheets/dm/components/_modal.scss
+++ b/app/assets/stylesheets/dm/components/_modal.scss
@@ -80,6 +80,10 @@
 
 .publication-modal-content {
   width: 524px;
+
+  h2 {
+    background-color: color($theme-color-error-dark);
+  }
 }
 
 /* Add Animation */

--- a/app/views/practices/_publication_validation_modal.html.erb
+++ b/app/views/practices/_publication_validation_modal.html.erb
@@ -1,7 +1,7 @@
 <div id="practiceEditorPublicationModal" class="bg-base-light publication-modal-hidden">
   <div class="padding-y-9 publication-modal">
     <div class="margin-x-auto bg-white radius-md publication-modal-content">
-      <div class="bg-secondary text-white radius-top-md">
+      <div class="text-white radius-top-md">
         <h2 class="margin-0 padding-205 font-sans-lg">Cannot publish yet</h2>
       </div>
       <div class="publication-modal-body font-sans-md">


### PR DESCRIPTION
### JIRA issue link
https://agile6.atlassian.net/browse/DM-2918

## Description - what does this code do?
Adds red background to publish practice modal.

## Testing done - how did you test it/steps on how can another person can test it 
1. Log in as an admin and visit a `/some-unpublished-practice/edit/introduction`.
2. Click "Publish innovation" and make sure the header for the publication modal is now red.

## Screenshots, Gifs, Videos from application (if applicable)
![Screen Shot 2021-10-12 at 1 54 37 PM](https://user-images.githubusercontent.com/34111449/137005519-663a04a0-4171-4b7d-bfe8-2b87db6c6c87.png)

## Link to mock-ups/mock ups (image file if you have it) (if applicable)


## Acceptance criteria
- Just change it to red

## Definition of done
- [ ] Unit tests written (if applicable)
- [ ] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [X] A link has been provided to the originating JIRA issue
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs