### PR TITLE
DM-2969: Invalidate practices json cache every 12 hours

### DIFF
--- a/app/controllers/practices_controller.rb
+++ b/app/controllers/practices_controller.rb
@@ -676,11 +676,11 @@ class PracticesController < ApplicationController
 
   def cached_json_practices
     if helpers.is_user_a_guest?
-      Rails.cache.fetch('searchable_public_practices_json') do
+      Rails.cache.fetch('searchable_public_practices_json', expires_in: 12.hours) do
         practices_json(Practice.public_facing.sort_by_retired.get_with_categories_and_adoptions_ct)
       end
     else
-      Rails.cache.fetch('searchable_practices_json') do
+      Rails.cache.fetch('searchable_practices_json', expires_in: 12.hours) do
         practices_json(Practice.sort_by_retired.get_with_categories_and_adoptions_ct)
       end
     end


### PR DESCRIPTION
### JIRA issue link
[DM-2969](https://agile6.atlassian.net/browse/DM-2969)

## Description - what does this code do?
This PR invalidates the practices json cache after 12 hours even if select practice fields have not been updated. This is to ensure the AWS URLs for the practice's main display images for the practice have not expired.

## Testing done - how did you test it/steps on how can another person can test it 
- In the practices_controller change the expires_in value to something you can test like `1.minutes`.
- Have a rails console open
In the console
- run `Rails.cache.clear`
- run `Rails.cache.redis.keys` and make sure you do not see any keys

- Go to the search page
In the console
- run `Rails.cache.redis.keys` and make sure you see keys
- after 1 min,  run `Rails.cache.redis.keys` and make sure you do not see any keys

- Reload the search page
In the console
- run `Rails.cache.redis.keys` and make sure you see keys

## Screenshots, Gifs, Videos from application (if applicable)


## Link to mock-ups/mock ups (image file if you have it) (if applicable)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Unit tests written (if applicable)
- [ ] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating JIRA issue
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs