### PR TITLE
Dm 2832

### DIFF
--- a/app/assets/stylesheets/dm/pages/_facilities.scss
+++ b/app/assets/stylesheets/dm/pages/_facilities.scss
@@ -28,6 +28,10 @@
       }
     }
 
+    .fa-bookmark:hover{
+      color: blue;
+    }
+
     tr:first-of-type {
       th {
         button {

--- a/app/assets/stylesheets/dm/pages/_facilities.scss
+++ b/app/assets/stylesheets/dm/pages/_facilities.scss
@@ -28,8 +28,28 @@
       }
     }
 
-    .fa-bookmark:hover{
-      color: blue;
+    .fas {
+      color: color($theme-color-primary-vivid);
+
+      &:hover {
+        color: color($theme-color-primary-dark);
+      }
+
+      &:active {
+        color: color($theme-color-primary-darker);
+      }
+    }
+
+    .far {
+      color: color($theme-color-base-ink);
+
+      &:hover {
+        color: color($theme-color-primary-vivid);
+      }
+
+      &:active {
+        color: color($theme-color-primary-dark);
+      }
     }
 
     tr:first-of-type {

--- a/app/controllers/commontator/comments_controller.rb
+++ b/app/controllers/commontator/comments_controller.rb
@@ -99,8 +99,9 @@ class Commontator::CommentsController < Commontator::ApplicationController
 
           params[:refresh_page] = user_practice.verified_implementer != (params[:user_practice_status] == 'verified_implementer')
 
-          user_practice.update_attributes(verified_implementer: true, team_member: false) if params[:user_practice_status] == 'verified_implementer'
-          user_practice.update_attributes(verified_implementer: false, team_member: true) if params[:user_practice_status] == 'team_member'
+          user_practice.update_attributes(verified_implementer: true, team_member: false, other: false) if params[:user_practice_status] == 'verified_implementer'
+          user_practice.update_attributes(verified_implementer: false, team_member: true, other: false) if params[:user_practice_status] == 'team_member'
+          user_practice.update_attributes(verified_implementer: false, team_member: false, other: true) if params[:user_practice_status] == 'other'
 
           @comment.save
           ahoy.track "Practice comment updated", { comment_id: @comment.id, creator_id: @comment.creator_id, editor_id: @comment.editor_id, body: @comment.body }


### PR DESCRIPTION
### JIRA issue link
https://agile6.atlassian.net/browse/DM-2832

## Description - what does this code do?
1.  Fixes bookmark styling issue on Facilities show page.
2. Fixes issue with Comments: when editing a comment and changing the role to "Other" the role was not being updated on the same page for different posts (for the current user).

## Testing done - how did you test it/steps on how can another person can test it 
------------ bookmark icon on the facilities show page -------------------------------------------------------
1.  Log in and navigate to a /facilities/SHOW-PAGE and scroll down to the Innovations adopted at this facility section.  Scroll down to where the innovations are isted and under the "Innovation name" column find the book mark icon next to the innovation title.  
2. Bookmark the innovation but notice that when you click on the bookmark icon - no red color displays around the border of the icon or that the entire bookmark icon isn't red.  i.e.,  currently when you click the icon it displays red on the hover or mousedown events.
![image](https://user-images.githubusercontent.com/60527788/140425109-beaf4c74-e852-4c57-92e9-596b12f185bc.png)
3.  You should be able to toggle between bookmarked and not bookmarked without seeing any red.
![image](https://user-images.githubusercontent.com/60527788/140425434-670fdb93-812f-468b-a374-5d227648285b.png)

---------Commontator practice show page.  When editing a comment and changing the role back to Other does not update other entries on the page. ------------
1.  Navigate to a Practice show page that has existing comments by different users.
2. Create comments with the "I am currently adopting this innovation" radio button selected.
 --> notice that the comment contains the "INNOVATION ADOPTER" tag next to the users name and position.
![image](https://user-images.githubusercontent.com/60527788/140427003-370135d0-e377-4428-81ee-fd8b1a1d208d.png)

3.  Create replies to the comments.  
4. Edit one of the replys by clicking the edit icon.. and change the role back to 'Other".  
![image](https://user-images.githubusercontent.com/60527788/140427771-b9e468f3-9a66-4917-9242-ed8224f9626e.png)

5. Click Save.
=> All of the posts for that user in that comment thread should be updated.  There should be no "INNOVATION ADOPTER" OR "INNOVATION OWNER" tag next to the name of the current user (you).  Other users posts should be the same as they were.
![image](https://user-images.githubusercontent.com/60527788/140428169-d1e4d237-73f9-4620-84ab-146a3104a292.png)





## Link to mock-ups/mock ups (image file if you have it) (if applicable)
N/A

## Acceptance criteria
I make a comment as “Other” edit that comment to select “I am currently adopting this practice” or “I am a member of this practice team” and then go back to select “Other” my role for that comment does not get updated when I reselect “Other”.

Bookmark button on click on “Practices adopted at this facility” on facilities show page is show up as red

## Definition of done
- [] Unit tests written (if applicable)
- [ ] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating JIRA issue
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs