### PR TITLE
DM-2990: Added QUERI formatted downloads for adoptions and published …

### DIFF
--- a/app/admin/practices.rb
+++ b/app/admin/practices.rb
@@ -44,6 +44,7 @@ ActiveAdmin.register Practice do
 
       # building out xlsx file
       p.workbook.add_worksheet(:name => "Practices - #{Date.today}") do |sheet|
+        col_widths = [50, 100, 50, 50, 50]
         sheet.add_row [
                         'Practice',
                         'Description',
@@ -71,8 +72,9 @@ ActiveAdmin.register Practice do
                           practice.date_initiated.present? ? date_format(practice.date_initiated) : '(start date unknown)',
                           origin_display_name(practice) === '' ? 'None' : origin_display_name(practice),
                           partners_text
-                        ], style: @xlsx_entry
+                        ], style: @xlsx_entry_text_top
         end
+        sheet.column_widths *col_widths
       end
     end
     # generating downloadable .xlsx file

--- a/app/assets/stylesheets/active_admin.scss
+++ b/app/assets/stylesheets/active_admin.scss
@@ -237,3 +237,26 @@
     margin-left: 20%;
   }
 }
+
+.index.admin_practices {
+  #collection_selection {
+    position: relative;
+  }
+
+  .table_tools {
+    position: absolute;
+
+    a:first-of-type {
+      margin-left: 0;
+    }
+  }
+
+  .admin-download-published-practices {
+    text-decoration: none !important;
+    background-color: #5ea3d3;
+    padding: 10px 20px;
+    color: #ffffff !important;
+    font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
+    font-size: 1.0em;
+  }
+}

--- a/app/helpers/active_admin_helpers.rb
+++ b/app/helpers/active_admin_helpers.rb
@@ -30,7 +30,8 @@ module ActiveAdminHelpers
         rurality: selected_facility[0].rurality,
         complexity: selected_facility[0].fy17_parent_station_complexity_level,
         station_number: selected_facility[0].station_number,
-        visn: selected_facility[0].visn
+        visn: selected_facility[0].visn,
+        practice_name: dh.practice.name
       }
     }
     sorted_diffusion_histories = practice_diffusion_histories.sort_by { |pdh| [pdh[:state], pdh[:facility_name]] }
@@ -170,6 +171,51 @@ module ActiveAdminHelpers
             column("Lifetime") {|ast| ast[:total]}
           end
         end
+      end
+    end
+  end
+
+  def add_adoption_columns(adoption_data, sheet, options = { :add_practice_name => false })
+      sheet.add_row [
+                     options[:add_practice_name] ? 'Practice' : nil,
+                    'State',
+                    'Location',
+                    'VISN',
+                    'Station Number',
+                    'Adoption Date',
+                    'Adoption Status',
+                    'Rurality',
+                    'Facility Complexity'
+                  ].compact, style: @xlsx_sub_header_3
+
+    adoption_data.each do |data_array|
+      # adoption information
+      if options[:add_practice_name]
+        data_array.each do |hash|
+          sheet.add_row [
+                          hash[:practice_name],
+                          hash[:state],
+                          adoption_facility_name(hash),
+                          hash[:visn].number,
+                          hash[:station_number],
+                          adoption_date(hash),
+                          adoption_status(hash),
+                          adoption_rurality(hash),
+                          hash[:complexity]
+                        ], style: @xlsx_entry
+
+        end
+      else
+        sheet.add_row [
+                        data_array[:state],
+                        adoption_facility_name(data_array),
+                        data_array[:visn].number,
+                        data_array[:station_number],
+                        adoption_date(data_array),
+                        adoption_status(data_array),
+                        adoption_rurality(data_array),
+                        data_array[:complexity]
+                      ], style: @xlsx_entry
       end
     end
   end

--- a/app/helpers/active_admin_helpers.rb
+++ b/app/helpers/active_admin_helpers.rb
@@ -88,6 +88,8 @@ module ActiveAdminHelpers
     @xlsx_legend_no_bottom_border = s.add_style b: true, u: true, border: {style: :thin, color: 'FFFFFF', edges: [:bottom]}
     @xlsx_legend_no_top_border = s.add_style b: true, border: {style: :thin, color: 'FFFFFF', edges: [:top]}
     @xlsx_legend_no_y_border = s.add_style b: true, border: {style: :thin, color: 'FFFFFF', edges: [:bottom, :top]}
+    @xlsx_entry_text_top = s.add_style sz: 12, alignment: { horizontal: :left, vertical: :top, wrap_text: true}
+    @xlsx_entry_text_bottom = s.add_style sz: 12, alignment: { horizontal: :left, vertical: :bottom, wrap_text: true}
   end
 
   def get_search_term_counts_by_type(ahoy_event_name, search_terms_array)
@@ -202,7 +204,7 @@ module ActiveAdminHelpers
                           adoption_status(hash),
                           adoption_rurality(hash),
                           hash[:complexity]
-                        ], style: @xlsx_entry
+                        ], style: @xlsx_entry_text_bottom
 
         end
       else
@@ -215,7 +217,7 @@ module ActiveAdminHelpers
                         adoption_status(data_array),
                         adoption_rurality(data_array),
                         data_array[:complexity]
-                      ], style: @xlsx_entry
+                      ], style: @xlsx_entry_text_bottom
       end
     end
   end

--- a/spec/features/admin/admin_adoptions_spec.rb
+++ b/spec/features/admin/admin_adoptions_spec.rb
@@ -59,7 +59,7 @@ describe 'Admin Adoptions Tab', type: :feature do
   it 'should allow an admin to download adoption data as a .xlsx file' do
     visit '/admin'
     click_link 'Adoptions'
-    export_button = find(:css, "input[type='submit']")
+    export_button = find(:css, "input[value='Download All']")
     export_button.click
 
     # should not navigate away from metrics page


### PR DESCRIPTION
### JIRA issue link
https://agile6.atlassian.net/browse/DM-2990
https://agile6.atlassian.net/browse/DM-3006

## Description - what does this code do?
1. Adds a QUERI-formatted download option for adoptions and published practices in the admin panel.

## Testing done - how did you test it/steps on how can another person can test it 
1. Log in as an admin and visit '/admin/adoptions`.
2. Click on the `Download All` button and make sure the data looks the same as before.
3. Visit the adoptions page of a published practice and add a new adoption.
4. Go back to `/admin/adoptions`, click `Download All` again, and make sure the new adoption was properly documented.
5. Click on `QUERI Download` and make sure the adoption data in the spreadsheet matches the data from the `Download All` spreadsheet, just in a different format (see the JIRA link for the QUERI format).
6. Visit `/admin/practices` and click on `Published Practices QUERI Download`.
7. Make sure you only see a list of published practices and that the format matches the requested format in the JIRA link.
8. _**NOTE:**_ The `description` is actually the practice summary (confirmed via the 4-sight practice on PROD).

## Screenshots, Gifs, Videos from application (if applicable)
![Screen Shot 2021-11-12 at 12 52 15 PM](https://user-images.githubusercontent.com/34111449/141514059-d7924576-a85d-44ff-9922-eba0c7898d07.png)
![Screen Shot 2021-11-12 at 1 05 36 PM](https://user-images.githubusercontent.com/34111449/141514066-f0469c0b-8f52-4b7f-ac7d-957932f8fa2e.png)

## Link to mock-ups/mock ups (image file if you have it) (if applicable)


## Acceptance criteria
- Pull Innovation Data that matches Table B (see attached)
- If possible, have the data pull match the format show in Table B 
- Format Adoptions data pull to match Table A attached where there is a practices column instead of a row and then the practices below it
- Fix VISN to be readable instead of a string

## Definition of done
- [ ] Unit tests written (if applicable)
- [ ] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [X] A link has been provided to the originating JIRA issue
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs