### PR TITLE
DM-3020: Removed portion of partners index page description and remov…

### DIFF
--- a/app/views/practice_partners/index.html.erb
+++ b/app/views/practice_partners/index.html.erb
@@ -4,8 +4,7 @@
     <h1 class="font-sans-2xl margin-top-3 margin-bottom-05">Partners</h1>
     <div class="grid-row">
       <p class="font-sans-lg line-height-sans-505 grid-col-10">
-        Best innovations are always being developed, vetted, and promoted by offices within the VA. Below is a list of some of the
-        organizations creating and implementing best innovations. Select an organization to view their innovation partnerships.
+        Best innovations are always being developed, vetted, and promoted by offices within the VA.
       </p>
     </div>
   </section>
@@ -19,7 +18,6 @@
           <div class="grid-row">
             <div class="grid-col-8 margin-bottom-3">
               <h3 class="font-sans-lg margin-top-0 margin-bottom-05"><%= link_to "#{ss.name}#{ss.short_name.present? ? " (#{ss.short_name.upcase})" : ''}", practice_partner_path(ss), class: 'usa-link', title: "Go to #{ss.name} partner page" %></h3>
-              <p class="font-sans-md line-height-sans-505"><%= ss.description %></p>
             </div>
           </div>
         <% end  %>


### PR DESCRIPTION
### JIRA issue link
https://agile6.atlassian.net/browse/DM-3020

## Description - what does this code do?
Removes some text from the Partners index page

## Testing done - how did you test it/steps on how can another person can test it 
1. Visit '/partners` and make sure the second sentence (check the A/C) has been removed from below the h1.
2. Make sure the description text below each partner link has been removed.

## Screenshots, Gifs, Videos from application (if applicable)
![Screen Shot 2021-11-12 at 1 37 33 PM](https://user-images.githubusercontent.com/34111449/141518276-6638bdde-ee8d-4636-b7aa-0101096a11f3.png)

## Link to mock-ups/mock ups (image file if you have it) (if applicable)


## Acceptance criteria
- Remove second sentence from header "Below is a list of some of the organizations creating and implementing best innovations. Select an organization to view their innovation partnerships."
- Remove text from after each Partner 

## Definition of done
- [ ] Unit tests written (if applicable)
- [ ] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [X] A link has been provided to the originating JIRA issue
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs