### PR TITLE
DM-3019: Removed extra underline from subpage hyperlink component

### DIFF
--- a/app/views/page/show.html.erb
+++ b/app/views/page/show.html.erb
@@ -149,7 +149,7 @@
               </div>
             <% else %>
               <div class="grid-row margin-bottom-5 grid-col-12 desktop:grid-col-8 pb-link-default <%= 'margin-x-auto' if @page.narrow? %>">
-                <a href="<%= component.url %>" class="width-full usa-link">
+                <a href="<%= component.url %>" class="width-full usa-link text-no-underline">
                   <h2 class="font-sans-xl display-inline margin-top-0 text-underline"><%= component.title %></h2>
                   <span class="margin-left-1 fas fa-chevron-right fa-icon-125 text-middle padding-bottom-2"></span>
                 </a>


### PR DESCRIPTION
### JIRA issue link
https://agile6.atlassian.net/browse/DM-3019

## Description - what does this code do?
Removes extra underline from page-builder's `SubpageHyperlink` component.

## Testing done - how did you test it/steps on how can another person can test it 
1. If you don't have a page-builder page that contains a subpage hyperlink, log in as an admin, add one, and then visit the page.
2. Make sure you don't see the extra small line at the end of the text.

## Screenshots, Gifs, Videos from application (if applicable)
Before:
![](https://user-images.githubusercontent.com/34111449/142917170-0ef7f787-0604-4994-a7ed-209a757b1aff.png)
After:
![](https://user-images.githubusercontent.com/34111449/142917229-f3b43658-62a5-419e-b038-72d841011058.png)

## Link to mock-ups/mock ups (image file if you have it) (if applicable)
https://www.figma.com/file/H2aII1WHRlySNG6r2HlZbY/Sitemap?node-id=1431%3A5109

## Acceptance criteria
- Remove the little line from the end of a PB link

## Definition of done
- [ ] Unit tests written (if applicable)
- [ ] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [X] A link has been provided to the originating JIRA issue
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs