### PR TITLE
DM-3009: Fix all parent categories filter select in search

### DIFF
--- a/app/assets/javascripts/_otherCategories.es6
+++ b/app/assets/javascripts/_otherCategories.es6
@@ -85,12 +85,9 @@
     }
 
     function executeOtherCategoryFunctions() {
-        // omit the following functions on the search page:
-        if (window.location.pathname !== '/search') {
-            attachShowOtherClinicalCategoryFields();
-            attachShowOtherOperationalCategoryFields();
-            attachShowOtherStrategicCategoryFields();
-        }
+        attachShowOtherClinicalCategoryFields();
+        attachShowOtherOperationalCategoryFields();
+        attachShowOtherStrategicCategoryFields();
         addAllCheckBoxListener('.all-clinical-checkbox', '.clinical-checkbox');
         addAllCheckBoxListener('.all-operational-checkbox', '.operational-checkbox');
         addAllCheckBoxListener('.all-strategic-checkbox', '.strategic-checkbox');

--- a/app/views/practices/_search.js.erb
+++ b/app/views/practices/_search.js.erb
@@ -931,6 +931,28 @@ function preventFiltersAccordionContentFlickerOnPageLoad() {
     });
 }
 
+function addAllCheckBoxListener(allCheckboxSelector, standardCheckboxSelector) {
+    let allCheckbox = allCheckboxSelector;
+    let checkbox = standardCheckboxSelector;
+
+    $(document).on('change', allCheckbox, function() {
+        if ($(this).prop('checked')) {
+            $(checkbox).prop('checked', true);
+        } else {
+            $(checkbox).prop("checked", false);
+        }
+    });
+
+    $(document).on('change', checkbox, function() {
+        let catCheckboxesCountMinusAllAndOther = $(checkbox).length;
+        if ($(`input${checkbox}:checked`).length === catCheckboxesCountMinusAllAndOther) {
+            $(allCheckbox).prop('checked', true);
+        } else {
+            $(allCheckbox).prop('checked', false);
+        }
+    });
+}
+
 function execSearchFunctions() {
     searchPracticesPage();
     openMobileFiltersModal();
@@ -939,6 +961,9 @@ function execSearchFunctions() {
     toggleMobileAdoptingAccordion();
     closeMobileFiltersModal();
     preventFiltersAccordionContentFlickerOnPageLoad();
+    addAllCheckBoxListener('.all-clinical-checkbox', '.clinical-checkbox');
+    addAllCheckBoxListener('.all-operational-checkbox', '.operational-checkbox');
+    addAllCheckBoxListener('.all-strategic-checkbox', '.strategic-checkbox');
 }
 
 document.addEventListener('turbolinks:load', function () {

--- a/app/views/practices/search.html.erb
+++ b/app/views/practices/search.html.erb
@@ -3,7 +3,6 @@
 <% provide :footer_classes, 'bg-gray-2' %>
 <% provide :head_tags do %>
   <%= javascript_include_tag '_practice_card_utilities', 'data-turbolinks-track': 'false' %>
-  <%= javascript_include_tag '_otherCategories', 'data-turbolinks-track': 'false' %>
   <%= javascript_tag 'data-turbolinks-track': 'false' do %>
     <%= render partial: 'search', formats: [:js] %>
   <% end %>

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -349,6 +349,29 @@ describe 'Search', type: :feature do
         expect(page).to have_content(@practice12.name)
       end
 
+      it 'should select all subcategories when selecting the parent category' do
+        visit_search_page
+        toggle_filters_accordion
+        select_category('.cat-all-strategic-label')
+        expect(find("#cat-2-input", visible: false)).to be_checked
+        expect(find("#cat-3-input", visible: false)).to be_checked
+        expect(find("#cat-4-input", visible: false)).to be_checked
+        expect(find("#cat-5-input", visible: false)).to be_checked
+        expect(find("#cat-6-input", visible: false)).to be_checked
+        update_results
+        expect(page).to have_content('7 results')
+        toggle_filters_accordion
+        select_category('.cat-2-label')
+        expect(find("#cat-all-strategic-input", visible: false)).to_not be_checked
+        expect(find("#cat-2-input", visible: false)).to_not be_checked
+        expect(find("#cat-3-input", visible: false)).to be_checked
+        expect(find("#cat-4-input", visible: false)).to be_checked
+        expect(find("#cat-5-input", visible: false)).to be_checked
+        expect(find("#cat-6-input", visible: false)).to be_checked
+        update_results
+        expect(page).to have_content('5 results')
+      end
+
       it 'should collect practices that match ALL of the conditions if the user selects filters AND uses the search input' do
         # Filter practices down to where there are two matches
         visit_search_page


### PR DESCRIPTION
### JIRA issue link
N/A

## Description - what does this code do?
This PR fixes the issue on the search page where if users selected "All clinical" or "All strategic" or "All operational" category filters it would not select all categories.

## Testing done - how did you test it/steps on how can another person can test it 
Ensure you can select all categories using the checkbox and the search works.
Ensure you can deselect all categories all the checkboxes are unselected.
Do this on both the search page and the innovation's introduction edit page.


## Screenshots, Gifs, Videos from application (if applicable)


## Link to mock-ups/mock ups (image file if you have it) (if applicable)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Unit tests written (if applicable)
- [X] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating JIRA issue
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs