### PR TITLE
DM-3029: Made both the visn cards and practice cards focusable via th…

### DIFF
--- a/app/assets/stylesheets/dm/components/_practice_card.scss
+++ b/app/assets/stylesheets/dm/components/_practice_card.scss
@@ -13,6 +13,13 @@
         text-decoration-color: color($theme-color-accent-warm);
       }
     }
+
+    &:focus {
+      .dm-practice-card-container {
+        outline: 0.25rem solid #2491ff;
+        outline-offset: 0;
+      }
+    }
   }
   // retired banner button
   .dm-practice-retired-banner {

--- a/app/assets/stylesheets/dm/pages/_visns.scss
+++ b/app/assets/stylesheets/dm/pages/_visns.scss
@@ -48,6 +48,13 @@
       }
     }
 
+    &:focus {
+      div {
+        outline: 0.25rem solid #2491ff;
+        outline-offset: 0;
+      }
+    }
+
     &:visited {
       .visn-name {
         color: color($theme-color-primary);

--- a/app/views/practices/_search.js.erb
+++ b/app/views/practices/_search.js.erb
@@ -86,7 +86,7 @@ function buildPracticeCard(result) {
     var favoriteButton = '';
     if (!result.item.retired) {
         favoriteButton =
-            '<a aria-label="Bookmark ' + practiceName + '" tabindex="-1" aria-hidden="true" class="dm-practice-bookmark-btn" id="dm-bookmark-button-' + result.item.id + '" data-remote="true" rel="nofollow" data-method="post" href="/innovations/' + result.item.slug + '/favorite.js">' +
+            '<a aria-label="Bookmark ' + practiceName + '" tabindex="0" class="dm-practice-bookmark-btn" id="dm-bookmark-button-' + result.item.id + '" data-remote="true" rel="nofollow" data-method="post" href="/innovations/' + result.item.slug + '/favorite.js">' +
             '<i class="' + favoriteButtonIcon + ' fa-bookmark dm-favorite-icon-' + result.item.id + ' text-no-underline"></i>' +
             '</a>';
     }
@@ -116,7 +116,7 @@ function buildPracticeCard(result) {
         <% if current_user.present? %>
         favoriteButton +
         <% end %>
-        '<a href="/innovations/' + result.item.slug + '" aria-label="Go to ' + result.item.name + '" tabindex="-1" aria-hidden="true" class="dm-practice-link' + practiceLinkClass + '">' +
+        '<a href="/innovations/' + result.item.slug + '" aria-label="Go to ' + result.item.name + '" tabindex="0" class="dm-practice-link' + practiceLinkClass + '">' +
         '<div class=" dm-practice-card-container">' +
         cardImage +
         '<div class="padding-105 height-card-mobile">' +

--- a/app/views/shared/_practice_card.html.erb
+++ b/app/views/shared/_practice_card.html.erb
@@ -3,12 +3,12 @@
 <% end %>
 <div class="dm-practice-card padding-bottom-3 tablet:grid-col-6 desktop:grid-col-4">
   <% if current_user && !practice.retired %>
-    <%= link_to practice_favorite_path(practice, format: :js), method: :post, remote: true, 'title': "Bookmark #{practice.name}", 'aria-label': "Bookmark #{practice.name}", 'tabindex': '-1', 'aria-hidden': 'true', 'class': "dm-practice-bookmark-btn", 'id': "dm-bookmark-button-#{practice.id}" do %>
+    <%= link_to practice_favorite_path(practice, format: :js), method: :post, remote: true, 'title': "Bookmark #{practice.name}", 'aria-label': "Bookmark #{practice.name}", 'tabindex': '0', 'class': "dm-practice-bookmark-btn", 'id': "dm-bookmark-button-#{practice.id}" do %>
       <i class="<% if current_user.favorite_practice_ids.include?(practice.id) %>fas fa-bookmark<% else %>far fa-bookmark<% end %> dm-favorite-icon-<%= practice.id %>"></i>
     <% end %>
   <% end %>
-  <%= link_to practice_path(practice), 'aria-label': "Go to #{practice.name}", 'tabindex': '-1', 'aria-hidden': 'true', class: "dm-practice-link#{practice.main_display_image.present? ? '' : ' dm-alt-practice-link'}" do %>
-    <div class=" dm-practice-card-container bg-white">
+  <%= link_to practice_path(practice), 'aria-label': "Go to #{practice.name}", 'tabindex': '0', class: "dm-practice-link#{practice.main_display_image.present? ? '' : ' dm-alt-practice-link'}" do %>
+    <div class="dm-practice-card-container bg-white">
       <% if practice.main_display_image.present? %>
         <div class="dm-practice-card-img-container">
           <img alt="<%= practice.name %> Marketplace Card Image" class="grid-row marketplace-card-img radius-top-sm" src="<%= practice.main_display_image_s3_presigned_url(:thumb) %>">

--- a/app/views/va_facilities/_adopted_facility_table_row.html.erb
+++ b/app/views/va_facilities/_adopted_facility_table_row.html.erb
@@ -13,7 +13,7 @@
       (Retired)
     <% end %>
     <% if current_user %>
-      <%= link_to practice_favorite_path(ad, format: :js), method: :post, remote: true, 'title': "Bookmark #{ad[:name]}", 'aria-label': "Bookmark #{ad[:name]}", 'tabindex': '-1', 'aria-hidden': 'true', 'class': "dm-practice-bookmark-btn", 'id': "dm-bookmark-button-#{ad[:id]}" do %>
+      <%= link_to practice_favorite_path(ad, format: :js), method: :post, remote: true, 'title': "Bookmark #{ad[:name]}", 'aria-label': "Bookmark #{ad[:name]}", 'tabindex': '0', 'class': "dm-practice-bookmark-btn", 'id': "dm-bookmark-button-#{ad[:id]}" do %>
         <i class="<% if current_user.favorite_practice_ids.include?(ad[:id]) %>fas fa-bookmark<% else %>far fa-bookmark<% end %> dm-favorite-icon-<%= ad[:id] %>"></i>
       <% end %>
     <% end %>

--- a/app/views/visns/_visn_card.erb
+++ b/app/views/visns/_visn_card.erb
@@ -1,5 +1,5 @@
 <div class="dm-visn-card tablet:grid-col-6 desktop:grid-col-4 margin-bottom-3">
-  <%= link_to visn_path(visn), 'aria-label': "Go to VISN #{visn.number}", 'tabindex': '-1', 'aria-hidden': 'true', id: "visn-#{visn.number}-card-link", class: 'visn-card-link' do %>
+  <%= link_to visn_path(visn), 'aria-label': "Go to VISN #{visn.number}", 'tabindex': '0', id: "visn-#{visn.number}-card-link", class: 'visn-card-link' do %>
     <div class="visn-card-text padding-top-2 padding-bottom-3 padding-x-3 radius-md bg-white">
       <p class="visn-name font-sans-lg line-height-25px margin-bottom-3">VISN <%= visn.number %></p>
       <%= render partial: 'visn_metadata_list', locals: { visn: visn, grid: true } %>


### PR DESCRIPTION
### JIRA issue link
https://agile6.atlassian.net/browse/DM-3029

## Description - what does this code do?
Allows for keyboard users to focus on the practice and visn cards when navigating with the tab key

## Testing done - how did you test it/steps on how can another person can test it 
1. Visit `/visns`.
2. Ensure you can tab through each visn card, and the focus border is visible.
3. Visit a page that has practice cards.
4. Ensure you can tab through each practice card, and the focus border is visible.

## Screenshots, Gifs, Videos from application (if applicable)
_**VISN Cards**_
![](https://media.giphy.com/media/wUAGuN44GZ06AuOpzn/giphy.gif)

_**Practice Cards**_
![](https://media.giphy.com/media/J1BJxXUeihtxQd6XFr/giphy.gif)

## Link to mock-ups/mock ups (image file if you have it) (if applicable)


## Acceptance criteria
- Remove Aria hidden label for practice cards on link for practice cards

## Definition of done
- [ ] Unit tests written (if applicable)
- [ ] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [X] A link has been provided to the originating JIRA issue
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs