### PR TITLE
DM-2985: Update breadcrumb styles for non innovation pages

### DIFF
--- a/app/assets/javascripts/_page_show.es6
+++ b/app/assets/javascripts/_page_show.es6
@@ -58,34 +58,10 @@
       });
     }
 
-
-    // due to the breadcrumbs being rendered before everything else, move them into the gradient banner for page-builder pages, if the title and description are visible
-    function relocateAndStyleBreadcrumb() {
-        let breadcrumbContainer = '.breadcrumbs-container';
-        let breadcrumb = '.usa-breadcrumb__list-item';
-
-        if (!$('.page-builder-intro-container').hasClass('display-none')) {
-            $(breadcrumbContainer).parent().prependTo('.page-builder-intro-content');
-            $(breadcrumbContainer).parent().removeClass('grid-container');
-            $(breadcrumbContainer).addClass('text-white padding-top-0 padding-bottom-1');
-            $(breadcrumb).first().find('a').addClass('dm-alt-link-white');
-        } else {
-            $(breadcrumbContainer).find('.fa-arrow-left').addClass('text-gray-50');
-        }
-    }
-
-    function addMarginToPageContentWithNoBreadCrumb() {
-        if ($('#breadcrumbs').parent().hasClass('display-none') && $('.page-builder-intro-container').hasClass('display-none')) {
-            $('#page-builder-page').addClass('margin-top-10');
-        }
-    }
-
     function execPageBuilderFunctions() {
         browsePageBuilderPageHappy();
         removeBottomMarginFromLastAccordionHeading();
         containerizeSubpageHyperlinkCards();
-        relocateAndStyleBreadcrumb();
-        addMarginToPageContentWithNoBreadCrumb();
     }
 
     $document.on('turbolinks:load', execPageBuilderFunctions);

--- a/app/assets/stylesheets/dm/_classes.scss
+++ b/app/assets/stylesheets/dm/_classes.scss
@@ -259,21 +259,6 @@ to confirm the class DOES NOT EXIST before adding a new class
   height: calc(1em * 1.2 * 1);
 }
 
-#breadcrumbs {
-  a:not(.dm-alt-link-white) {
-    color: color($theme-link-color) !important;
-
-    &:hover {
-      color: color($theme-link-hover-color) !important;
-      text-decoration: underline;
-    }
-
-    &:active {
-      color: color($theme-link-active-color) !important;
-    }
-  }
-}
-
 /* Font Awesome icon */
 .fa-icon-125 {
   font-size: 1.25rem;

--- a/app/assets/stylesheets/dm/components/_breadcrumbs.scss
+++ b/app/assets/stylesheets/dm/components/_breadcrumbs.scss
@@ -1,0 +1,39 @@
+// `usa-breadcrumb` OVERRIDES
+.usa-breadcrumb {
+  @include u-bg('transparent', !important);
+  .fas {
+    font-size: 13px;
+  }
+
+  .usa-breadcrumb__link {
+    @include u-text('underline');
+
+    &::before {
+      margin-right: 8px !important;
+    }
+
+    &:visited {
+      @include u-text('primary-vivid', !important);
+    }
+  }
+
+  .usa-breadcrumb__list-item {
+    white-space: normal !important;
+  }
+}
+
+.dm-breadcrumb--gradient-bg {
+  @extend .usa-breadcrumb;
+
+  .usa-breadcrumb__link {
+    @include u-text('white', !important);
+
+    &:hover {
+      text-decoration: underline;
+    }
+
+    &:visited {
+      @include u-text('white', !important);
+    }
+  }
+}

--- a/app/assets/stylesheets/dm/components/_gradient_banner.scss
+++ b/app/assets/stylesheets/dm/components/_gradient_banner.scss
@@ -8,6 +8,11 @@
   background: linear-gradient(236.03deg, color($theme-color-primary-vivid) 10.06%, #182F4C 93.13%);
   transform: matrix(1, 0, 0, -1, 0, 0);
 
+    // since the transform style from dm-gradient-banner flips the text along with the gradient colors, we need to flip the text inside of the grid-container to return it to its original state
+    .grid-container {
+      transform: matrix(1, 0, 0, -1, 0, 0);
+    }
+
   // Per research, the banner may have varying heights. As of 8/10/21, the designs use 318px (desktop version). Add any other height options as an extension class here
   &-318 {
     @extend .dm-gradient-banner;

--- a/app/assets/stylesheets/dm/pages/_home.scss
+++ b/app/assets/stylesheets/dm/pages/_home.scss
@@ -4,11 +4,6 @@
 
 .dm-homepage {
   .homepage-welcome-banner {
-    // since the transform style from dm-gradient-banner flips the text along with the gradient colors, we need to flip the text inside of the grid-container to return it to its original state
-    .grid-container {
-      transform: matrix(1, 0, 0, -1, 0, 0);
-    }
-
     .homepage-welcome-banner-body-text-container {
       margin-bottom: 119px;
 

--- a/app/assets/stylesheets/dm/pages/_page_builder.scss
+++ b/app/assets/stylesheets/dm/pages/_page_builder.scss
@@ -1,6 +1,0 @@
-.page-builder-intro-container {
-  // since the transform style from dm-gradient-banner flips the text along with the gradient colors, we need to flip the text inside of the grid-container to return it to its original state
-  .grid-container {
-    transform: matrix(1, 0, 0, -1, 0, 0);
-  }
-}

--- a/app/assets/stylesheets/dm_uswds/theme/_uswds-theme-custom-styles.scss
+++ b/app/assets/stylesheets/dm_uswds/theme/_uswds-theme-custom-styles.scss
@@ -110,14 +110,6 @@ i.e.
   color: color($theme-color-primary) !important;
 }
 
-.usa-breadcrumb {
-  background-color: transparent !important;
-
-  .page-builder-breadcrumb {
-    position: static;
-  }
-}
-
 .usa-breadcrumb__list-item:not(:last-child)::after {
   background: asset_url('angle-arrow-right.svg') no-repeat center / 0.84375ex 1.35ex !important;
 }

--- a/app/controllers/page_controller.rb
+++ b/app/controllers/page_controller.rb
@@ -4,7 +4,6 @@ class PageController < ApplicationController
     @page = Page.includes(:page_group).find_by(slug: page_slug.downcase, page_groups: {slug: params[:page_group_friendly_id].downcase})
     @page_components = @page.page_components
     @path_parts = request.path.split('/')
-    @builder_landing_page = Page.where(slug: 'home', page_group_id: @page.page_group_id).first
     @facilities_data = VaFacility.cached_va_facilities
     @practice_list_components = []
     set_pagy_practice_list_array(@page_components)

--- a/app/helpers/navigation_helper.rb
+++ b/app/helpers/navigation_helper.rb
@@ -3,6 +3,8 @@ module NavigationHelper
 
   def setup_breadcrumb_navigation
     session[:breadcrumbs] = session[:breadcrumbs] || []
+    session[:heading] = nil
+    session[:description] = nil
     action = params[:action]
     controller = params[:controller]
 
@@ -31,7 +33,6 @@ module NavigationHelper
       # Diffusion map
       if action == 'diffusion_map'
         empty_breadcrumbs
-        session[:breadcrumbs] << { 'display': 'Diffusion map', 'path': diffusion_map_path }
       end
     end
 
@@ -57,7 +58,7 @@ module NavigationHelper
     end
 
     def add_visn_index_breadcrumb
-      session[:breadcrumbs] << { 'display': 'VISNs', 'path': visns_path }
+      session[:breadcrumbs] << { 'display': 'VISN index', 'path': visns_path }
     end
 
     ### PRACTICE BREADCRUMBS
@@ -186,15 +187,15 @@ module NavigationHelper
     end
 
     ### VAMC breadcrumbs
-    #
     def add_facility_index_breadcrumb
-      session[:breadcrumbs] << { 'display': 'Facilities', 'path': va_facilities_path }
+      session[:breadcrumbs] << { 'display': 'Facility index', 'path': va_facilities_path }
     end
+
     if controller == 'va_facilities'
       if action == 'index'
         empty_breadcrumbs
-        session[:breadcrumbs] << { 'display': 'Facilities', 'path': va_facilities_path }
       end
+
       if action == 'show'
         va_facility = VaFacility.find_by!(slug: params[:id])
         empty_breadcrumbs
@@ -204,7 +205,6 @@ module NavigationHelper
       end
     end
 
-
     ### PRACTICE PARTNER BREADCRUMBS
     def add_partners_breadcrumb
       session[:breadcrumbs] << { 'display': 'Partners', 'path': practice_partners_path }
@@ -213,9 +213,7 @@ module NavigationHelper
     if controller == 'practice_partners'
       # practice partners path
       if action == 'index'
-        # empty the breadcrumbs and start a new 'path'
         empty_breadcrumbs
-        add_partners_breadcrumb
       end
 
       # practice partner show path
@@ -225,6 +223,8 @@ module NavigationHelper
         @practice_partner = PracticePartner.friendly.find(params[:id])
         partner_breadcrumb = session[:breadcrumbs].find { |b| b['display'] == @practice_partner.name }
 
+        heading = @practice_partner.name + (@practice_partner.short_name.present? ? " (#{@practice_partner.short_name.upcase})" : '')
+        session[:heading] = heading
 
         if partner_breadcrumb.blank?
           add_partners_breadcrumb
@@ -256,15 +256,17 @@ module NavigationHelper
 
         if @page_slug == 'home'
           empty_breadcrumbs
-          add_landing_page_breadcrumb(@builder_page_path)
         elsif @builder_landing_page.exists?
           empty_breadcrumbs
           add_landing_page_breadcrumb("/#{params[:page_group_friendly_id]}")
           add_sub_page_breadcrumb
         else
           empty_breadcrumbs
-          add_landing_page_breadcrumb('')
-          add_sub_page_breadcrumb
+        end
+
+        if @page.is_visible
+          session[:heading] = @page.title
+          session[:description] = @page.description
         end
       end
     end
@@ -313,7 +315,6 @@ module NavigationHelper
     if controller == 'visns'
       if action == 'index'
         empty_breadcrumbs
-        add_visn_index_breadcrumb
       end
 
       if action == 'show'

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -85,10 +85,8 @@
       id="main-content"
       class="<%= params[:controller] %> <%= params[:action] %>-main <%= yield(:main_classes) %><%= ' additional-return-to-top-padding' if params[:controller] === 'practices' && NavigationHelper::RETURN_TO_TOP_PAGES.include?(params[:action]) %>"
     >
-      <% if session[:breadcrumbs].any? %>
-        <% if !(params[:controller] === 'page' && params[:page_slug].nil?) || !(params[:controller] === 'page' && @builder_landing_page.nil?) %>
-          <%= render 'shared/breadcrumbs' %>
-        <% end %>
+      <% if session[:breadcrumbs].any? || session[:heading].present? %>
+        <%= render 'shared/breadcrumbs' %>
       <% end %>
       <%= yield %>
     </main>

--- a/app/views/maps/diffusion_map.html.erb
+++ b/app/views/maps/diffusion_map.html.erb
@@ -1,4 +1,4 @@
-<section class="grid-container margin-top-3" id="map-of-diffusion">
+<section class="grid-container margin-top-10" id="map-of-diffusion">
   <% if ENV['GOOGLE_API_KEY'].present? %>
     <% provide :head_tags do %>
       <%= javascript_tag 'data-turbolinks-track': 'reload' do %>

--- a/app/views/page/show.html.erb
+++ b/app/views/page/show.html.erb
@@ -8,20 +8,7 @@
 
 <% page_narrow_classes = 'desktop:grid-col-8 margin-x-auto' if @page.narrow? %>
 
-<div id="page-builder-page">
-  <%# due to the matrix applied to the gradient banner (per design), the padding directions needed to be applied inversely, so padding-top is actually padding-bottom and vice versa %>
-  <div id="page-<%= @page.id %>"
-       class="grid-col-12 dm-gradient-banner<%= ' display-none' unless @page.is_visible %> margin-bottom-5 page-builder-intro-container text-white<%= @builder_landing_page.nil? || params[:page_slug].nil? ? ' padding-y-10' : ' padding-top-10 padding-bottom-6' %>"
-  >
-    <div class="grid-container page-builder-intro-content">
-      <h1 class="font-sans-2xl margin-top-0 margin-bottom-3 usa-prose-h1">
-        <%= @page.title %>
-      </h1>
-      <p class="font-sans-lg usa-prose-intro line-height-36 grid-col-10">
-        <%= @page.description %>
-      </p>
-    </div>
-  </div>
+<div id="page-builder-page" class="margin-top-5">
   <section class="grid-container">
     <div class="dm-page-content">
       <% @page_components.each_with_index do |pc, index| %>

--- a/app/views/practice_partners/index.html.erb
+++ b/app/views/practice_partners/index.html.erb
@@ -1,7 +1,7 @@
-<div>
+<div class="margin-top-8 margin-top-128-desktop">
   <section class="grid-container margin-bottom-3">
     <%= render partial: "shared/messages", locals: {small_text: false} %>
-    <h1 class="font-sans-2xl margin-top-3 margin-bottom-05">Partners</h1>
+    <h1 class="font-sans-2xl margin-bottom-3">Partners</h1>
     <div class="grid-row">
       <p class="font-sans-lg line-height-sans-505 grid-col-10">
         Best innovations are always being developed, vetted, and promoted by offices within the VA.

--- a/app/views/practice_partners/show.html.erb
+++ b/app/views/practice_partners/show.html.erb
@@ -6,7 +6,6 @@
   <section class="margin-bottom-5 margin-top-8 grid-container">
     <div class="grid-row">
       <div>
-        <h1 class="grid-col-12 font-sans-2xl margin-top-0 margin-bottom-2"><%= "#{@practice_partner.name}#{@practice_partner.short_name.present? ? " (#{@practice_partner.short_name.upcase})" : ''}"%></h1>
         <p class="grid-col-12 margin-0 line-height-26 tablet:grid-col-8"><%= @practice_partner.description %></p>
       </div>
     </div>

--- a/app/views/practices/search.html.erb
+++ b/app/views/practices/search.html.erb
@@ -15,7 +15,7 @@
   end
 %>
 <div id="search-page">
-  <section class="grid-container margin-bottom-neg-3 tablet:margin-bottom-5">
+  <section class="grid-container margin-bottom-neg-3 tablet:margin-bottom-5 margin-top-5">
     <%= render partial: "shared/messages", locals: {small_text: false} %>
     <form id="update-search-results-form">
       <div class="usa-search usa-search--big margin-bottom-2 grid-col-12">

--- a/app/views/shared/_breadcrumbs.html.erb
+++ b/app/views/shared/_breadcrumbs.html.erb
@@ -1,38 +1,72 @@
 <%
   action = params[:action]
   controller = params[:controller]
+  original_breadcrumbs = session[:breadcrumbs]
+  heading = session[:heading]
+  description = session[:description]
+  breadcrumbs = original_breadcrumbs.dup
+  # ensures breadcrumb isn't displayed if user is on that page
+  if breadcrumbs.size > 1 && controller != 'practices'
+    last_breadcrumb = breadcrumbs.last
+    last_breadcrumb_path = last_breadcrumb[:path] || last_breadcrumb['path']
+    breadcrumbs.pop if last_breadcrumb_path === request.env['PATH_INFO']
+  # ensures breadcrumb isn't displayed for search page
+  elsif breadcrumbs.size === 1 && (request.env['PATH_INFO'] === '/search' || (controller === 'users' && action === 'show' && breadcrumbs.last[:display] === 'Profile'))
+    breadcrumbs.pop
+  end
 %>
-
-<section class="grid-container<%= ' display-none' if (controller == 'page' && params[:page_slug].nil?) || (controller == 'page' && @builder_landing_page.nil?) %>">
-  <div id="breadcrumbs" class="grid-col-auto usa-breadcrumb breadcrumbs-container" aria-label="Breadcrumbs">
-    <ol class="usa-breadcrumb__list">
-      <% if !(controller === 'home' && action === 'index') && controller != 'page' %>
-        <li class="usa-breadcrumb__list-item">
-          <a href="/" class="usa-breadcrumb__link">Home</a>
-        </li>
-      <% end %>
-      <%
-        breadcrumbs = session[:breadcrumbs]
-      %>
-
-      <% breadcrumbs.each_with_index do |b, i| %>
-        <%
-          last_crumb = breadcrumbs.size - 1 == i
-        %>
-
-          <%# Check if the page is a page-builder page using the controller and action names %>
-          <% if !last_crumb && controller == 'page' && action == 'show' && @builder_landing_page.present? %>
-            <%= render partial: 'shared/link_breadcrumb', locals: {breadcrumb: b} %>
-          <% elsif !last_crumb && b['display'] == 'Edit' %>
-            <%= render partial: 'shared/link_breadcrumb', locals: {breadcrumb: b} %>
-          <% elsif !last_crumb && params[:controller] != 'page' %>
-            <%= render partial: 'shared/link_breadcrumb', locals: {breadcrumb: b} %>
-          <% elsif last_crumb && b['display'] == 'Edit' %>
-            <%= render partial: 'shared/text_breadcrumb', locals: {breadcrumb: b} %>
+<section class="<%= "dm-gradient-banner" if heading.present? %>">
+  <div class="grid-container <%= "padding-y-6" if heading.present? %>">
+    <% if breadcrumbs.present? %>
+      <div id="breadcrumbs" class="grid-col-auto usa-breadcrumb breadcrumbs-container <%= heading.present? ? "dm-breadcrumb--gradient-bg padding-top-6 padding-bottom-105" : "padding-y-4" %>" aria-label="Breadcrumbs">
+        <ol class="usa-breadcrumb__list<%= " text-white" if heading.present? %>">
+          <%# TODO: Consolidate this once practice breadcrumbs designs are finalized %>
+          <% if controller === 'practices' && (action === 'show' || breadcrumbs.any? { |b| b[:display] === "Edit"}) %>
+            <li class="usa-breadcrumb__list-item">
+              <a href="/" class="usa-breadcrumb__link">Home</a>
+            </li>
+            <% breadcrumbs.each_with_index do |b, i| %>
+              <% last_crumb = breadcrumbs.size - 1 == i %>
+              <% if !last_crumb %>
+                <%= render partial: 'shared/link_breadcrumb', locals: {breadcrumb: b} %>
+              <% else %>
+                <%= render partial: 'shared/text_breadcrumb', locals: {breadcrumb: b} %>
+              <% end %>
+            <% end %>
+          <% elsif breadcrumbs.size === 1 %>
+            <%
+              current_path = request.env['PATH_INFO']
+              is_same_path = breadcrumbs.first['path'] === current_path
+              breadcrumb_path = is_same_path ? root_path : breadcrumbs.first['path'] || breadcrumbs.first[:path]
+              breadcrumb_display = is_same_path ? 'Home' : breadcrumbs.first['display'] || breadcrumbs.first[:display]
+              breadcrumb_display.upcase if heading.present?
+            %>
+            <li class="usa-breadcrumb__list-item">
+              <i class='fas fa-arrow-left margin-right-05 <%= heading.present? ? 'text-white' : 'text-gray-50' %>'></i>
+              <%= link_to(breadcrumb_display, breadcrumb_path, class: 'usa-breadcrumb__link padding-left-05 font-sans-sm') %>
+            </li>
           <% else %>
-            <%= render partial: 'shared/text_breadcrumb', locals: {breadcrumb: b} unless params[:controller] === 'page' %>
+            <% breadcrumbs.each_with_index do |b, i| %>
+              <%
+                last_crumb = breadcrumbs.size - 1 == i
+              %>
+              <%= render partial: 'shared/link_breadcrumb', locals: {breadcrumb: b} %>
+            <% end %>
           <% end %>
+        </ol>
+      </div>
+    <% end %>
+    <% if heading.present? %>
+      <div class="dm-breadcrumb-heading">
+        <h1 class="usa-prose-h1 margin-top-0 margin-bottom-3 text-white">
+          <%= heading %>
+        </h1>
+        <% if description.present? %>
+          <p class="font-sans-lg usa-prose-intro line-height-36 grid-col-10 text-white">
+            <%= description %>
+          </p>
         <% end %>
-    </ol>
+      </div>
+    <% end %>
   </div>
 </section>

--- a/app/views/shared/_text_breadcrumb.html.erb
+++ b/app/views/shared/_text_breadcrumb.html.erb
@@ -1,3 +1,5 @@
 <li class="usa-breadcrumb__list-item usa-current" aria-current="page">
-  <span><%= breadcrumb['display'] || breadcrumb[:display] %></span>
+  <span>
+    <%= breadcrumb['display'] || breadcrumb[:display] %>
+  </span>
 </li>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,4 +1,4 @@
-<div class="margin-top-0 grid-container">
+<div class="margin-top-8 grid-container">
   <section class="usa-section padding-top-0 padding-bottom-0">
     <div class="<%= @created_practices.empty? && @favorite_practices.empty?  ? 'profile-min-height' : '' %>">
       <div class="grid-row margin-bottom-2px">

--- a/app/views/va_facilities/index.html.erb
+++ b/app/views/va_facilities/index.html.erb
@@ -6,11 +6,11 @@
   <%= javascript_include_tag 'va_facilities/facilities_utilities', 'data-turbolinks-track': 'reload' %>
 <% end %>
 
-<section class="usa-section padding-y-0 grid-col-12" id="dm-va-facilities-index" data-reload="true">
+<section class="usa-section margin-top-8 margin-top-128-desktop padding-y-0 grid-col-12" id="dm-va-facilities-index" data-reload="true">
   <div class="grid-container position-relative grid-col-12">
     <div class="grid-row grid-gap">
       <div class="grid-col-12">
-        <h1 class="font-sans-2xl margin-top-5 margin-bottom-3">
+        <h1 class="font-sans-2xl margin-top-0 margin-bottom-3">
           Facilities
         </h1>
         <span>Looking for a full list of VISNs? <a class="usa-link" href="<%= visns_path %>">Click here</a></span>

--- a/app/views/va_facilities/show.html.erb
+++ b/app/views/va_facilities/show.html.erb
@@ -14,7 +14,7 @@
 <section class="usa-section padding-y-0 grid-col-12" id="dm-va-facilities-show">
   <input type="hidden" id="facility_station_number" value="<%= @va_facility.station_number %>"/>
   <div class="grid-container position-relative grid-col-12">
-    <h1 class="margin-top-5 margin-bottom-3">
+    <h1 class="margin-top-0 margin-bottom-3">
       <%= @va_facility.official_station_name %>
     </h1>
     <div class="grid-row grid-gap-3">

--- a/app/views/visns/index.html.erb
+++ b/app/views/visns/index.html.erb
@@ -1,10 +1,10 @@
 <% provide :body_classes, 'bg-gray-2' %>
 <% provide :footer_classes, 'bg-gray-2' %>
 
-<div id="visns-index" class="grid-container">
+<div id="visns-index" class="grid-container margin-top-8 margin-top-128-desktop">
   <%= render partial: "shared/messages", locals: { small_text: false } %>
   <section id="visns-map" class="margin-bottom-3">
-    <h1 class="font-sans-2xl margin-top-8 margin-bottom-3 line-height-46px">VISNs</h1>
+    <h1 class="font-sans-2xl margin-top-0 margin-bottom-3 line-height-46px">VISNs</h1>
     <div class="margin-bottom-2">
       <span class="usa-prose-body">Veterans Integrated Services Networks are regional systems of care within the Veterans Health Administration.</span>
     </div>

--- a/app/views/visns/show.html.erb
+++ b/app/views/visns/show.html.erb
@@ -12,7 +12,7 @@
 
 <div id="visns-show" class="grid-container" data-reload="true">
   <%= render partial: "shared/messages", locals: { small_text: false } %>
-  <section id="visn-introduction" class="margin-bottom-3 margin-top-8">
+  <section id="visn-introduction" class="margin-bottom-3">
     <div class="display-inline-block">
     <h1 class="font-sans-2xl line-height-46px margin-top-0 display-inline-block">VISN
       <span class="text-top display-inline-block usa-prose-body"> <%= render partial: "visns/visns_tooltip", locals: { data_position: 'top'} %></span>

--- a/spec/features/pages/show_page_spec.rb
+++ b/spec/features/pages/show_page_spec.rb
@@ -53,7 +53,7 @@ describe 'Page Builder - Show', type: :feature do
     @page.update_attributes(is_visible: false)
     visit '/programming/ruby-rocks'
 
-    expect(page).to have_css('.dm-gradient-banner', visible: false)
+    expect(page).to_not have_css('.dm-gradient-banner')
     expect(page).to_not have_content('ruby')
     expect(page).to_not have_content('what a gem')
   end

--- a/spec/features/shared/breadcrumbs_spec.rb
+++ b/spec/features/shared/breadcrumbs_spec.rb
@@ -3,14 +3,38 @@ require 'rails_helper'
 describe 'Breadcrumbs', type: :feature do
   before do
     @pp = PracticePartner.create!(name: 'Diffusion of Excellence', short_name: '', description: 'The Diffusion of Excellence Initiative helps to identify and disseminate clinical and administrative best innovations through a learning environment that empowers its top performers to apply their innovative ideas throughout the system — further establishing VA as a leader in health care while promoting positive outcomes for Veterans.', icon: 'fas fa-heart', color: '#E4A002')
+    @img_path_1 = "#{Rails.root}/spec/assets/acceptable_img.jpg"
+    ENV['GOOGLE_API_KEY'] = ENV['GOOGLE_TEST_API_KEY']
     @user = User.create!(email: 'spongebob.squarepants@va.gov', password: 'Password123', password_confirmation: 'Password123', skip_va_validation: true, confirmed_at: Time.now, accepted_terms: true)
     @user2 = User.create!(email: 'patrick.star@bikinibottom.net', password: 'Password123', password_confirmation: 'Password123', skip_va_validation: true, confirmed_at: Time.now, accepted_terms: true)
     @admin = User.create!(email: 'sandy.cheeks@bikinibottom.net', password: 'Password123', password_confirmation: 'Password123', skip_va_validation: true, confirmed_at: Time.now, accepted_terms: true)
     @approver = User.create!(email: 'squidward.tentacles@bikinibottom.net', password: 'Password123', password_confirmation: 'Password123', skip_va_validation: true, confirmed_at: Time.now, accepted_terms: true)
     @admin.add_role(User::USER_ROLES[1].to_sym)
     @approver.add_role(User::USER_ROLES[0].to_sym)
-    @user_practice = Practice.create!(name: 'The Best Innovation Ever!', user: @user, initiating_facility: 'Test facility name', initiating_facility_type: 'other', tagline: 'Test tagline')
-    @user_practice2 = Practice.create!(name: 'Another Best Innovation', user: @user, initiating_facility: 'vc_0508V', tagline: 'Test tagline 2')
+    @user_practice = Practice.create!(name: 'The Best Innovation Ever', user: @user, initiating_facility: 'Test facility name', initiating_facility_type: 'other', tagline: 'Test tagline', is_public: true, published: true, approved: true, enabled: true, summary: 'test innovation summary')
+    @user_practice2 = Practice.create!(name: 'Another Best Innovation', user: @user, initiating_facility: 'vc_0508V', tagline: 'Test tagline 2', highlight_attachment: File.new(@img_path_1), highlight: true, highlight_body: 'highlighted innovation', is_public: true, published: true, approved: true, enabled: true)
+    visn_1 = Visn.create!(name: 'VISN 1', number: 2)
+    fac_1 = VaFacility.create!(
+      visn: visn_1,
+      station_number: "421",
+      official_station_name: "A Test name",
+      common_name: "A first facility Test Common Name",
+      fy17_parent_station_complexity_level: "1a-High Complexity",
+      latitude: "44.03409934",
+      longitude: "-70.70545322",
+      rurality: "U",
+      street_address: "1 Test Ave",
+      street_address_city: "Las Vegas",
+      street_address_state: "NV",
+      station_phone_number: '207-623-8411',
+      classification: 'Primary Care CBOC',
+      street_address_zip_code: "11111",
+      slug: "a-first-facility-test-common-name",
+      station_number_suffix_reservation_effective_date: "05/23/1995",
+      mailing_address_city: "Las Vegas"
+    )
+    dh_1 = DiffusionHistory.create!(practice: @user_practice, va_facility: fac_1)
+    DiffusionHistoryStatus.create!(diffusion_history: dh_1, status: 'Completed')
     login_as(@user, :scope => :user, :run_callbacks => false)
     PracticePartnerPractice.create!(practice_partner: @pp, practice: @user_practice)
     @page_group = PageGroup.create!(name: 'programming', description: 'Pages about programming go in this group.')
@@ -18,48 +42,201 @@ describe 'Breadcrumbs', type: :feature do
     @page = Page.create!(title: 'Test', description: 'This is a test page', slug: 'home', page_group: @page_group, published: Time.now)
     @page2 = Page.create!(title: 'Test', description: 'This is a test page', slug: 'test-page', page_group: @page_group2, published: Time.now)
     @page3 = Page.create!(title: 'Test', description: 'This is a test page', slug: 'test-page', page_group: @page_group, published: Time.now)
+    visit '/'
   end
 
-  describe 'Practice partners flow' do
-    it 'should show Practice partners' do
-      @user_practice.update(published: true, approved: true)
-      visit '/partners'
-      expect(page).to be_accessible.according_to :wcag2a, :section508
+  after do
+    ENV['GOOGLE_API_KEY'] = nil
+  end
 
+  describe 'Pages that should not have breadcrumbs' do
+    it 'should not display breadcrumbs for the search page from the navbar button' do
+      find('#dm-navbar-search-button').click
+      expect(page).to_not have_css('#breadcrumbs')
+    end
+
+    it 'should not display breadcrumbs for the search page when clicking "Browse all innovations"' do
+      click_link('Browse all innovations')
+      expect(page).to_not have_css('#breadcrumbs')
+    end
+
+    it 'should not display breadcrumbs for the search page when clicking the homepage search' do
+      find('#dm-homepage-search-button').click
+      expect(page).to_not have_css('#breadcrumbs')
+    end
+
+    it 'should not display breadcrumbs for the about page' do
+      find_all("a[href='/about']").first.click
+      expect(page).to_not have_css('#breadcrumbs')
+    end
+
+    it 'should not display breadcrumbs for the partners index' do
+      find_all("a[href='/partners']").first.click
+      expect(page).to_not have_css('#breadcrumbs')
+    end
+
+    it 'should not display breadcrumbs for the diffusion map' do
+      click_button('Browse by locations')
+      find("a[href='/diffusion-map']").click
+      expect(page).to have_css(".diffusion_map-main", visible: true)
+      expect(page).to_not have_css('#breadcrumbs')
+    end
+
+    it 'should not display breadcrumbs for the nominate an innovation page' do
+      find("a[href='/nominate-an-innovation']").click
+      expect(page).to_not have_css('#breadcrumbs')
+    end
+
+    it 'should not display breadcrumbs for the visns index' do
+      click_button('Browse by locations')
+      find("a[href='/visns']").click
+      expect(page).to_not have_css('#breadcrumbs')
+    end
+
+    it 'should not display breadcrumbs for the facilities index' do
+      click_button('Browse by locations')
+      find("a[href='/facilities']").click
+      expect(page).to_not have_css('#breadcrumbs')
+    end
+  end
+
+  describe 'Featured innovation' do
+    it 'should show breadcrumbs to the home page when a user clicks a highlighted innovation' do
+      click_link('View innovation')
+      expect(page).to have_css("#pr-view-introduction", visible: true)
       within(:css, '#breadcrumbs') do
         expect(page).to have_content('Home')
-        expect(page).to have_content('Partners')
-      end
-      click_on('Diffusion of Excellence')
-      sleep 0.1
-      expect(page).to be_accessible.according_to :wcag2a, :section508
-      within(:css, '#breadcrumbs') do
-        expect(page).to have_content('Home')
-        expect(page).to have_content('Partners')
-        expect(page).to have_content('Diffusion of Excellence')
-      end
-
-      find('.dm-practice-link').click
-      expect(page).to have_current_path(practice_path(@user_practice))
-
-      within(:css, '#breadcrumbs') do
-        expect(page).to have_content('Home')
-        expect(page).to have_content('Partners')
-        expect(page).to have_content('Diffusion of Excellence')
-        expect(page).to have_content('The Best Innovation Ever!')
+        expect(page).to have_content('Another Best Innovation')
+        expect(page).to have_link(href: '/')
+        expect(page).to_not have_link(href: '/innovations/another-best-innovation')
       end
     end
   end
 
-  describe 'Practices flow' do
+  describe 'Innovation search' do
+    it 'should show proper breadcrumbs when a user searches for a practice and then visits that practice\'s page' do
+      @user_practice.update(published: true, approved: true)
+      fill_in('dm-navbar-search-field', with: 'the best')
+      find('#dm-navbar-search-button').click
+      expect(page).to have_content('The Best')
+      expect(page).to be_accessible.according_to :wcag2a, :section508
+      click_on('Go to The Best Innovation Ever')
+      expect(page).to have_css("#pr-view-introduction", visible: true)
+      within(:css, '#breadcrumbs') do
+        expect(page).to have_content('Home')
+        expect(page).to have_content('Search')
+        expect(page).to have_content('The Best Innovation Ever')
+        expect(page).to have_link(href: '/')
+        expect(page).to_not have_link(href: '/innovations/the-best-innovation-ever')
+      end
+
+      find('a[href="/search?query=the%20best"]').click
+      expect(page).to have_current_path('/search?query=the%20best')
+      expect(page).to_not have_css('#breadcrumbs')
+    end
+  end
+
+  describe 'Innovations partners' do
+    it 'should show display breadcrumbs only for the show pages' do
+      @user_practice.update(published: true, approved: true)
+      find("a[href='/partners']").click
+      expect(page).to be_accessible.according_to :wcag2a, :section508
+      click_on('Diffusion of Excellence')
+      expect(page).to have_css("#breadcrumbs", visible: true)
+      expect(page).to have_css('.dm-gradient-banner')
+      within(:css, '#breadcrumbs') do
+        expect(page).to have_css('.fa-arrow-left')
+        expect(page).to have_content('Partners')
+        expect(page).to have_link(href: '/partners')
+      end
+      within(:css, '.dm-breadcrumb-heading') do
+        expect(page).to have_content('Diffusion of Excellence')
+      end
+      find('.dm-practice-link').click
+      expect(page).to have_current_path(practice_path(@user_practice))
+      expect(page).to have_css("#pr-view-introduction", visible: true)
+      within(:css, '#breadcrumbs') do
+        expect(page).to have_content('Partners')
+        expect(page).to have_content('Diffusion of Excellence')
+        expect(page).to have_link(href: '/partners')
+        expect(page).to have_link(href: '/partners/diffusion-of-excellence')
+      end
+    end
+  end
+
+  describe 'Visns' do
+    it 'should show breadcrumbs for visns show page' do
+      click_button('Browse by locations')
+      find('a[href="/visns"]').click
+      find('.visn-card-link').click
+      expect(page).to have_css("#breadcrumbs", visible: true)
+      within(:css, '#breadcrumbs') do
+        expect(page).to have_css('.fa-arrow-left')
+        expect(page).to have_content('VISN index')
+        expect(page).to have_link(href: '/visns')
+      end
+      find('.dm-practice-link').click
+      expect(page).to have_current_path(practice_path(@user_practice))
+      expect(page).to have_css("#pr-view-introduction", visible: true)
+      within(:css, '#breadcrumbs') do
+        expect(page).to have_content('VISN index')
+        expect(page).to have_content('2')
+        expect(page).to have_link(href: '/visns')
+        expect(page).to have_link(href: '/visns/2')
+      end
+      find('a[href="/visns/2"]').click
+      fill_in('visn-search-field', with: 'best')
+      find('#visn-search-button').click
+      find('.dm-practice-link').click
+      expect(page).to have_css("#pr-view-introduction", visible: true)
+      expect(page).to have_current_path(practice_path(@user_practice))
+      within(:css, '#breadcrumbs') do
+        expect(page).to have_content('Home')
+        expect(page).to have_content('VISN index')
+        expect(page).to have_content('2')
+        expect(page).to have_content('The Best Innovation Ever')
+        expect(page).to have_link(href: '/')
+        expect(page).to have_link(href: '/visns')
+        expect(page).to have_link(href: '/visns/2?query=best')
+        expect(page).to_not have_link(href: '/innovations/the-best-innovation-ever')
+      end
+    end
+  end
+
+  describe 'Facilities' do
+    it 'should show breadcrumbs for facilities show page' do
+      click_button('Browse by locations')
+      find('a[href="/facilities"]').click
+      find('a[href="/facilities/a-first-facility-test-common-name"]').click
+      expect(page).to have_css("#dm-va-facilities-show", visible: true)
+      within(:css, '#breadcrumbs') do
+        expect(page).to have_css('.fa-arrow-left')
+        expect(page).to have_content('Facilities index')
+        expect(page).to have_link(href: '/facilities')
+      end
+      find('a[href="/innovations/the-best-innovation-ever"]').click
+      expect(page).to have_css("#pr-view-introduction", visible: true)
+      within(:css, '#breadcrumbs') do
+        expect(page).to have_content('Home')
+        expect(page).to have_content('Facilities')
+        expect(page).to have_content('A first facility Test Common Name')
+        expect(page).to have_content('The Best Innovation Ever')
+        expect(page).to have_link(href: '/')
+        expect(page).to have_link(href: '/facilities')
+        expect(page).to have_link(href: '/facilities/a-first-facility-test-common-name')
+        expect(page).to_not have_link(href: '/innovations/the-best-innovation-ever')
+      end
+    end
+  end
+
+  describe 'Innovations' do
     it 'should show proper breadcrumbs when a user visits a practice\'s "next steps"' do
       @user_practice.update(published: true, approved: true)
       visit practice_path(@user_practice)
-      expect(page).to be_accessible.according_to :wcag2a, :section508
 
       within(:css, '#breadcrumbs') do
         expect(page).to have_content('Home')
-        expect(page).to have_content('The Best Innovation Ever!')
+        expect(page).to have_content('The Best Innovation Ever')
       end
     end
 
@@ -68,7 +245,7 @@ describe 'Breadcrumbs', type: :feature do
 
       within(:css, '#breadcrumbs') do
         expect(page).to have_content('Home')
-        expect(page).to have_content('The Best Innovation Ever!')
+        expect(page).to have_content('The Best Innovation Ever')
       end
 
       # Browse to a different practice's show page
@@ -76,7 +253,7 @@ describe 'Breadcrumbs', type: :feature do
 
       within(:css, '#breadcrumbs') do
         expect(page).to have_content('Home')
-        expect(page).to_not have_content('The Best Innovation Ever!')
+        expect(page).to_not have_content('The Best Innovation Ever')
         expect(page).to have_content('Another Best Innovation')
       end
     end
@@ -87,7 +264,7 @@ describe 'Breadcrumbs', type: :feature do
 
       within(:css, '#breadcrumbs') do
         expect(page).to have_content('Home')
-        expect(page).to have_content('The Best Innovation Ever!')
+        expect(page).to have_content('The Best Innovation Ever')
         expect(page).to have_content('Edit')
       end
       expect(page).to have_selector('#instructions', visible: true)
@@ -95,7 +272,7 @@ describe 'Breadcrumbs', type: :feature do
 
       within(:css, '#breadcrumbs') do
         expect(page).to have_content('Home')
-        expect(page).to have_content('The Best Innovation Ever!')
+        expect(page).to have_content('The Best Innovation Ever')
         expect(page).to have_content('Edit')
       end
       expect(page).to have_selector('#dm-practice-nav', visible: true)
@@ -103,72 +280,10 @@ describe 'Breadcrumbs', type: :feature do
 
       within(:css, '#breadcrumbs') do
         expect(page).to have_content('Home')
-        expect(page).to have_content('The Best Innovation Ever!')
+        expect(page).to have_content('The Best Innovation Ever')
         expect(page).to have_content('Edit')
         expect(page).to have_content('Metrics')
       end
-    end
-  end
-
-  describe 'Practice Search flow' do
-    it 'should show proper breadcrumbs when a user searches for a practice and then visits that practice\'s page' do
-      @user_practice.update(published: true, approved: true)
-      visit '/'
-      fill_in('dm-navbar-search-field', with: 'the best')
-      find('#dm-navbar-search-button').click
-      expect(page).to have_content('The Best')
-      expect(page).to be_accessible.according_to :wcag2a, :section508
-      within(:css, '#breadcrumbs') do
-        expect(page).to have_content('Home')
-        expect(page).to have_content('Search')
-      end
-      click_on('Go to The Best Innovation Ever!')
-      # TODO: why is this timing out?
-      # expect(page).to be_accessible.according_to :wcag2a, :section508
-      within(:css, '#breadcrumbs') do
-        expect(page).to have_content('Home')
-        expect(page).to have_content('Search')
-        expect(page).to have_content('The Best Innovation Ever!')
-      end
-
-      # go back to search page
-      fill_in('dm-navbar-search-field', with: 'the best')
-      find('#dm-navbar-search-button').click
-      expect(page).to have_current_path('/search?query=the%20best')
-
-      within(:css, '#breadcrumbs') do
-        expect(page).to have_content('Home')
-        expect(page).to have_content('Search')
-
-        # go back to homepage
-        click_on('Home')
-      end
-      expect(page).to have_current_path('/')
-    end
-
-    it 'should add a search breadcrumb with no query if the user visits a practice page via the url bar(does not click on the practice\'s card)' do
-      @user_practice.update(published: true, approved: true)
-      visit '/'
-      fill_in('dm-navbar-search-field', with: 'the best')
-      find('#dm-navbar-search-button').click
-
-      expect(page).to have_content('The Best')
-      expect(page).to be_accessible.according_to :wcag2a, :section508
-      within(:css, '#breadcrumbs') do
-        expect(page).to have_content('Home')
-        expect(page).to have_content('Search')
-      end
-
-      # Visit a practice's page from the url bar
-      visit practice_path(@user_practice2)
-
-      within(:css, '#breadcrumbs') do
-        expect(page).to have_content('Home')
-        expect(page).to have_content('Search')
-        # go back to search
-        click_on('Search')
-      end
-      expect(page).to have_current_path('/search')
     end
   end
 

--- a/spec/features/shared/breadcrumbs_spec.rb
+++ b/spec/features/shared/breadcrumbs_spec.rb
@@ -211,14 +211,14 @@ describe 'Breadcrumbs', type: :feature do
       expect(page).to have_css("#dm-va-facilities-show", visible: true)
       within(:css, '#breadcrumbs') do
         expect(page).to have_css('.fa-arrow-left')
-        expect(page).to have_content('Facilities index')
+        expect(page).to have_content('Facility index')
         expect(page).to have_link(href: '/facilities')
       end
       find('a[href="/innovations/the-best-innovation-ever"]').click
       expect(page).to have_css("#pr-view-introduction", visible: true)
       within(:css, '#breadcrumbs') do
         expect(page).to have_content('Home')
-        expect(page).to have_content('Facilities')
+        expect(page).to have_content('Facility index')
         expect(page).to have_content('A first facility Test Common Name')
         expect(page).to have_content('The Best Innovation Ever')
         expect(page).to have_link(href: '/')
@@ -297,11 +297,11 @@ describe 'Breadcrumbs', type: :feature do
 
     it 'Should not show any breadcrumbs for a subpage that has a page group without a landing page or the landing page of a page group' do
       visit '/test/test-page'
-      expect(page).to have_css('#breadcrumbs', visible: false)
+      expect(page).to_not have_css('#breadcrumbs')
       expect(page).to_not have_css('.usa-breadcrumb__link')
 
       visit '/programming/home'
-      expect(page).to have_css('#breadcrumbs', visible: false)
+      expect(page).to_not have_css('#breadcrumbs')
     end
   end
 end

--- a/spec/features/shared/breadcrumbs_spec.rb
+++ b/spec/features/shared/breadcrumbs_spec.rb
@@ -140,7 +140,6 @@ describe 'Breadcrumbs', type: :feature do
     it 'should show display breadcrumbs only for the show pages' do
       @user_practice.update(published: true, approved: true)
       find("a[href='/partners']").click
-      expect(page).to be_accessible.according_to :wcag2a, :section508
       click_on('Diffusion of Excellence')
       expect(page).to have_css("#breadcrumbs", visible: true)
       expect(page).to have_css('.dm-gradient-banner')


### PR DESCRIPTION
### JIRA issue link
[DM-2985](https://agile6.atlassian.net/browse/DM-2985)

## Description - what does this code do?
This PR updates the following:
- styling of the breadcrumbs to match the figma designs
- breadcrumbs have not been updated for the innovation show and edit pages
- page builder pages and all other pages use the same breadcrumb logic

## Testing done - how did you test it/steps on how can another person can test it 
- Check the practice show and edit pages to ensure the breadcrumbs have not changed
- Check the partners index and show pages to ensure the breadcrumbs match the designs
- Check the diffusion map, facility show and index, and VISN show and index pages to ensure the breadcrumbs match the designs
- Check the page builder pages and landing pages to ensure breadcrumbs appear as intended

## Screenshots, Gifs, Videos from application (if applicable)


## Link to mock-ups/mock ups (image file if you have it) (if applicable)
[Figma](https://www.figma.com/file/H2aII1WHRlySNG6r2HlZbY/Sitemap?node-id=1408%3A4059)

## Acceptance criteria
- [ ]

## Definition of done
- [] Unit tests written (if applicable)
- [X] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [X] A link has been provided to the originating JIRA issue
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs