### PR TITLE
DM-3093: Fix styles for gradient banner breadcrumbs

### DIFF
--- a/app/views/shared/_breadcrumbs.html.erb
+++ b/app/views/shared/_breadcrumbs.html.erb
@@ -18,7 +18,7 @@
 <section class="<%= "dm-gradient-banner" if heading.present? %>">
   <div class="grid-container <%= "padding-y-6" if heading.present? %>">
     <% if breadcrumbs.present? %>
-      <div id="breadcrumbs" class="grid-col-auto usa-breadcrumb breadcrumbs-container <%= heading.present? ? "dm-breadcrumb--gradient-bg padding-top-6 padding-bottom-105" : "padding-y-4" %>" aria-label="Breadcrumbs">
+      <div id="breadcrumbs" class="grid-col-auto usa-breadcrumb breadcrumbs-container <%= heading.present? ? "dm-breadcrumb--gradient-bg padding-top-0 padding-bottom-105" : "padding-y-4" %>" aria-label="Breadcrumbs">
         <ol class="usa-breadcrumb__list<%= " text-white" if heading.present? %>">
           <%# TODO: Consolidate this once practice breadcrumbs designs are finalized %>
           <% if controller === 'practices' && (action === 'show' || breadcrumbs.any? { |b| b[:display] === "Edit"}) %>


### PR DESCRIPTION
### JIRA issue link
[DM-3093](https://agile6.atlassian.net/browse/DM-3093)

## Description - what does this code do?
Removes extra padding in gradient banners

## Testing done - how did you test it/steps on how can another person can test it 
Check the individual partners page or a page builder page with breadcrumbs and the title that is visible

## Screenshots, Gifs, Videos from application (if applicable)
**Before**
<img width="1508" alt="Screen Shot 2021-12-21 at 9 52 46 AM" src="https://user-images.githubusercontent.com/20211771/146963631-4a3b29aa-33ca-46d8-9ac6-18700adf7364.png">

**After**
<img width="1508" alt="Screen Shot 2021-12-21 at 9 54 00 AM" src="https://user-images.githubusercontent.com/20211771/146963809-0144a239-43cb-4328-a48d-1772d61d6973.png">

## Link to mock-ups/mock ups (image file if you have it) (if applicable)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Unit tests written (if applicable)
- [ ] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating JIRA issue
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs