### PR TITLE
DM-2994: Add terms and conditions page & update modal

### DIFF
--- a/app/controllers/terms_and_conditions_controller.rb
+++ b/app/controllers/terms_and_conditions_controller.rb
@@ -1,0 +1,5 @@
+class TermsAndConditionsController < ApplicationController
+  def index
+  end
+end
+

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -183,4 +183,8 @@ module ApplicationHelper
       '_blank'
     end
   end
+
+  def get_terms_and_conditions_body_text(current_user)
+    "VA systems are intended to be used by authorized#{current_user.present? ? ' VA network ' : ' '}users for viewing and retrieving information; except as otherwise authorized for official business and limited personal use under VA policy. Information from this system resides on and transmits through computer systems and networks funded by VA. Access or use constitutes understanding and acceptance that there is no reasonable expectation of privacy in the use of Government networks or systems. Access or use of this system constitutes user understanding and acceptance of these terms and constitutes unconditional consent to review and action includes but is not limited to: monitoring; recording; copying; auditing; inspecting."
+  end
 end

--- a/app/helpers/navigation_helper.rb
+++ b/app/helpers/navigation_helper.rb
@@ -325,7 +325,12 @@ module NavigationHelper
 
     # remove breadcrumbs from 'About' page
     if controller == 'about' && action == 'index'
-        empty_breadcrumbs
+      empty_breadcrumbs
+    end
+
+    # remove breadcrumbs from 'Terms and conditions' page
+    if controller == 'terms_and_conditions' && action == 'index'
+      empty_breadcrumbs
     end
 
     # remove breadcrumbs from any custom error page

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -2,7 +2,6 @@
   var forceModal = <%= @force_terms_and_conditions_modal %>;
 <% end %>
 <%= javascript_include_tag '_terms_and_conditions', 'data-turbolinks-track': 'reload' %>
-
 <%= render partial: 'shared/terms_and_conditions_modal' %>
 
 <footer class="<%= yield(:footer_classes) %>">
@@ -29,7 +28,7 @@
         <a href="https://www.va.gov/privacy-policy" target="_blank" class="desktop:display-inline-block desktop:grid-col-auto desktop:padding-0 desktop:border-top-0 border-top-1px border-base desktop:margin-right-8 grid-col-12 padding-y-2 padding-x-2 dm-footer-link">
           Privacy policy
         </a>
-        <a href="#dm-terms-and-conditions-modal" class="desktop:display-inline-block desktop:grid-col-auto desktop:padding-0 desktop:border-top-0 border-top-1px border-base grid-col-12 padding-y-2 padding-x-2 dm-footer-link" aria-controls="dm-terms-and-conditions-modal" data-open-modal>
+        <a href="<%= terms_and_conditions_path %>" class="desktop:display-inline-block desktop:grid-col-auto desktop:padding-0 desktop:border-top-0 border-top-1px border-base grid-col-12 padding-y-2 padding-x-2 dm-footer-link">
           Terms and conditions
         </a>
       </div>

--- a/app/views/shared/_terms_and_conditions_modal.html.erb
+++ b/app/views/shared/_terms_and_conditions_modal.html.erb
@@ -1,17 +1,17 @@
 <div
-  class="usa-modal usa-modal--lg"
+  class="usa-modal"
   id="dm-terms-and-conditions-modal"
   aria-labelledby="dm-terms-and-conditions-modal-heading"
   aria-describedby="dm-terms-and-conditions-modal-description"
   <%= 'data-force-action' if @force_terms_and_conditions_modal%>>
   <div class="usa-modal__content">
     <div class="usa-modal__main">
-      <h2 class="usa-modal__heading" id="dm-terms-and-conditions-modal-heading">
-        <p class="font-sans-2xl margin-bottom-3">Terms and conditions</p>
+      <h3 class="usa-modal__heading usa-prose-h3 margin-bottom-1" id="dm-terms-and-conditions-modal-heading">
+        Terms and conditions
       </h2>
       <div class="usa-prose">
-        <p id="dm-terms-and-conditions-modal-description">
-          VA systems are intended to be used by authorized <%= current_user.present? ? 'VA network' : '' %> users for viewing and retrieving information; except as otherwise authorized for official business and limited personal use under VA policy. Information from this system resides on and transmits through computer systems and networks funded by VA. Access or use constitutes understanding and acceptance that there is no reasonable expectation of privacy in the use of Government networks or systems. Access or use of this system constitutes user understanding and acceptance of these terms and constitutes unconditional consent to review and action includes but is not limited to: monitoring; recording; copying; auditing; inspecting;
+        <p id="dm-terms-and-conditions-modal-description" class="usa-prose-body">
+          <%= get_terms_and_conditions_body_text(current_user) %>
         </p>
       </div>
       <div class="usa-modal__footer">
@@ -19,7 +19,7 @@
           <li class="usa-button-group__item">
             <% if @force_terms_and_conditions_modal %>
               <%= form_tag({action: 'accept_terms', controller: 'users'}, method: :post) do |f| %>
-                <%= submit_tag 'I acknowledge the terms', class: 'usa-button margin-0 padding-2 margin-bottom-4-important' %>
+                <%= submit_tag 'I acknowledge the terms', class: 'usa-button' %>
               <% end %>
             <% else %>
               <button

--- a/app/views/terms_and_conditions/index.html.erb
+++ b/app/views/terms_and_conditions/index.html.erb
@@ -1,0 +1,15 @@
+<div id="dm-terms-and-conditions-page" class="grid-container">
+  <%= render partial: "shared/messages", locals: { small_text: true } %>
+
+  <section class="margin-top-8 margin-bottom-0 margin-top-128-desktop desktop:margin-bottom-8" role="region" aria-label="Terms and conditions">
+    <div class="grid-row grid-col-12 desktop:grid-col-8">
+      <h1 class="usa-prose-h1 margin-top-0 margin-bottom-4">Terms and conditions</h1>
+      <p class="usa-prose-body">
+        <%= get_terms_and_conditions_body_text(current_user) %>
+      </p>
+      <p class="usa-prose-body margin-top-2">
+        By continuing to access this website I agree to these terms.
+      </p>
+    </div>
+  </section>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -120,6 +120,7 @@ Rails.application.routes.draw do
   get '/facilities/:id/update_practices_adopted_at_facility', action: 'update_practices_adopted_at_facility', controller: 'va_facilities'
   get '/about', controller: 'about', action: 'index', as: 'about'
   post '/about', controller: 'about', action: 'email'
+  get '/terms-and-conditions', controller: 'terms_and_conditions', action: 'index'
   match '/404', to: 'errors#page_not_found_404', via: :all
   match '/500', to: 'errors#internal_server_error_500', via: :all
 

--- a/spec/features/shared/footer_spec.rb
+++ b/spec/features/shared/footer_spec.rb
@@ -27,7 +27,7 @@ describe 'Diffusion Marketplace footer', type: :feature, js: true do
         expect(page).to have_link('Nominate an innovation')
         expect(page).to have_link('Open calls')
         expect(page).to have_link('Privacy policy')
-        expect(page).to have_link('Terms')
+        expect(page).to have_link('Terms and conditions')
       end
     end
 

--- a/spec/features/terms_and_conditions_spec.rb
+++ b/spec/features/terms_and_conditions_spec.rb
@@ -17,36 +17,31 @@ describe 'Terms and conditions', type: :feature do
         it 'Should direct the user to the terms and conditions page the first time the user logs into the site' do
             login_as(@user, :scope => :user, :run_callbacks => false)
             visit '/'
-            expect(page).to be_accessible.according_to :wcag2a, :section508
             expect_forced_terms_modal
         end
 
         it 'Should allow the user to view the site\'s content if the user accepts the terms' do
             login_as(@user, :scope => :user, :run_callbacks => false)
             visit '/'
-            expect(page).to be_accessible.according_to :wcag2a, :section508
             expect_forced_terms_modal
             click_button('I acknowledge the terms')
             visit '/partners'
-            expect(page).to be_accessible.according_to :wcag2a, :section508
             expect(page).not_to have_content('VA systems are intended to be used by authorized VA network users')
             expect(page).to have_content('Partners')
             expect(page).to have_content('Best innovations are always being developed, vetted, and promoted by offices within the VA.')
             expect(page).to have_current_path('/partners')
             click_link 'Terms and conditions'
+            expect(current_path).to eq('/terms-and-conditions')
             expect(page).to have_content('VA systems are intended to be used by authorized VA network users')
             expect(page).to have_no_content('I acknowledge the terms')
-            expect(page).to have_content('Continue to access this website and agree to these terms')
-            expect(page).to have_css('.usa-modal__close')
+            expect(page).to have_content('By continuing to access this website I agree to these terms.')
         end
 
         it 'Should not allow the user to traverse the app without accepting the terms and conditions' do
             login_as(@user, :scope => :user, :run_callbacks => false)
             visit '/'
-            expect(page).to be_accessible.according_to :wcag2a, :section508
             expect_forced_terms_modal
             visit '/partners'
-            expect(page).to be_accessible.according_to :wcag2a, :section508
             expect_forced_terms_modal
             expect(page).to have_current_path('/partners')
         end
@@ -66,21 +61,20 @@ describe 'Terms and conditions', type: :feature do
     context 'not logged in user' do
         it 'Should not direct the user to the terms and conditions page' do
             visit '/partners'
-            expect(page).to be_accessible.according_to :wcag2a, :section508
             expect(page).to have_content('Partners')
             expect(page).to have_content('Best innovations are always being developed, vetted, and promoted by offices within the VA.')
             expect(page).not_to have_content('VA systems are intended to be used by authorized VA network users')
         end
 
-        it 'Should display the terms and conditions modal' do
+        it 'Should display the terms and conditions page' do
             visit '/partners'
-            expect(page).to be_accessible.according_to :wcag2a, :section508
             click_link 'Terms and conditions'
+            expect(page).to be_accessible.according_to :wcag2a, :section508
             expect(page).to have_content('Terms and conditions')
+            expect(current_path).to eq('/terms-and-conditions')
             expect(page).to have_content('VA systems are intended to be used by authorized users')
+            expect(page).to have_content('By continuing to access this website I agree to these terms.')
             expect(page).to have_no_content('I acknowledge the terms')
-            expect(page).to have_content('Continue to access this website and agree to these terms')
-            expect(page).to have_css('.usa-modal__close')
         end
     end
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -210,4 +210,20 @@ RSpec.describe ApplicationHelper, type: :helper do
       end
     end
   end
+
+  describe "#get_terms_and_conditions_body_text" do
+    context "when given no current user" do
+      it "returns the terms and conditions text without `VA network` in it" do
+        mock_current_user = nil
+        expect(helper.get_terms_and_conditions_body_text(mock_current_user)).to eq("VA systems are intended to be used by authorized users for viewing and retrieving information; except as otherwise authorized for official business and limited personal use under VA policy. Information from this system resides on and transmits through computer systems and networks funded by VA. Access or use constitutes understanding and acceptance that there is no reasonable expectation of privacy in the use of Government networks or systems. Access or use of this system constitutes user understanding and acceptance of these terms and constitutes unconditional consent to review and action includes but is not limited to: monitoring; recording; copying; auditing; inspecting.")
+      end
+    end
+
+    context "when given a current user" do
+      it "returns the terms and conditions text with `VA network` in it" do
+        mock_current_user = {id: 1}
+        expect(helper.get_terms_and_conditions_body_text(mock_current_user)).to eq("VA systems are intended to be used by authorized VA network users for viewing and retrieving information; except as otherwise authorized for official business and limited personal use under VA policy. Information from this system resides on and transmits through computer systems and networks funded by VA. Access or use constitutes understanding and acceptance that there is no reasonable expectation of privacy in the use of Government networks or systems. Access or use of this system constitutes user understanding and acceptance of these terms and constitutes unconditional consent to review and action includes but is not limited to: monitoring; recording; copying; auditing; inspecting.")
+      end
+    end
+  end
 end


### PR DESCRIPTION
### JIRA issue link
[DM-2994](https://agile6.atlassian.net/browse/DM-2994)

## Description - what does this code do?
This PR does the following:
- updates the terms and conditions modal to use the updated forced action modal style
- adds a terms and conditions page

## Testing done - how did you test it/steps on how can another person can test it 
**User that did not accept terms**
1. Log in as a user that did not accept the terms and conditions.
2. Go to various pages and you should see the terms and conditions modal on every page
3. Agree to the terms and conditions
4. Navigating to different pages should not show the modal
5. Clicking on the terms and conditions link in the footer navigates to the terms and conditions page

**Public "user"**
1. Do not be signed in as any user
2. Navigate to any page on the site
3. You should not see a terms and conditions modal
4. Clicking on the terms and conditions link in the footer navigates to the terms and conditions page

## Screenshots, Gifs, Videos from application (if applicable)


## Link to mock-ups/mock ups (image file if you have it) (if applicable)


## Acceptance criteria
- [X] T&C styling and text fixes
- [X] ADD T&C page (put link in footer)
- [X] Update T&C Modal for first time internal users

## Definition of done
- [X] Unit tests written (if applicable)
- [X] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [X] A link has been provided to the originating JIRA issue
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs