### PR TITLE
Dm 2998

### DIFF
--- a/app/assets/stylesheets/dm/components/_diffusion_history.scss
+++ b/app/assets/stylesheets/dm/components/_diffusion_history.scss
@@ -82,6 +82,10 @@
       max-height: 500px;
       overflow-y: auto;
       border: 1px solid color($theme-color-base-ink);
+
+      .grid-col-4 {
+        @include u-padding-right('05');
+      }
     }
 
     .fa-question-circle {

--- a/app/assets/stylesheets/dm/pages/_search.scss
+++ b/app/assets/stylesheets/dm/pages/_search.scss
@@ -102,13 +102,12 @@
   background-color: color($theme-color-secondary-light) !important;
 
   @media screen and (min-width: 1024px) {
-    height: 55vh;
+    position: unset;
     border: 2px solid color($theme-color-base-lightest) !important;
     top: unset;
     right: unset;
     left: unset;
     bottom: unset;
-    position: absolute;
     background-color: color($theme-color-dm-white) !important;
   }
 
@@ -120,6 +119,14 @@
 
   .fa-times {
     display: block !important;
+  }
+
+  .search-category-filters, .search-originating-facility-filter, .search-adopting-facility-filter {
+    @include u-margin-bottom(1);
+
+    @media screen and (min-width: 1024px) {
+      @include u-margin-bottom(0);
+    }
   }
 }
 

--- a/app/assets/stylesheets/dm/pages/_search.scss
+++ b/app/assets/stylesheets/dm/pages/_search.scss
@@ -179,6 +179,12 @@
       }
     }
   }
+
+  .usa-checkbox__label {
+    @media screen and (max-width: 1023px) {
+      @include u-margin-top(0, !important);
+    }
+  }
 }
 
 .mobile-modal-container {

--- a/app/assets/stylesheets/dm/pages/_search.scss
+++ b/app/assets/stylesheets/dm/pages/_search.scss
@@ -165,6 +165,9 @@
 }
 
 .category-container {
+  .desktop\:grid-col-4 {
+    @include u-padding-right('05');
+  }
   div:last-child {
     .usa-checkbox {
       &:last-child {

--- a/app/assets/stylesheets/dm/pages/_search.scss
+++ b/app/assets/stylesheets/dm/pages/_search.scss
@@ -114,7 +114,7 @@
   fieldset {
     border: none !important;
     margin: 0 !important;
-    width: 100% !important
+    width: 100% !important;
   }
 
   .fa-times {

--- a/app/views/practices/search_partials/_category_checkbox.html.erb
+++ b/app/views/practices/search_partials/_category_checkbox.html.erb
@@ -12,5 +12,5 @@
          name="<%= category_name %>"
          value="<%= category_name %>"
   >
-  <label class="usa-checkbox__label margin-bottom-2 cat-<%= category_id %>-label" for="cat-<%= category_id %>-input" title="<%= category_name %>"><span><%= category_name.truncate(20) %></span></label>
+  <label class="usa-checkbox__label margin-bottom-2 cat-<%= category_id %>-label" for="cat-<%= category_id %>-input" title="<%= category_name %>"><span><%= category_name %></span></label>
 </div>

--- a/app/views/practices/search_partials/_search_filters.html.erb
+++ b/app/views/practices/search_partials/_search_filters.html.erb
@@ -1,7 +1,7 @@
 <div class="grid-row padding-x-3 padding-bottom-0 desktop:padding-x-0">
   <fieldset class="padding-0">
     <legend class="usa-sr-only">Category Filter</legend>
-    <div class="bg-gray-5 desktop:padding-bottom-2px">
+    <div class="bg-gray-5 desktop:padding-bottom-2px search-category-filters">
       <h2 class="usa-accordion__heading">
         <button class="usa-accordion__button mobile-category-accordion desktop:display-none"
                 aria-expanded="false"
@@ -39,7 +39,7 @@
 
   <fieldset class="padding-0">
     <legend class="usa-sr-only">Originating Facility Filter</legend>
-    <div class="bg-gray-5 margin-bottom-1 desktop:margin-bottom-0 desktop:padding-bottom-2px">
+    <div class="bg-gray-5 desktop:padding-bottom-2px search-originating-facility-filter">
       <h2 class="usa-accordion__heading">
         <button class="usa-accordion__button mobile-origin-accordion desktop:display-none"
                 aria-expanded="false"
@@ -57,7 +57,7 @@
 
   <fieldset class="padding-0">
     <legend class="usa-sr-only">Adopting Facility Filter</legend>
-    <div class="bg-gray-5 margin-bottom-1 desktop:margin-bottom-0 desktop:padding-bottom-2px">
+    <div class="bg-gray-5 desktop:padding-bottom-2px search-adopting-facility-filter">
       <h2 class="usa-accordion__heading">
         <button class="usa-accordion__button mobile-adopting-accordion desktop:display-none"
                 aria-expanded="false"

--- a/spec/features/admin/admin_categories_spec.rb
+++ b/spec/features/admin/admin_categories_spec.rb
@@ -60,7 +60,7 @@ describe 'Admin Dashboard Categories Tab', type: :feature do
       expect(cache_keys).not_to include("categories")
       add_categories_to_cache
       find('.search-filters-accordion-button').click
-      expect(page).to have_content('Completely update...')
+      expect(page).to have_content('Completely updated category')
     end
 
     it 'Should be reset if a new category is created through the admin panel' do


### PR DESCRIPTION
### JIRA issue link
https://agile6.atlassian.net/browse/DM-2998

## Description - what does this code do?
Removes the hover effect for the search filters accordion and instead pushes the content down the page.

## Testing done - how did you test it/steps on how can another person can test it 
1. Visit `/search`, open up the filters accordion, and make sure the sort select and the results are now below the accordion as opposed to under it.
2. Make sure the category names are no longer truncated.

## Screenshots, Gifs, Videos from application (if applicable)
![](https://media.giphy.com/media/yfbIqPAOyFxGEWQFpj/giphy.gif)

## Link to mock-ups/mock ups (image file if you have it) (if applicable)


## Acceptance criteria
- Accordion push other elements down
- Do this on Search page 
- Make text for categories go onto next line instead of cutting off (See Strategic->DEI)
- Practices at bottom

## Definition of done
- [ ] Unit tests written (if applicable)
- [ ] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [X] A link has been provided to the originating JIRA issue
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs