### PR TITLE
DM-3090: Paginate partners page innovation cards

### DIFF
--- a/app/assets/stylesheets/dm/pages/_practice_partners.scss
+++ b/app/assets/stylesheets/dm/pages/_practice_partners.scss
@@ -1,7 +1,3 @@
-.partner-page-min-height {
-  min-height: 700px;
-}
-
 .practice-partner-list .grid-container .grid-row:last-child {
   div {
     margin-bottom: 0;

--- a/app/controllers/practice_partners_controller.rb
+++ b/app/controllers/practice_partners_controller.rb
@@ -11,6 +11,16 @@ class PracticePartnersController < ApplicationController
   # GET /practice_partners/1.json
   def show
     @facilities_data = VaFacility.cached_va_facilities.order_by_station_name
+    @partner_practices = helpers.is_user_a_guest? ? @practice_partner.practices.published_enabled_approved.public_facing.sort_by_retired.sort_a_to_z : @practice_partner.practices.published_enabled_approved.sort_by_retired.sort_a_to_z
+    @pagy_partner_practices, @paginated_partner_practices = pagy_array(
+      @partner_practices,
+      items: 12,
+      link_extra: "data-remote='true' class='paginated-partner-practices-page-#{params[:page].present? ? params[:page].to_i + 1 : 2}-link dm-button--outline-secondary margin-top-105 width-15'"
+    )
+    respond_to do |format|
+      format.html
+      format.js
+    end
   end
 
   private

--- a/app/controllers/practice_partners_controller.rb
+++ b/app/controllers/practice_partners_controller.rb
@@ -11,7 +11,7 @@ class PracticePartnersController < ApplicationController
   # GET /practice_partners/1.json
   def show
     @facilities_data = VaFacility.cached_va_facilities.order_by_station_name
-    @partner_practices = helpers.is_user_a_guest? ? @practice_partner.practices.published_enabled_approved.public_facing.sort_by_retired.sort_a_to_z : @practice_partner.practices.published_enabled_approved.sort_by_retired.sort_a_to_z
+    @partner_practices = helpers.is_user_a_guest? ? @practice_partner.practices.searchable_public_practices : @practice_partner.practices.searchable_practices
     @pagy_partner_practices, @paginated_partner_practices = pagy_array(
       @partner_practices,
       items: 12,

--- a/app/views/page/_practice_list_container.html.erb
+++ b/app/views/page/_practice_list_container.html.erb
@@ -1,5 +1,0 @@
-<% if practices.any? %>
-  <% practices.each do |practice| %>
-    <%= render partial: 'shared/practice_card', locals: { practice: practice} %>
-  <% end %>
-<% end %>

--- a/app/views/page/show.html.erb
+++ b/app/views/page/show.html.erb
@@ -108,7 +108,9 @@
           %>
           <% if pplc[:practices].any? %>
             <div class="margin-bottom-2<%= ' margin-bottom-0' if last_component === index %>">
-              <%= render partial: 'shared/practice_cards_row', locals: { practices: pplc[:practices], classes: "dm-practice-card-list dm-paginated-#{component_index}-practices"} %>
+              <div class="dm-practice-card-list dm-paginated-<%= component_index %>-practices">
+                <%= render partial: 'shared/practice_cards_row', locals: { practices: pplc[:practices] } %>
+              </div>
               <div class="text-center dm-load-more-practices-<%= component_index %>-btn-container" >
                 <% link = pagy_link_proc(pplc[:pagy]) %>
                 <%=  link.call(pplc[:pagy].vars[:page] + 1, 'Load more').html_safe %>

--- a/app/views/page/show.html.erb
+++ b/app/views/page/show.html.erb
@@ -108,9 +108,7 @@
           %>
           <% if pplc[:practices].any? %>
             <div class="margin-bottom-2<%= ' margin-bottom-0' if last_component === index %>">
-              <div class="dm-practice-card-list grid-row grid-gap-3 dm-paginated-<%= component_index %>-practices">
-                <%= render partial: 'page/practice_list_container', locals: { practices: pplc[:practices], component_index: component_index } %>
-              </div>
+              <%= render partial: 'shared/practice_cards_row', locals: { practices: pplc[:practices], classes: "dm-practice-card-list dm-paginated-#{component_index}-practices"} %>
               <div class="text-center dm-load-more-practices-<%= component_index %>-btn-container" >
                 <% link = pagy_link_proc(pplc[:pagy]) %>
                 <%=  link.call(pplc[:pagy].vars[:page] + 1, 'Load more').html_safe %>

--- a/app/views/page/show.js.erb
+++ b/app/views/page/show.js.erb
@@ -9,7 +9,7 @@ function paginatedPracticeListPageComponent() {
   <% next_page = pagy.next %>
 
   // Append the next set of practice cards to the current set
-  $(practicesClass).append("<%= escape_javascript render(partial: 'page/practice_list_container', locals: {
+  $(practicesClass).append("<%= escape_javascript render(partial: 'shared/practice_cards_row', locals: {
     practices: data_set,
     component_index: @pagy_type})
   %>")

--- a/app/views/practice_partners/show.html.erb
+++ b/app/views/practice_partners/show.html.erb
@@ -1,25 +1,24 @@
-<div class="partner-page-min-height margin-bottom-10">
+<div>
   <section class="grid-container">
     <%= render partial: "shared/messages", locals: {small_text: false} %>
   </section>
 
-  <section class="margin-bottom-5 margin-top-8 grid-container">
-    <div class="grid-row">
+  <section class="margin-top-8 grid-container">
+    <div class="grid-row margin-bottom-5">
       <div>
         <p class="grid-col-12 margin-0 line-height-26 tablet:grid-col-8"><%= @practice_partner.description %></p>
       </div>
     </div>
-  </section>
-  <section>
-    <div class="grid-container margin-bottom-5">
-      <% @partner_practices = @practice_partner.practices %>
-      <% if @partner_practices.any? %>
-        <div class="grid-row grid-gap-3">
-          <% @partner_practices.order(retired: :asc, name: :asc).each do |p| %>
-            <%= render partial: 'shared/practice_card', locals: {practice: p, featured: false} %>
-          <% end %>
-        </div>
-      <% end %>
+    <div class="dm-paginated-partner-practices">
+      <%
+        paginated_partner_practices = @paginated_partner_practices
+        pagy_partner_practices = @pagy_partner_practices
+      %>
+      <%= render partial: 'shared/practice_cards_row', locals: { practices: paginated_partner_practices } %>
+    </div>
+    <div class="dm-load-more-container text-center">
+      <% link = pagy_link_proc(pagy_partner_practices) %>
+      <%= link.call(pagy_partner_practices.vars[:page].to_i + 1, 'Load more').html_safe if pagy_partner_practices.count > 3 %>
     </div>
   </section>
 </div>

--- a/app/views/practice_partners/show.js.erb
+++ b/app/views/practice_partners/show.js.erb
@@ -1,0 +1,25 @@
+function paginatedPartnerPractices() {
+  var practicesClass = ".dm-paginated-partner-practices";
+  var loadMoreClass = ".dm-load-more-container";
+
+  <% pagy = @pagy_partner_practices %>
+  <% current_page = pagy.page %>
+  <% next_page = pagy.next %>
+
+  // Append the next set of practice cards to the current set
+  $(practicesClass).append("<%= escape_javascript render(partial: 'shared/practice_cards_row', locals: {
+    practices: @paginated_partner_practices
+  }) %>")
+
+  // If there's another set of cards, remove the current 'Load more' link and then add one for the next page
+  <% if next_page.present? %>
+    $(loadMoreClass).empty();
+    <% link = pagy_link_proc(pagy) %>
+    $(loadMoreClass).append(`<%= link.call(next_page, 'Load more').html_safe %>`);
+  <% else %>
+  // If there isn't another set, remove the current 'Load more' link
+    $(loadMoreClass).remove();
+  <% end %>
+}
+
+$(paginatedPartnerPractices);

--- a/app/views/shared/_practice_cards_row.html.erb
+++ b/app/views/shared/_practice_cards_row.html.erb
@@ -1,0 +1,6 @@
+<% classes ||= nil %>
+<div class="grid-row grid-gap-3<%= (' ' + classes) if classes.present? %>">
+  <% practices.each do |p| %>
+    <%= render partial: 'shared/practice_card', locals: { practice: p } %>
+  <% end %>
+</div>

--- a/spec/features/pages/show_page_spec.rb
+++ b/spec/features/pages/show_page_spec.rb
@@ -12,6 +12,7 @@ describe 'Page Builder - Show', type: :feature do
       Practice.create!(name: 'An amazing practice', approved: true, published: true, tagline: 'Test tagline', user: user),
       Practice.create!(name: 'A beautiful practice', approved: true, published: true, tagline: 'Test tagline', user: user),
       Practice.create!(name: 'A superb practice', approved: true, published: true, tagline: 'Test tagline', user: user),
+      Practice.create!(name: 'Third to last practice', approved: true, published: true, tagline: 'Test tagline', user: user),
       Practice.create!(name: 'Second to last practice', approved: true, published: true, tagline: 'Test tagline', user: user),
       Practice.create!(name: 'The last practice', approved: true, published: true, tagline: 'Test tagline', user: user)
     ]
@@ -67,10 +68,12 @@ describe 'Page Builder - Show', type: :feature do
     expect(page).to have_content('A beautiful practice')
     expect(page).to have_content('A superb practice')
     expect(page).to have_no_content('Second to last practice')
+    expect(page).to have_no_content('Third to last practice')
     expect(page).to have_no_content('The last practice')
     expect(page).to have_css('.dm-practice-link')
     expect(page).to have_content('Load more')
     find('.dm-paginated-0-link').click
+    expect(page).to have_content('Third to last practice')
     expect(page).to have_content('Second to last practice')
     expect(page).to have_content('The last practice')
   end

--- a/spec/features/pages/show_page_spec.rb
+++ b/spec/features/pages/show_page_spec.rb
@@ -12,6 +12,7 @@ describe 'Page Builder - Show', type: :feature do
       Practice.create!(name: 'An amazing practice', approved: true, published: true, tagline: 'Test tagline', user: user),
       Practice.create!(name: 'A beautiful practice', approved: true, published: true, tagline: 'Test tagline', user: user),
       Practice.create!(name: 'A superb practice', approved: true, published: true, tagline: 'Test tagline', user: user),
+      Practice.create!(name: 'Second to last practice', approved: true, published: true, tagline: 'Test tagline', user: user),
       Practice.create!(name: 'The last practice', approved: true, published: true, tagline: 'Test tagline', user: user)
     ]
 
@@ -65,10 +66,12 @@ describe 'Page Builder - Show', type: :feature do
     expect(page).to have_content('An amazing practice')
     expect(page).to have_content('A beautiful practice')
     expect(page).to have_content('A superb practice')
+    expect(page).to have_no_content('Second to last practice')
     expect(page).to have_no_content('The last practice')
     expect(page).to have_css('.dm-practice-link')
     expect(page).to have_content('Load more')
     find('.dm-paginated-0-link').click
+    expect(page).to have_content('Second to last practice')
     expect(page).to have_content('The last practice')
   end
 

--- a/spec/features/pages/show_page_spec.rb
+++ b/spec/features/pages/show_page_spec.rb
@@ -12,8 +12,6 @@ describe 'Page Builder - Show', type: :feature do
       Practice.create!(name: 'An amazing practice', approved: true, published: true, tagline: 'Test tagline', user: user),
       Practice.create!(name: 'A beautiful practice', approved: true, published: true, tagline: 'Test tagline', user: user),
       Practice.create!(name: 'A superb practice', approved: true, published: true, tagline: 'Test tagline', user: user),
-      Practice.create!(name: 'Third to last practice', approved: true, published: true, tagline: 'Test tagline', user: user),
-      Practice.create!(name: 'Second to last practice', approved: true, published: true, tagline: 'Test tagline', user: user),
       Practice.create!(name: 'The last practice', approved: true, published: true, tagline: 'Test tagline', user: user)
     ]
 
@@ -67,14 +65,10 @@ describe 'Page Builder - Show', type: :feature do
     expect(page).to have_content('An amazing practice')
     expect(page).to have_content('A beautiful practice')
     expect(page).to have_content('A superb practice')
-    expect(page).to have_no_content('Second to last practice')
-    expect(page).to have_no_content('Third to last practice')
     expect(page).to have_no_content('The last practice')
     expect(page).to have_css('.dm-practice-link')
     expect(page).to have_content('Load more')
     find('.dm-paginated-0-link').click
-    expect(page).to have_content('Third to last practice')
-    expect(page).to have_content('Second to last practice')
     expect(page).to have_content('The last practice')
   end
 

--- a/spec/features/practice_partners_spec.rb
+++ b/spec/features/practice_partners_spec.rb
@@ -8,31 +8,81 @@ describe 'Practice partners pages', type: :feature do
     @approver = User.create!(email: 'squidward.tentacles@bikinibottom.net', password: 'Password123', password_confirmation: 'Password123', skip_va_validation: true, confirmed_at: Time.now, accepted_terms: true)
     @admin.add_role(User::USER_ROLES[1].to_sym)
     @approver.add_role(User::USER_ROLES[0].to_sym)
-    @user_practice = Practice.create!(name: 'A public practice', approved: true, published: true, initiating_facility_type: 'other', user: @user2)
-    PracticePartnerPractice.create!(practice_partner: @pp, practice: @user_practice)
+    @pr_1 = Practice.create!(name: 'A public practice', approved: true, published: true, enabled: true, is_public: true, initiating_facility_type: 'other', user: @user2)
+    @pr_2 = Practice.create!(name: 'practice two', approved: true, published: true, enabled: true, initiating_facility_type: 'other', user: @user2)
+    @pr_3 = Practice.create!(name: 'practice three', approved: true, published: true, enabled: true, initiating_facility_type: 'other', user: @user2)
+    @pr_4 = Practice.create!(name: 'practice four', approved: true, published: true, enabled: true, initiating_facility_type: 'other', user: @user2)
+    @pr_5 = Practice.create!(name: 'practice five', approved: true, published: true, enabled: true, initiating_facility_type: 'other', user: @user2)
+    @pr_6 = Practice.create!(name: 'practice six', approved: true, published: true, enabled: true, initiating_facility_type: 'other', user: @user2)
+    @pr_7 = Practice.create!(name: 'practice seven', approved: true, published: true, enabled: true, initiating_facility_type: 'other', user: @user2)
+    @pr_8 = Practice.create!(name: 'practice eight', approved: true, published: true, enabled: true, initiating_facility_type: 'other', user: @user2)
+    @pr_9 = Practice.create!(name: 'practice nine', approved: true, published: true, enabled: true, initiating_facility_type: 'other', user: @user2)
+    @pr_10 = Practice.create!(name: 'practice ten', approved: true, published: true, enabled: true, initiating_facility_type: 'other', user: @user2)
+    @pr_11 = Practice.create!(name: 'practice eleven', approved: true, published: true, enabled: true, initiating_facility_type: 'other', user: @user2)
+    @pr_12 = Practice.create!(name: 'practice twelve', approved: true, published: true, enabled: true, initiating_facility_type: 'other', user: @user2)
+    @pr_13 = Practice.create!(name: 'practice thirteen', approved: true, published: true, enabled: true, initiating_facility_type: 'other', user: @user2)
+    PracticePartnerPractice.create!(practice_partner: @pp, practice: @pr_1)
+    PracticePartnerPractice.create!(practice_partner: @pp, practice: @pr_2)
+    PracticePartnerPractice.create!(practice_partner: @pp, practice: @pr_3)
+    PracticePartnerPractice.create!(practice_partner: @pp, practice: @pr_4)
+    PracticePartnerPractice.create!(practice_partner: @pp, practice: @pr_5)
+    PracticePartnerPractice.create!(practice_partner: @pp, practice: @pr_6)
+    PracticePartnerPractice.create!(practice_partner: @pp, practice: @pr_7)
+    PracticePartnerPractice.create!(practice_partner: @pp, practice: @pr_8)
+    PracticePartnerPractice.create!(practice_partner: @pp, practice: @pr_9)
+    PracticePartnerPractice.create!(practice_partner: @pp, practice: @pr_10)
+    PracticePartnerPractice.create!(practice_partner: @pp, practice: @pr_11)
+    PracticePartnerPractice.create!(practice_partner: @pp, practice: @pr_12)
+    PracticePartnerPractice.create!(practice_partner: @pp, practice: @pr_13)
   end
 
-  it 'should navigate to strategic sponsors list page' do
-    visit '/partners'
-    # TODO: this is timing out in CI
-    # expect(page).to be_accessible.according_to :wcag2a, :section508
-    expect(current_path).to eq('/partners')
+  context 'for a logged in user' do
+    before do
+      login_as(@user, :scope => :user, :run_callbacks => false)
+      page.set_rack_session(:user_type => 'ntlm')
+    end
+
+    it 'should navigate to strategic sponsors list page' do
+      visit '/partners'
+      # TODO: this is timing out in CI
+      # expect(page).to be_accessible.according_to :wcag2a, :section508
+      expect(current_path).to eq('/partners')
+    end
+
+    it 'should show the initiating facility\'s name' do
+      @pr_1.update(initiating_facility: 'Foobar Facility')
+      visit '/partners/diffusion-of-excellence'
+      expect(page).to be_accessible.according_to :wcag2a, :section508
+      expect(page).to have_content(@pr_1.name)
+      expect(page).to have_content('Foobar Facility')
+    end
+
+    it 'should display the initiating facility\'s initiating facility property if it is not found in the map' do
+      @pr_1.update(initiating_facility: 'Test facility')
+      visit '/partners/diffusion-of-excellence'
+      expect(page).to have_content(@pr_1.name)
+      expect(page).to have_content('Test facility')
+    end
+
+    it 'should paginate the practice cards if there are more than 12 cards' do
+      visit '/partners/diffusion-of-excellence'
+      expect(page).to have_content('Load more')
+      pr_card_count = find_all('.dm-practice-card').size
+      expect(pr_card_count).to eq(12)
+      find('.paginated-partner-practices-page-2-link').click
+      expect(page).to have_content('practice two')
+      updated_pr_card_count = find_all('.dm-practice-card').size
+      expect(updated_pr_card_count).to eq(13)
+      expect(page).to have_no_content('Load more')
+    end
   end
 
-  it 'should show the initiating facility\'s name' do
-    @user_practice.update(initiating_facility: 'Foobar Facility')
-    visit '/partners/diffusion-of-excellence'
-    expect(page).to be_accessible.according_to :wcag2a, :section508
-    expect(page).to have_content(@user_practice.name)
-    expect(page).to have_content('Foobar Facility')
-  end
-
-  it 'should display the initiating facility\'s initiating facility property if it is not found in the map' do
-    @user_practice.update(initiating_facility: 'Test facility')
-    visit '/partners/diffusion-of-excellence'
-    expect(page).to be_accessible.according_to :wcag2a, :section508
-
-    expect(page).to have_content(@user_practice.name)
-    expect(page).to have_content('Test facility')
+  context 'for a public user' do
+    it 'should only display the public practice' do
+      visit '/partners/diffusion-of-excellence'
+      pr_card_count = find_all('.dm-practice-card').size
+      expect(pr_card_count).to eq(1)
+      expect(page).to have_content('A public practice')
+    end
   end
 end


### PR DESCRIPTION
### JIRA issue link
[DM-3090](https://agile6.atlassian.net/browse/DM-3090)

## Description - what does this code do?
This PR paginates the innovations cards on the partners show page. On page load, it paginates the innovation cards if there are more than 12. Clicking "Load more" shows another 12 cards. It also shows the appropriate public or all innovation cards associated with a partner for a logged in user vs. a public user.

## Testing done - how did you test it/steps on how can another person can test it 
As a logged in user
- Go to a partner's show page and ensure all practices associated with that partner are appearing
- Ensure any pagination is correct
As a public user
- Go to a partner's show page and ensure only public practices associated with that partner are appearing
- Ensure any pagination is correct

page builder page with innovation cards
- ensure innovation cards are correctly being paginated on page builder pages

## Screenshots, Gifs, Videos from application (if applicable)


## Link to mock-ups/mock ups (image file if you have it) (if applicable)


## Acceptance criteria
- [X] Only load X (I think it's 12) practice cards at a time
- [X] Have "Load More" 
- [X] clicking “Load more” adds an additional 12 cards


## Definition of done
- [ ] Unit tests written (if applicable)
- [X] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [X] A link has been provided to the originating JIRA issue
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs