### PR TITLE
DM-3090: Fix pagination for < 12 innovations on partners pg

### DIFF
--- a/app/views/practice_partners/show.html.erb
+++ b/app/views/practice_partners/show.html.erb
@@ -18,7 +18,7 @@
     </div>
     <div class="dm-load-more-container text-center">
       <% link = pagy_link_proc(pagy_partner_practices) %>
-      <%= link.call(pagy_partner_practices.vars[:page].to_i + 1, 'Load more').html_safe if pagy_partner_practices.count > 3 %>
+      <%= link.call(pagy_partner_practices.vars[:page].to_i + 1, 'Load more').html_safe if pagy_partner_practices.count > 12 %>
     </div>
   </section>
 </div>

--- a/spec/features/practice_partners_spec.rb
+++ b/spec/features/practice_partners_spec.rb
@@ -84,6 +84,7 @@ describe 'Practice partners pages', type: :feature do
       visit '/partners/diffusion-of-excellence'
       pr_card_count = find_all('.dm-practice-card').size
       expect(pr_card_count).to eq(1)
+      expect(page).to have_no_content('Load more')
       expect(page).to have_content('A public practice')
       expect(page).to have_no_content('random practice')
     end


### PR DESCRIPTION
### JIRA issue link


## Description - what does this code do?
Ensures pagination only appears on partners pages with more than 12 innovations

## Testing done - how did you test it/steps on how can another person can test it 


## Screenshots, Gifs, Videos from application (if applicable)


## Link to mock-ups/mock ups (image file if you have it) (if applicable)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Unit tests written (if applicable)
- [ ] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating JIRA issue
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs