### PR TITLE
Dm 3110

### DIFF
--- a/app/controllers/clinical_resource_hubs_controller.rb
+++ b/app/controllers/clinical_resource_hubs_controller.rb
@@ -1,0 +1,13 @@
+class ClinicalResourceHubsController < ApplicationController
+  before_action :set_crh, only: [:show]
+  def show
+
+  end
+
+  private
+  def set_crh
+    debugger
+    @visn = Visn.find_by!(number: params[:id])
+    @crh = ClinicalResourceHub.find_by!(visn: @visn) if @visn.present?
+  end
+end

--- a/app/controllers/clinical_resource_hubs_controller.rb
+++ b/app/controllers/clinical_resource_hubs_controller.rb
@@ -6,7 +6,6 @@ class ClinicalResourceHubsController < ApplicationController
 
   private
   def set_crh
-    debugger
     @visn = Visn.find_by!(number: params[:id])
     @crh = ClinicalResourceHub.find_by!(visn: @visn) if @visn.present?
   end

--- a/app/models/clinical_resource_hub.rb
+++ b/app/models/clinical_resource_hub.rb
@@ -1,0 +1,10 @@
+class ClinicalResourceHub < ApplicationRecord
+  # extend FriendlyId
+  # friendly_id :name, use: :slugged
+  belongs_to :visn
+  has_many :diffusion_histories
+
+  def to_param
+    visn.number.to_s
+  end
+end

--- a/app/models/clinical_resource_hub.rb
+++ b/app/models/clinical_resource_hub.rb
@@ -1,6 +1,4 @@
 class ClinicalResourceHub < ApplicationRecord
-  # extend FriendlyId
-  # friendly_id :name, use: :slugged
   belongs_to :visn
   has_many :diffusion_histories
 

--- a/app/models/concerns/diffusion_history_validator.rb
+++ b/app/models/concerns/diffusion_history_validator.rb
@@ -1,6 +1,5 @@
 class DiffusionHistoryValidator < ActiveModel::Validator
   def validate(record)
-    debugger
     is_valid = record.va_facility_id.present? || record.clinical_resource_hub_id.present?
     begin
       unless is_valid

--- a/app/models/concerns/diffusion_history_validator.rb
+++ b/app/models/concerns/diffusion_history_validator.rb
@@ -1,0 +1,12 @@
+class DiffusionHistoryValidator < ActiveModel::Validator
+  def validate(record)
+    is_valid = record.va_facility_id.present? # || record.clinical_resource_hub_id.preset?
+    begin
+      unless is_valid
+        raise StandardError.new 'No facility or CRH present'
+      end
+    rescue => e
+      record.errors.add(:url, e.message)
+    end
+  end
+end

--- a/app/models/concerns/diffusion_history_validator.rb
+++ b/app/models/concerns/diffusion_history_validator.rb
@@ -1,6 +1,7 @@
 class DiffusionHistoryValidator < ActiveModel::Validator
   def validate(record)
-    is_valid = record.va_facility_id.present? # || record.clinical_resource_hub_id.preset?
+    debugger
+    is_valid = record.va_facility_id.present? || record.clinical_resource_hub_id.present?
     begin
       unless is_valid
         raise StandardError.new 'No facility or CRH present'

--- a/app/models/diffusion_history.rb
+++ b/app/models/diffusion_history.rb
@@ -4,7 +4,6 @@ class DiffusionHistory < ApplicationRecord
   belongs_to :clinical_resource_hub, optional: true
 
 
-  #TODO
   validates_with DiffusionHistoryValidator, on: [:create, :update] #check CRH exists or facility exists
 
 

--- a/app/models/diffusion_history.rb
+++ b/app/models/diffusion_history.rb
@@ -1,6 +1,13 @@
 class DiffusionHistory < ApplicationRecord
   belongs_to :practice
-  belongs_to :va_facility
+  belongs_to :va_facility, optional: true
+  belongs_to :clinical_resource_hub, optional: true
+
+
+  #TODO
+  validates_with DiffusionHistoryValidator, on: [:create, :update] #check CRH exists or facility exists
+
+
   has_many :diffusion_history_statuses, dependent: :destroy
   after_save :clear_searchable_practices_cache
   after_destroy :clear_searchable_practices_cache
@@ -16,4 +23,6 @@ class DiffusionHistory < ApplicationRecord
   def clear_searchable_practices_cache
     practice.clear_searchable_cache
   end
+
+
 end

--- a/app/models/visn.rb
+++ b/app/models/visn.rb
@@ -1,5 +1,6 @@
 class Visn < ApplicationRecord
   has_many :va_facilities, dependent: :destroy
+  has_one :clinical_resource_hub, dependent: :destroy
   has_many :visn_liaisons, dependent: :destroy
 
   before_save :clear_visn_cache_on_save

--- a/app/views/clinical_resource_hubs/show.html.erb
+++ b/app/views/clinical_resource_hubs/show.html.erb
@@ -1,0 +1,3 @@
+<div>
+    hello world
+</div>

--- a/app/views/clinical_resource_hubs/show.html.erb
+++ b/app/views/clinical_resource_hubs/show.html.erb
@@ -1,3 +1,5 @@
 <div>
+  <%# debugger %>
+  <%= params["id"] %>
     hello world
 </div>

--- a/app/views/clinical_resource_hubs/show.html.erb
+++ b/app/views/clinical_resource_hubs/show.html.erb
@@ -1,5 +1,8 @@
 <div>
   <%# debugger %>
-  <%= params["id"] %>
+  VISN NUmber: <%= params["id"] %>
+  <div>
+  VISN_ID: <%= @crh.visn_id %>
+  </div>
     hello world
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -78,6 +78,8 @@ Rails.application.routes.draw do
   end
 
   root 'home#index'
+  get '/crh/:id' => 'clinical_resource_hubs#show'
+  resources :clinical_resource_hubs, param: :number
   get '/practices' => 'practices#index'
   get '/partners' => 'practice_partners#index'
   # Adding this for the View Toolkit button on practice page. Though we don't have any uploaded yet so I'm not using it.

--- a/db/migrate/20220111151820_create_clinical_resource_hubs.rb
+++ b/db/migrate/20220111151820_create_clinical_resource_hubs.rb
@@ -1,0 +1,9 @@
+class CreateClinicalResourceHubs < ActiveRecord::Migration[5.2]
+  def change
+    create_table :clinical_resource_hubs do |t|
+      t.belongs_to :visn, foreign_key: true
+      t.string :name
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20220112155536_add_clinical_resource_hub_foreign_key_to_diffusion_histories.rb
+++ b/db/migrate/20220112155536_add_clinical_resource_hub_foreign_key_to_diffusion_histories.rb
@@ -1,0 +1,5 @@
+class AddClinicalResourceHubForeignKeyToDiffusionHistories < ActiveRecord::Migration[5.2]
+  def change
+    add_reference :diffusion_histories, :clinical_resource_hub, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_09_10_151628) do
+ActiveRecord::Schema.define(version: 2022_01_11_151820) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -232,6 +232,14 @@ ActiveRecord::Schema.define(version: 2021_09_10_151628) do
     t.integer "position"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "clinical_resource_hubs", force: :cascade do |t|
+    t.bigint "visn_id"
+    t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["visn_id"], name: "index_clinical_resource_hubs_on_visn_id"
   end
 
   create_table "commontator_comments", force: :cascade do |t|
@@ -1350,6 +1358,7 @@ ActiveRecord::Schema.define(version: 2021_09_10_151628) do
   add_foreign_key "clinical_condition_practices", "practices"
   add_foreign_key "clinical_location_practices", "clinical_locations"
   add_foreign_key "clinical_location_practices", "practices"
+  add_foreign_key "clinical_resource_hubs", "visns"
   add_foreign_key "commontator_comments", "commontator_comments", column: "parent_id", on_update: :restrict, on_delete: :cascade
   add_foreign_key "commontator_comments", "commontator_threads", column: "thread_id", on_update: :cascade, on_delete: :cascade
   add_foreign_key "commontator_subscriptions", "commontator_threads", column: "thread_id", on_update: :cascade, on_delete: :cascade

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_01_11_151820) do
+ActiveRecord::Schema.define(version: 2022_01_12_155536) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -346,6 +346,8 @@ ActiveRecord::Schema.define(version: 2022_01_11_151820) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "va_facility_id"
+    t.bigint "clinical_resource_hub_id"
+    t.index ["clinical_resource_hub_id"], name: "index_diffusion_histories_on_clinical_resource_hub_id"
     t.index ["practice_id"], name: "index_diffusion_histories_on_practice_id"
     t.index ["va_facility_id"], name: "index_diffusion_histories_on_va_facility_id"
   end
@@ -1368,6 +1370,7 @@ ActiveRecord::Schema.define(version: 2022_01_11_151820) do
   add_foreign_key "developing_facility_type_practices", "developing_facility_types"
   add_foreign_key "developing_facility_type_practices", "practices"
   add_foreign_key "difficulties", "practices"
+  add_foreign_key "diffusion_histories", "clinical_resource_hubs"
   add_foreign_key "diffusion_histories", "practices"
   add_foreign_key "diffusion_histories", "va_facilities"
   add_foreign_key "diffusion_history_statuses", "diffusion_histories"

--- a/lib/assets/practice_origin_lookup.json
+++ b/lib/assets/practice_origin_lookup.json
@@ -775,5 +775,16 @@
         }
       ]
     }
+  ],
+  "crh":
+  [
+    {
+      "name": "VISN 1 Clinical Resource Hub (Remote)",
+      "visn_number": 1
+    },
+    {
+      "name": "VISN 2 Clinical Resource Hub (Remote)",
+      "visn_number": 2
+    }
   ]
 }

--- a/lib/assets/practice_origin_lookup.json
+++ b/lib/assets/practice_origin_lookup.json
@@ -785,6 +785,70 @@
     {
       "name": "VISN 2 Clinical Resource Hub (Remote)",
       "visn_number": 2
+    },
+    {
+      "name": "VISN 4 Clinical Resource Hub (Remote)",
+      "visn_number": 4
+    },
+    {
+      "name": "VISN 5 Clinical Resource Hub (Remote)",
+      "visn_number": 5
+    },
+    {
+      "name": "VISN 6 Clinical Resource Hub (Remote)",
+      "visn_number": 6
+    },
+    {
+      "name": "VISN 7 Clinical Resource Hub (Remote)",
+      "visn_number": 7
+    },
+    {
+      "name": "VISN 8 Clinical Resource Hub (Remote)",
+      "visn_number": 8
+    },
+    {
+      "name": "VISN 9 Clinical Resource Hub (Remote)",
+      "visn_number": 9
+    },
+    {
+      "name": "VISN 10 Clinical Resource Hub (Remote)",
+      "visn_number": 10
+    },
+    {
+      "name": "VISN 12 Clinical Resource Hub (Remote)",
+      "visn_number": 12
+    },
+    {
+      "name": "VISN 15 Clinical Resource Hub (Remote)",
+      "visn_number": 15
+    },
+    {
+      "name": "VISN 16 Clinical Resource Hub (Remote)",
+      "visn_number": 16
+    },
+    {
+      "name": "VISN 17 Clinical Resource Hub (Remote)",
+      "visn_number": 17
+    },
+    {
+      "name": "VISN 19 Clinical Resource Hub (Remote)",
+      "visn_number": 19
+    },
+    {
+      "name": "VISN 20 Clinical Resource Hub (Remote)",
+      "visn_number": 20
+    },
+    {
+      "name": "VISN 21 Clinical Resource Hub (Remote)",
+      "visn_number": 21
+    },
+    {
+      "name": "VISN 22 Clinical Resource Hub (Remote)",
+      "visn_number": 22
+    },
+    {
+      "name": "VISN 23 Clinical Resource Hub (Remote)",
+      "visn_number": 23
     }
   ]
 }

--- a/lib/tasks/clinical_resource_hubs.rake
+++ b/lib/tasks/clinical_resource_hubs.rake
@@ -1,0 +1,16 @@
+namespace :clinical_resource_hubs do
+  desc 'Create new Clinical_Resource_Hub records based on the data from the practice_origin_lookup.json file'
+
+  @origin_data = JSON.parse(File.read("#{Rails.root}/lib/assets/practice_origin_lookup.json"))
+
+  task :create_clinical_resource_hubs => :environment do
+    @origin_data["crh"].each do |v|
+      visn = Visn.where(number: v["visn_number"]).first
+      ClinicalResourceHub.create!(
+          visn_id: visn.id,
+          name: v["name"]
+      )
+    end
+    puts "All Clinical Resource Hubs have been added to the DB!"
+  end
+end

--- a/spec/features/crh_spec.rb
+++ b/spec/features/crh_spec.rb
@@ -1,23 +1,26 @@
 require 'rails_helper'
-require 'spec_helper'
 
-describe 'CRH pages', type: :feature do
-
+describe 'Clinical_Resource_Hubs', type: :feature do
   before do
     @visn_1 = Visn.create!(name: 'visn_1', number: 1)
     @crh = ClinicalResourceHub.create!(name: 'crh1', visn_id: @visn_1.id)
   end
-  describe 'show page' do
-    it 'should throw error if crh_path not defined' do
-      visit clinical_resource_hub_path
-      expect(page).to have_content('Page not found')
-      expect(page).to have_content('We\'re sorry, we can\'t find the page you\'re looking for. It might have been removed, changed names, or is otherwise unavailable.')
+
+  describe 'CRH show page' do
+    describe 'bad route' do
+      it 'should show 404 error' do
+        visit '/crh/'
+        expect(page).to have_content('Page not found')
+        expect(page).to have_content('We\'re sorry, we can\'t find the page you\'re looking for. It might have been removed, changed names, or is otherwise unavailable.')
+      end
     end
 
-    if 'should throw error if visn_number not found in DB'
-      visit clinical_resource_hub_path(@crh)
-      expect(page).to_not have_content('Page not found')
-      expect(page).to_not have_content('We\'re sorry, we can\'t find the page you\'re looking for. It might have been removed, changed names, or is otherwise unavailable.')
+    describe 'route works' do
+      it 'should not show 404' do
+        visit '/crh/1'
+        expect(page).to_not have_content('Page not found')
+        expect(page).to_not have_content('We\'re sorry, we can\'t find the page you\'re looking for. It might have been removed, changed names, or is otherwise unavailable.')
+      end
     end
   end
 end

--- a/spec/features/crh_spec.rb
+++ b/spec/features/crh_spec.rb
@@ -2,13 +2,9 @@ require 'rails_helper'
 require 'spec_helper'
 
 describe 'show page' do
-  it 'should be there if the VISN number exists in the DB' do
-    visit '/crh/1'
-    expect(page).to have_content("Department of Veterans Affairs")
-  end
-
   it 'should throw error if VISN number does not exist in the DB' do
     visit '/crh/50'
-    expect(page).to have_content("Couldn't find Visn")
+    expect(page).to have_content('Internal server error')
+    expect(page).to have_content('We\'re sorry, something went wrong. We\'re working to fix it as soon as we can. Please check back in 30 minutes.')
   end
 end

--- a/spec/features/crh_spec.rb
+++ b/spec/features/crh_spec.rb
@@ -2,15 +2,21 @@ require 'rails_helper'
 require 'spec_helper'
 
 describe 'CRH pages', type: :feature do
+
+  before do
+    def visit_crh_page s_url
+      visit s_url
+    end
+  end
   describe 'show page' do
     it 'should throw error if crh_path not defined' do
-      visit '/crh'
+      visit_crh_page '/crh'
       expect(page).to have_content('Page not found')
       expect(page).to have_content('We\'re sorry, we can\'t find the page you\'re looking for. It might have been removed, changed names, or is otherwise unavailable.')
     end
 
     if 'should throw error if visn_number not found in DB'
-      visit '/crh/150'
+      visit_crh_page '/crh/150'
       expect(page).to have_content('Page not found')
       expect(page).to have_content('We\'re sorry, we can\'t find the page you\'re looking for. It might have been removed, changed names, or is otherwise unavailable.')
     end

--- a/spec/features/crh_spec.rb
+++ b/spec/features/crh_spec.rb
@@ -1,16 +1,18 @@
 require 'rails_helper'
 require 'spec_helper'
 
-describe 'show page' do
-  it 'should throw error if crh_path not defined' do
-    visit '/crh'
-    expect(page).to have_content('Page not found')
-    expect(page).to have_content('We\'re sorry, we can\'t find the page you\'re looking for. It might have been removed, changed names, or is otherwise unavailable.')
-  end
+describe 'CRH pages', type: :feature do
+  describe 'show page' do
+    it 'should throw error if crh_path not defined' do
+      visit '/crh'
+      expect(page).to have_content('Page not found')
+      expect(page).to have_content('We\'re sorry, we can\'t find the page you\'re looking for. It might have been removed, changed names, or is otherwise unavailable.')
+    end
 
-  if 'should throw error if visn_number not found in DB'
-    visit '/crh/150'
-    expect(page).to have_content('Page not found')
-    expect(page).to have_content('We\'re sorry, we can\'t find the page you\'re looking for. It might have been removed, changed names, or is otherwise unavailable.')
+    if 'should throw error if visn_number not found in DB'
+      visit '/crh/150'
+      expect(page).to have_content('Page not found')
+      expect(page).to have_content('We\'re sorry, we can\'t find the page you\'re looking for. It might have been removed, changed names, or is otherwise unavailable.')
+    end
   end
 end

--- a/spec/features/crh_spec.rb
+++ b/spec/features/crh_spec.rb
@@ -7,14 +7,6 @@ describe 'Clinical_Resource_Hubs', type: :feature do
   end
 
   describe 'CRH show page' do
-    describe 'bad route' do
-      it 'should show 404 error' do
-        visit '/crh/'
-        expect(page).to have_content('Page not found')
-        expect(page).to have_content('We\'re sorry, we can\'t find the page you\'re looking for. It might have been removed, changed names, or is otherwise unavailable.')
-      end
-    end
-
     describe 'route works' do
       it 'should not show 404' do
         visit '/crh/1'

--- a/spec/features/crh_spec.rb
+++ b/spec/features/crh_spec.rb
@@ -4,21 +4,20 @@ require 'spec_helper'
 describe 'CRH pages', type: :feature do
 
   before do
-    def visit_crh_page s_url
-      visit s_url
-    end
+    @visn_1 = Visn.create!(name: 'visn_1', number: 1)
+    @crh = ClinicalResourceHub.create!(name: 'crh1', visn_id: @visn_1.id)
   end
   describe 'show page' do
     it 'should throw error if crh_path not defined' do
-      visit_crh_page '/crh'
+      visit clinical_resource_hub_path
       expect(page).to have_content('Page not found')
       expect(page).to have_content('We\'re sorry, we can\'t find the page you\'re looking for. It might have been removed, changed names, or is otherwise unavailable.')
     end
 
     if 'should throw error if visn_number not found in DB'
-      visit_crh_page '/crh/150'
-      expect(page).to have_content('Page not found')
-      expect(page).to have_content('We\'re sorry, we can\'t find the page you\'re looking for. It might have been removed, changed names, or is otherwise unavailable.')
+      visit clinical_resource_hub_path(@crh)
+      expect(page).to_not have_content('Page not found')
+      expect(page).to_not have_content('We\'re sorry, we can\'t find the page you\'re looking for. It might have been removed, changed names, or is otherwise unavailable.')
     end
   end
 end

--- a/spec/features/crh_spec.rb
+++ b/spec/features/crh_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+require 'spec_helper'
+
+describe 'show page' do
+  it 'should be there if the VISN number exists in the DB' do
+    visit '/crh/1'
+    expect(page).to have_content("Department of Veterans Affairs")
+  end
+
+  it 'should throw error if VISN number does not exist in the DB' do
+    visit '/crh/50'
+    expect(page).to have_content("Couldn't find Visn")
+  end
+end

--- a/spec/features/crh_spec.rb
+++ b/spec/features/crh_spec.rb
@@ -2,9 +2,15 @@ require 'rails_helper'
 require 'spec_helper'
 
 describe 'show page' do
-  it 'should throw error if VISN number does not exist in the DB' do
-    visit '/crh/50'
-    expect(page).to have_content('Internal server error')
-    expect(page).to have_content('We\'re sorry, something went wrong. We\'re working to fix it as soon as we can. Please check back in 30 minutes.')
+  it 'should throw error if crh_path not defined' do
+    visit '/crh'
+    expect(page).to have_content('Page not found')
+    expect(page).to have_content('We\'re sorry, we can\'t find the page you\'re looking for. It might have been removed, changed names, or is otherwise unavailable.')
+  end
+
+  if 'should throw error if visn_number not found in DB'
+    visit '/crh/150'
+    expect(page).to have_content('Page not found')
+    expect(page).to have_content('We\'re sorry, we can\'t find the page you\'re looking for. It might have been removed, changed names, or is otherwise unavailable.')
   end
 end


### PR DESCRIPTION
### JIRA issue link
https://agile6.atlassian.net/browse/DM-3110

## Description - what does this code do?
Adds Clinical Resource Hubs (CRH) to practice_origin_lookup.json - for reference.
Adds Clinical Resource Hubs to DB with foreign key to VISNS and reference to Diffusion_histories
Adds /CRH/visn_number  route for viewing clinical resource hubs 


## Testing done - how did you test it/steps on how can another person can test it 
1.  Run DB:migrations
2.  Run rake task: rake clinical_resource_hubs:create_clinical_resource_hubs.  Ensure that all CRH's are added to the "clinical_resource_hubs' table correctly.
3.  navigate to /crh/X where x is a valid visn_number and ensure the views/clinical_resource_hubs/show.html.erb displays (currently just a place holder for the show page content).  In my DB /crh/7 will display "Visn Number: 7 and Visn_id: 12... which is the actual visn_id field in the visns table for visn_number 7.
![image](https://user-images.githubusercontent.com/60527788/150014648-2f8aa480-b4ad-4d4f-9cce-28cf7cf27e52.png)

4.  Navigate to /crh/X where X is not a valid visn_number and ensure that route error displays indicating that the visn number does not exist.
![image](https://user-images.githubusercontent.com/60527788/150015129-6700cbe2-55d8-4be1-8409-214f7b5a9ab2.png)

## Link to mock-ups/mock ups (image file if you have it) (if applicable)
N/A

## Acceptance criteria
Change xlsx to JSON
Add to Practice Origin Lookup JSON file
Create model and schema
Write task to create record
Add route for CRH (/CRH/#) 

## Definition of done
- [ ] Unit tests written (if applicable)
- [ ] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating JIRA issue
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs