### PR TITLE
DM-3138: Add step indicator to innovation editor

### DIFF
--- a/app/assets/stylesheets/dm/components/_prose.scss
+++ b/app/assets/stylesheets/dm/components/_prose.scss
@@ -55,3 +55,9 @@
   @include u-line-height('body', 5);
   @include u-text('normal');
 }
+
+.usa-prose-caption {
+  @include u-font('body', '2xs');
+  @include u-line-height('body', 3);
+  @include u-text('italic');
+}

--- a/app/assets/stylesheets/dm/components/_step_indicator.scss
+++ b/app/assets/stylesheets/dm/components/_step_indicator.scss
@@ -1,0 +1,22 @@
+// `usa-step-indicator` OVERRIDES
+.usa-step-indicator {
+  .usa-step-indicator__segment {
+    a {
+      @include u-text('base-dark');
+
+      &:visited {
+        @include u-text('base-dark');
+      }
+    }
+
+    &--current, &--complete {
+      a {
+        @include u-text('ink');
+
+        &:visited {
+          @include u-text('ink');
+        }
+      }
+    }
+  }
+}

--- a/app/controllers/practices_controller.rb
+++ b/app/controllers/practices_controller.rb
@@ -1,5 +1,5 @@
 class PracticesController < ApplicationController
-  include CropperUtils, PracticesHelper, PracticeEditorUtils, EditorSessionUtils, PracticeEditorSessionsHelper, PracticeUtils, ThreeColumnDataHelper
+  include CropperUtils, PracticesHelper, PracticeEditorUtils, EditorSessionUtils, PracticeEditorSessionsHelper, PracticeUtils, ThreeColumnDataHelper, UsersHelper
   prepend_before_action :skip_timeout, only: [:session_time_remaining]
   before_action :set_practice, only: [:show, :edit, :update, :destroy, :highlight, :un_highlight, :feature,
                                       :un_feature, :favorite, :instructions, :overview, :impact, :resources, :documentation,

--- a/app/helpers/navigation_helper.rb
+++ b/app/helpers/navigation_helper.rb
@@ -120,70 +120,48 @@ module NavigationHelper
       end
 
       ### PRACTICE EDITOR BREADCRUMBS ###
-      def instructions_breadcrumb
-        session[:breadcrumbs].find { |b| b['display'] == 'Instructions' }
-      end
-
-      def add_instructions_breadcrumb(practice)
-        session[:breadcrumbs] << { 'display': 'Edit', 'path': practice_instructions_path(practice) }
-      end
-
-      def reset_editor_breadcrumbs(practice)
-        empty_breadcrumbs
-        add_practice_breadcrumb(practice)
-        add_instructions_breadcrumb(practice)
-      end
-
       # Instructions breadcrumbs
       if action == 'instructions'
-        reset_editor_breadcrumbs(practice_by_practice_id)
+        empty_breadcrumbs
       end
 
       if action == 'metrics'
-        reset_editor_breadcrumbs(practice_by_practice_id)
-        session[:breadcrumbs] << { 'display': 'Metrics', 'path': practice_metrics_path(practice_by_practice_id) }
+        empty_breadcrumbs
       end
 
       # Editors breadcrumbs
       if action == 'editors'
-        reset_editor_breadcrumbs(practice_by_practice_id)
-        session[:breadcrumbs] << { 'display': 'Editors', 'path': practice_introduction_path(practice_by_practice_id) }
+        empty_breadcrumbs
       end
 
       # Introduction breadcrumbs
       if action == 'introduction'
-        reset_editor_breadcrumbs(practice_by_practice_id)
-        session[:breadcrumbs] << { 'display': 'Introduction', 'path': practice_introduction_path(practice_by_practice_id) }
+        empty_breadcrumbs
       end
 
       # Adoptions breadcrumbs
       if action == 'adoptions'
-        reset_editor_breadcrumbs(practice_by_practice_id)
-        session[:breadcrumbs] << { 'display': 'Adoptions', 'path': practice_adoptions_path(practice_by_practice_id) }
+        empty_breadcrumbs
       end
 
       # Overview breadcrumbs
       if action == 'overview'
-        reset_editor_breadcrumbs(practice_by_practice_id)
-        session[:breadcrumbs] << { 'display': 'Overview', 'path': practice_overview_path(practice_by_practice_id) }
+        empty_breadcrumbs
       end
 
       # Implementation breadcrumbs
       if action == 'implementation'
-        reset_editor_breadcrumbs(practice_by_practice_id)
-        session[:breadcrumbs] << { 'display': 'Implementation', 'path': practice_implementation_path(practice_by_practice_id) }
+        empty_breadcrumbs
       end
 
       # Contact breadcrumbs
       if action == 'contact'
-        reset_editor_breadcrumbs(practice_by_practice_id)
-        session[:breadcrumbs] << { 'display': 'Contact', 'path': practice_contact_path(practice_by_practice_id) }
+        empty_breadcrumbs
       end
 
       # About breadcrumbs
       if action == 'about'
-        reset_editor_breadcrumbs(practice_by_practice_id)
-        session[:breadcrumbs] << { 'display': 'About', 'path': practice_about_path(practice_by_practice_id) }
+        empty_breadcrumbs
       end
     end
 

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,6 +1,6 @@
 <div class="dm-homepage">
   <%= render partial: "shared/messages", locals: {small_text: false} %>
-  <div class="usa-prose-caption font-sans-2xs shark-tank-banner display-flex flex-align-center">
+  <div class="font-sans-2xs shark-tank-banner display-flex flex-align-center">
     <div class="padding-x-2 desktop-lg:padding-x-4">
       <a href="/competitions/shark-tank" class="text-bold dm-footer-link">Click here</a> <span>to view innovations from the 2020 and 2021 Shark Tank competitions.</span>
     </div>

--- a/app/views/practices/form/_practice_last_updated.html.erb
+++ b/app/views/practices/form/_practice_last_updated.html.erb
@@ -1,9 +1,0 @@
-<% session = PracticeEditorSession.where(practice_id: @practice.id).where.not(session_end_time: nil).last %>
-<% if session.present? %>
-  <div class="margin-y-2">
-    <div class="text-base">
-      Innovation last updated on
-      <%= get_local_date_and_time(session.session_end_time) %> by <%= session_username(session) %>
-    </div>
-  </div>
-<% end %>

--- a/app/views/practices/form/about.html.erb
+++ b/app/views/practices/form/about.html.erb
@@ -1,5 +1,5 @@
-<% provide :main_classes, 'bg-gray-2' %>
-<% provide :footer_classes, 'bg-gray-2' %>
+<% provide :main_classes, 'bg-gray-0' %>
+<% provide :footer_classes, 'bg-gray-0' %>
 <% provide :head_tags do %>
   <%= javascript_include_tag 'practice_editor_utilities', 'data-turbolinks-track': 'reload' %>
   <%= javascript_tag 'data-turbolinks-track': 'reload' do %>
@@ -9,11 +9,11 @@
 
 <div class="grid-container position-relative">
   <div class="grid-row grid-gap">
-    <div id="about" class="grid-col-12">
+    <div id="about" class="grid-col-12 margin-top-4">
       <%= render partial: "shared/messages", locals: {small_text: false} %>
+      <%= render partial: "practices/shared/step_indicator" %>
       <section class="usa-section padding-top-0 padding-bottom-0 about">
-        <h1 class="font-sans-2xl line-height-46px margin-bottom-3">About</h1>
-        <%= render partial: "practices/form/practice_last_updated", locals: {small_text: true} %>
+        <h1 class="font-sans-2xl line-height-46px margin-bottom-3 margin-top-0">About</h1>
         <h2 class="text-normal line-height-36 font-sans-lg">
           This section helps people understand how your innovation started and introduces the original team.
         </h2>

--- a/app/views/practices/form/adoptions.html.erb
+++ b/app/views/practices/form/adoptions.html.erb
@@ -1,6 +1,5 @@
-<% provide :main_classes, 'bg-gray-2' %>
-<% provide :footer_classes, 'bg-gray-2' %>
-
+<% provide :main_classes, 'bg-gray-0' %>
+<% provide :footer_classes, 'bg-gray-0' %>
 <% provide :head_tags do %>
   <%= javascript_tag 'data-turbolinks-track': 'reload' do %>
     <%= render partial: 'practices/form/session_monitor', formats: [:js] %>
@@ -10,11 +9,11 @@
 
 <div class="grid-container">
   <div class="grid-row grid-gap">
-    <div id="dm-pe-adoptions" class="grid-col-12">
+    <div id="dm-pe-adoptions" class="grid-col-12 margin-top-4">
       <%= render partial: "shared/messages", locals: {small_text: false} %>
+      <%= render partial: "practices/shared/step_indicator" %>
       <section class="usa-section padding-top-0 padding-bottom-0">
-        <h1>Adoptions</h1>
-          <%= render partial: "practices/form/practice_last_updated", locals: {small_text: true} %>
+        <h1 class="margin-top-0">Adoptions</h1>
         <div class="usa-prose-intro">
           Share which facilities have successfully adopted your innovation. All adoptions roll up to the VAMC level. Aim to update this data quarterly.
         </div>

--- a/app/views/practices/form/contact.html.erb
+++ b/app/views/practices/form/contact.html.erb
@@ -1,6 +1,5 @@
-<% provide :main_classes, 'bg-gray-2' %>
-<% provide :footer_classes, 'bg-gray-2' %>
-
+<% provide :main_classes, 'bg-gray-0' %>
+<% provide :footer_classes, 'bg-gray-0' %>
 <% provide :head_tags do %>
   <%= javascript_include_tag 'practice_editor_utilities', 'data-turbolinks-track': 'reload' %>
   <%= javascript_tag 'data-turbolinks-track': 'reload' do %>
@@ -14,7 +13,6 @@
       <%= render partial: "shared/messages", locals: {small_text: false} %>
       <section class="usa-section padding-top-0 padding-bottom-0 contact">
         <h1 class="font-sans-2xl line-height-46px margin-bottom-3">Contact</h1>
-        <%= render partial: "practices/form/practice_last_updated", locals: {small_text: true} %>
         <h2 class="text-normal line-height-36 font-sans-lg">
           This section helps people to reach out for support, ask questions, and connect about your innovation.
         </h2>

--- a/app/views/practices/form/editors.html.erb
+++ b/app/views/practices/form/editors.html.erb
@@ -1,6 +1,5 @@
-<% provide :body_classes, 'bg-gray-2' %>
-<% provide :footer_classes, 'bg-gray-2' %>
-
+<% provide :main_classes, 'bg-gray-0' %>
+<% provide :footer_classes, 'bg-gray-0' %>
 <% provide :head_tags do %>
   <%= javascript_tag 'data-turbolinks-track': 'reload' do %>
     <%= render partial: 'editors', formats: [:js] %>
@@ -10,11 +9,11 @@
 
 <div class="grid-container">
   <div class="grid-row grid-gap">
-    <div id="editors" class="grid-col-12">
+    <div id="editors" class="grid-col-12 margin-top-4">
       <%= render partial: "shared/messages", locals: {small_text: false} %>
+      <%= render partial: "practices/shared/step_indicator" %>
       <section class="usa-section padding-top-0 padding-bottom-0 editors">
-        <h1 class="font-sans-2xl line-height-46px margin-bottom-3">Editors</h1>
-        <%= render partial: "practices/form/practice_last_updated", locals: {small_text: true} %>
+        <h1 class="font-sans-2xl line-height-46px margin-bottom-3 margin-top-0">Editors</h1>
         <% practice_editors = PracticeEditor.where(practice: @practice).order(created_at: :asc) %>
         <% practice_editors.each do |pe| %>
           <%

--- a/app/views/practices/form/implementation.html.erb
+++ b/app/views/practices/form/implementation.html.erb
@@ -1,5 +1,5 @@
-<% provide :main_classes, 'bg-gray-2' %>
-<% provide :footer_classes, 'bg-gray-2' %>
+<% provide :main_classes, 'bg-gray-0' %>
+<% provide :footer_classes, 'bg-gray-0' %>
 <% provide :head_tags do %>
   <%= javascript_include_tag 'practice_editor_utilities', 'data-turbolinks-track': 'reload' %>
   <%= javascript_include_tag 'practice_editor_timeline', 'data-turbolinks-track': 'reload' %>
@@ -12,11 +12,11 @@
 
 <div class="grid-container">
   <div class="grid-row grid-gap">
-    <div id="implementation" class="grid-col-12">
+    <div id="implementation" class="grid-col-12 margin-top-4">
       <%= render partial: "shared/messages", locals: {small_text: false} %>
+      <%= render partial: "practices/shared/step_indicator" %>
     <section class="usa-section padding-top-0 padding-bottom-0 implementation">
-      <h1 class="margin-bottom-3">Implementation</h1>
-      <%= render partial: "practices/form/practice_last_updated", locals: {small_text: true} %>
+      <h1 class="margin-bottom-3 margin-top-0">Implementation</h1>
       <h2 class="text-normal line-height-sans-6 font-sans-lg">
         Compile requirements and considerations to help another facility successfully implement your innovation.
       </h2>

--- a/app/views/practices/form/instructions.html.erb
+++ b/app/views/practices/form/instructions.html.erb
@@ -1,15 +1,11 @@
-<% provide :main_classes, 'bg-gray-2' %>
-<% provide :footer_classes, 'bg-gray-2' %>
-
+<% provide :main_classes, 'bg-gray-0' %>
+<% provide :footer_classes, 'bg-gray-0' %>
 <div class="grid-container position-relative">
     <div class="grid-row grid-gap">
-        <div class="desktop:grid-col-3 grid-col-auto z-bottom">&nbsp;</div>
-
-        <div id="instructions" class="desktop:grid-col-9 grid-col-12 padding-0">
+        <div id="instructions" class="grid-col-12 padding-0">
         <section class="margin-bottom-3">
           <%= render partial: "shared/messages", locals: {small_text: false} %>
           <h1 class="margin-bottom-3">Instructions</h1>
-          <%= render partial: "practices/form/practice_last_updated", locals: {small_text: true} %>
           <div class="usa-prose-intro">
             Please follow these instructions to build your innovation page. Your page is modular, meaning that most sections in the editor are optional and you can choose to fill out only the sections
             that make sense for your innovation.

--- a/app/views/practices/form/introduction.html.erb
+++ b/app/views/practices/form/introduction.html.erb
@@ -1,5 +1,5 @@
-<% provide :main_classes, 'bg-gray-2' %>
-<% provide :footer_classes, 'bg-gray-2' %>
+<% provide :main_classes, 'bg-gray-0' %>
+<% provide :footer_classes, 'bg-gray-0' %>
 <% provide :head_tags do %>
   <%= javascript_include_tag '_assign_facility_name', 'data-turbolinks-track': 'reload' %>
   <%= javascript_include_tag '_facilitySelect', 'data-turbolinks-track': 'reload' %>
@@ -36,11 +36,11 @@
 
 <div class="grid-container">
   <div class="grid-row grid-gap">
-    <div id="introduction" class="grid-col-12">
+    <div id="introduction" class="grid-col-12 margin-top-4">
       <%= render partial: "shared/messages", locals: {small_text: false} %>
+      <%= render partial: "practices/shared/step_indicator" %>
       <section class="usa-section padding-y-0 introduction">
-        <h1>Introduction</h1>
-        <%= render partial: "practices/form/practice_last_updated", locals: {small_text: true} %>
+        <h1 class="margin-top-0">Introduction</h1>
         <div class="usa-prose-intro">
           Introduce your innovation and provide a brief summary to people who may be unfamiliar with it.
         </div>

--- a/app/views/practices/form/metrics.html.erb
+++ b/app/views/practices/form/metrics.html.erb
@@ -1,6 +1,5 @@
-<% provide :main_classes, 'bg-gray-2' %>
-<% provide :footer_classes, 'bg-gray-2' %>
-
+<% provide :main_classes, 'bg-gray-0' %>
+<% provide :footer_classes, 'bg-gray-0' %>
 <% provide :head_tags do %>
   <%= javascript_include_tag 'metrics_page', 'data-turbolinks-track': 'reload' %>
   <%= javascript_include_tag 'practice_editor_utilities', 'data-turbolinks-track': 'reload' %>
@@ -13,10 +12,9 @@
 <div class="grid-container">
   <div class="grid-row grid-gap">
     <div id="metrics" class="grid-col-12">
-      <div>
       <%= render partial: "shared/messages", locals: {small_text: true} %>
     </div>
-      <section class="usa-section padding-top-0 padding-bottom-0" aria-label="Metrics">
+      <section class="usa-section padding-top-0 padding-bottom-0 margin-top-8 margin-top-128-desktop" aria-label="Metrics">
         <div class="grid-row flex-align-end margin-top--important">
           <h1 class="margin-bottom-3 margin-y-0 grid-col-3 font-sans-2xl">
             Metrics
@@ -28,7 +26,6 @@
               <span>Print</span>
             </a>
           </div>
-          <%= render partial: "practices/form/practice_last_updated", locals: {small_text: true} %>
         </div>
         <div class="margin-bottom-10 grid-row flex-align-center margin-top-3">
           <label for="metrics_duration" class="usa-label grid-col-3 margin-top-0">View your metrics for</label>

--- a/app/views/practices/form/overview.html.erb
+++ b/app/views/practices/form/overview.html.erb
@@ -1,5 +1,5 @@
-<% provide :main_classes, 'bg-gray-2' %>
-<% provide :footer_classes, 'bg-gray-2' %>
+<% provide :main_classes, 'bg-gray-0' %>
+<% provide :footer_classes, 'bg-gray-0' %>
 <% provide :head_tags do %>
   <%= javascript_include_tag 'practice_editor_utilities', 'data-turbolinks-track': 'reload' %>
   <%= javascript_include_tag 'practice_editor_overview', 'data-turbolinks-track': 'reload' %>
@@ -12,11 +12,11 @@
 
 <div class="grid-container position-relative">
   <div class="grid-row grid-gap">
-    <div id="overview" class="grid-col-12">
+    <div id="overview" class="grid-col-12 margin-top-4">
       <%= render partial: "shared/messages", locals: {small_text: false} %>
+      <%= render partial: "practices/shared/step_indicator" %>
       <section class="usa-section padding-top-0 padding-bottom-0 introduction">
-        <h1>Overview</h1>
-        <%= render partial: "practices/form/practice_last_updated", locals: {small_text: true} %>
+        <h1 class="margin-top-0">Overview</h1>
         <div class="usa-prose-intro">
           Describe the journey of your innovation from problem identification and the implementation of your solution
           through to measured results and outcomes.

--- a/app/views/practices/shared/_step_indicator.html.erb
+++ b/app/views/practices/shared/_step_indicator.html.erb
@@ -1,0 +1,40 @@
+<%
+  sessions = PracticeEditorSession.where(practice_id: @practice.id).where.not(session_end_time: nil)
+  session = sessions.present? ? sessions.last : nil
+%>
+<% if session.present? %>
+  <%
+    session_end_datetime = session.session_end_time
+    session_date = "#{session_end_datetime.strftime("%-m/%-d/%Y")}"
+    session_time = "#{session_end_datetime.strftime("%I:%M %p")} "
+    session_user = session.user
+    last_updated_text = "#{@practice.name} last updated on #{session_date} at #{session_time} by #{is_full_name_present(session_user) ? user_full_name(session_user) : session_user.email}"
+  %>
+  <div class="usa-prose-caption margin-bottom-1 text-base-dark">
+    <%= last_updated_text %>
+  </div>
+<% end %>
+<div class="usa-step-indicator" aria-label="progress">
+  <ol class="usa-step-indicator__segments">
+    <%
+      page_titles = ['editors', 'introduction', 'adoptions', 'overview', 'implementation', 'about']
+      action = params[:action]
+    %>
+    <% page_titles.each_with_index do |pt, i| %>
+      <% 
+        current_page_index = page_titles.index(action)
+        status = ''
+        if current_page_index > i
+          status = '--complete'
+        elsif current_page_index === i
+          status = '--current'
+        end
+      %>
+      <li class="usa-step-indicator__segment usa-step-indicator__segment<%= status %>">
+        <span class="usa-step-indicator__segment-label">
+          <%= link_to pt.capitalize, eval("practice_#{pt}_path(@practice)") %>
+        </span>
+      </li>
+    <% end %>
+  </ol>
+</div>

--- a/app/views/practices/show/show.html.erb
+++ b/app/views/practices/show/show.html.erb
@@ -1,7 +1,7 @@
 <% provide :head_tags do %>
   <%= javascript_include_tag 'practice_page', 'data-turbolinks-track': 'reload' %>
 <% end %>
-<section class="usa-section padding-y-0 margin-bottom-1">
+<section class="usa-section padding-y-0 margin-bottom-1 margin-top-0">
   <div class="grid-container position-relative">
     <div class="grid-row grid-gap">
       <div id="practice_show" class="grid-col-12 overview-section practice-section">

--- a/app/views/shared/_breadcrumbs.html.erb
+++ b/app/views/shared/_breadcrumbs.html.erb
@@ -6,7 +6,7 @@
   description = session[:description]
   breadcrumbs = original_breadcrumbs.dup
   # ensures breadcrumb isn't displayed if user is on that page
-  if breadcrumbs.size > 1 && controller != 'practices'
+  if breadcrumbs.size > 1
     last_breadcrumb = breadcrumbs.last
     last_breadcrumb_path = last_breadcrumb[:path] || last_breadcrumb['path']
     breadcrumbs.pop if last_breadcrumb_path === request.env['PATH_INFO']
@@ -18,22 +18,9 @@
 <section class="<%= "dm-gradient-banner" if heading.present? %>">
   <div class="grid-container <%= "padding-y-6" if heading.present? %>">
     <% if breadcrumbs.present? %>
-      <div id="breadcrumbs" class="grid-col-auto usa-breadcrumb breadcrumbs-container <%= heading.present? ? "dm-breadcrumb--gradient-bg padding-top-0 padding-bottom-105" : "padding-y-4" %>" aria-label="Breadcrumbs">
+      <div id="breadcrumbs" class="grid-col-auto usa-breadcrumb breadcrumbs-container <%= heading.present? ? "dm-breadcrumb--gradient-bg padding-top-0 padding-bottom-105" : 'padding-y-4' %>" aria-label="Breadcrumbs">
         <ol class="usa-breadcrumb__list<%= " text-white" if heading.present? %>">
-          <%# TODO: Consolidate this once practice breadcrumbs designs are finalized %>
-          <% if controller === 'practices' && (action === 'show' || breadcrumbs.any? { |b| b[:display] === "Edit"}) %>
-            <li class="usa-breadcrumb__list-item">
-              <a href="/" class="usa-breadcrumb__link">Home</a>
-            </li>
-            <% breadcrumbs.each_with_index do |b, i| %>
-              <% last_crumb = breadcrumbs.size - 1 == i %>
-              <% if !last_crumb %>
-                <%= render partial: 'shared/link_breadcrumb', locals: {breadcrumb: b} %>
-              <% else %>
-                <%= render partial: 'shared/text_breadcrumb', locals: {breadcrumb: b} %>
-              <% end %>
-            <% end %>
-          <% elsif breadcrumbs.size === 1 %>
+          <% if breadcrumbs.size === 1 %>
             <%
               current_path = request.env['PATH_INFO']
               is_same_path = breadcrumbs.first['path'] === current_path

--- a/spec/features/practice_editor/metrics_spec.rb
+++ b/spec/features/practice_editor/metrics_spec.rb
@@ -87,15 +87,6 @@ describe 'Metrics section', type: :feature, js: true do
       expect(page).to have_css('.rural-adoptions-count-last-30', text: '0')
       expect(page).to have_css('.urban-adoptions-count-last-30', text: '1')
     end
-
-    it 'should display last time innovation was updated.' do
-      login_as(@user1, :scope => :user, :run_callbacks => false)
-      PracticeEditorSession.create(user_id: @user1.id, practice_id: @practice.id, session_start_time: DateTime.now, session_end_time: DateTime.now, created_at: DateTime.now, updated_at: DateTime.now)
-      visit practice_metrics_path(@practice)
-      expect(page).to have_content('Innovation last updated on')
-      space = " "
-      expect(page).to have_content("#{@user1.first_name}#{space}#{@user1.last_name}")
-    end
   end
 
   describe 'Bookmark counts' do

--- a/spec/features/practice_editor/step_indicator_spec.rb
+++ b/spec/features/practice_editor/step_indicator_spec.rb
@@ -1,0 +1,142 @@
+require 'rails_helper'
+
+describe 'Practice editor', type: :feature, js: true do
+  before do
+    @admin = User.create!(email: 'toshiro.hitsugaya@va.gov', first_name: 'Foo', last_name: 'Bar', password: 'Password123', password_confirmation: 'Password123', skip_va_validation: true, confirmed_at: Time.now, accepted_terms: true)
+    @practice = Practice.create!(name: 'A public practice', slug: 'a-public-practice', approved: true, published: true, tagline: 'Test tagline', user: @admin)
+    @admin.add_role(User::USER_ROLES[0].to_sym)
+    @end_time = DateTime.new(2015, 1, 1, 11, 0, 0)
+    PracticeEditorSession.create(user_id: @admin.id, practice_id: @practice.id, session_start_time: DateTime.now, session_end_time: @end_time, created_at: DateTime.now, updated_at: DateTime.now)
+    page.driver.browser.manage.window.resize_to(1200, 600) # need to set this otherwise mobile version of editor displays
+  end
+
+  describe 'Step indicator' do
+    before do
+      login_as(@admin, :scope => :user, :run_callbacks => false)
+      visit practice_path(@practice)
+      expect(page).to be_accessible.according_to :wcag2a, :section508
+    end
+
+    it 'should display the step indicator on each page' do
+      session_date = "#{@end_time.strftime("%-m/%-d/%Y")}"
+      session_time = "#{@end_time.strftime("%I:%M %p")}"
+      last_updated_txt = "#{@practice.name} last updated on #{session_date} at #{session_time} by #{@admin.first_name} #{@admin.last_name}"
+
+      # editors
+      visit practice_editors_path(@practice)
+      expect(page).to have_content(last_updated_txt)
+      within(:css, '.usa-step-indicator') do
+        expect(page).to have_link(href: practice_editors_path(@practice))
+        expect(page).to have_link(href: practice_introduction_path(@practice))
+        expect(page).to have_link(href: practice_adoptions_path(@practice))
+        expect(page).to have_link(href: practice_overview_path(@practice))
+        expect(page).to have_link(href: practice_implementation_path(@practice))
+        expect(page).to have_link(href: practice_about_path(@practice))
+        segments = find_all('.usa-step-indicator__segment')
+        editors_segment = segments.first
+        editors_segment.has_css?('.usa-step-indicator__segment--current')
+        expect(editors_segment).to have_content('Editors')
+        introduction_segment = segments[1]
+        introduction_segment.has_css?('.usa-step-indicator__segment')
+      end
+
+      # introduction
+      visit practice_introduction_path(@practice)
+      expect(page).to have_content(last_updated_txt)
+      within(:css, '.usa-step-indicator') do
+        expect(page).to have_link(href: practice_editors_path(@practice))
+        expect(page).to have_link(href: practice_introduction_path(@practice))
+        expect(page).to have_link(href: practice_adoptions_path(@practice))
+        expect(page).to have_link(href: practice_overview_path(@practice))
+        expect(page).to have_link(href: practice_implementation_path(@practice))
+        expect(page).to have_link(href: practice_about_path(@practice))
+        segments = find_all('.usa-step-indicator__segment')
+        editors_segment = segments.first
+        editors_segment.has_css?('.usa-step-indicator__segment--complete')
+        introduction_segment = segments[1]
+        introduction_segment.has_css?('.usa-step-indicator__segment--current')
+        expect(introduction_segment).to have_content('Introduction')
+        adoptions_segment = segments[2]
+        adoptions_segment.has_css?('.usa-step-indicator__segment')
+      end
+
+      # adoptions
+      visit practice_adoptions_path(@practice)
+      expect(page).to have_content(last_updated_txt)
+      within(:css, '.usa-step-indicator') do
+        expect(page).to have_link(href: practice_editors_path(@practice))
+        expect(page).to have_link(href: practice_introduction_path(@practice))
+        expect(page).to have_link(href: practice_adoptions_path(@practice))
+        expect(page).to have_link(href: practice_overview_path(@practice))
+        expect(page).to have_link(href: practice_implementation_path(@practice))
+        expect(page).to have_link(href: practice_about_path(@practice))
+        segments = find_all('.usa-step-indicator__segment')
+        introduction_segment = segments[1]
+        introduction_segment.has_css?('.usa-step-indicator__segment--complete')
+        adoptions_segment = segments[2]
+        adoptions_segment.has_css?('.usa-step-indicator__segment--current')
+        expect(adoptions_segment).to have_content('Adoptions')
+        overview_segment = segments[3]
+        overview_segment.has_css?('.usa-step-indicator__segment')
+      end
+
+      # overview
+      visit practice_overview_path(@practice)
+      expect(page).to have_content(last_updated_txt)
+      within(:css, '.usa-step-indicator') do
+        expect(page).to have_link(href: practice_editors_path(@practice))
+        expect(page).to have_link(href: practice_introduction_path(@practice))
+        expect(page).to have_link(href: practice_adoptions_path(@practice))
+        expect(page).to have_link(href: practice_overview_path(@practice))
+        expect(page).to have_link(href: practice_implementation_path(@practice))
+        expect(page).to have_link(href: practice_about_path(@practice))
+        segments = find_all('.usa-step-indicator__segment')
+        adoptions_segment = segments[2]
+        adoptions_segment.has_css?('.usa-step-indicator__segment--complete')
+        overview_segment = segments[3]
+        overview_segment.has_css?('.usa-step-indicator__segment--current')
+        expect(overview_segment).to have_content('Overview')
+        implementation_segment = segments[3]
+        implementation_segment.has_css?('.usa-step-indicator__segment')
+      end
+
+      # implementation
+      visit practice_implementation_path(@practice)
+      expect(page).to have_content(last_updated_txt)
+      within(:css, '.usa-step-indicator') do
+        expect(page).to have_link(href: practice_editors_path(@practice))
+        expect(page).to have_link(href: practice_introduction_path(@practice))
+        expect(page).to have_link(href: practice_adoptions_path(@practice))
+        expect(page).to have_link(href: practice_overview_path(@practice))
+        expect(page).to have_link(href: practice_implementation_path(@practice))
+        expect(page).to have_link(href: practice_about_path(@practice))
+        segments = find_all('.usa-step-indicator__segment')
+        overview_segment = segments[3]
+        overview_segment.has_css?('.usa-step-indicator__segment--complete')
+        implementation_segment = segments[4]
+        implementation_segment.has_css?('.usa-step-indicator__segment--current')
+        expect(implementation_segment).to have_content('Implementation')
+        about_segment = segments[5]
+        about_segment.has_css?('.usa-step-indicator__segment')
+      end
+
+      # about
+      visit practice_about_path(@practice)
+      expect(page).to have_content(last_updated_txt)
+      within(:css, '.usa-step-indicator') do
+        expect(page).to have_link(href: practice_editors_path(@practice))
+        expect(page).to have_link(href: practice_introduction_path(@practice))
+        expect(page).to have_link(href: practice_adoptions_path(@practice))
+        expect(page).to have_link(href: practice_overview_path(@practice))
+        expect(page).to have_link(href: practice_implementation_path(@practice))
+        expect(page).to have_link(href: practice_about_path(@practice))
+        segments = find_all('.usa-step-indicator__segment')
+        implementation_segment = segments[4]
+        implementation_segment.has_css?('.usa-step-indicator__segment--complete')
+        about_segment = segments[5]
+        about_segment.has_css?('.usa-step-indicator__segment--current')
+        expect(about_segment).to have_content('About')
+      end
+    end
+  end
+end

--- a/spec/features/shared/breadcrumbs_spec.rb
+++ b/spec/features/shared/breadcrumbs_spec.rb
@@ -124,8 +124,9 @@ describe 'Breadcrumbs', type: :feature do
       click_link('View innovation')
       expect(page).to have_css("#pr-view-introduction", visible: true)
       within(:css, '#breadcrumbs') do
+        expect(page).to have_css('.fa-arrow-left')
         expect(page).to have_content('Home')
-        expect(page).to have_content('Another Best Innovation')
+        expect(page).to have_no_content('Another Best Innovation')
         expect(page).to have_link(href: '/')
         expect(page).to_not have_link(href: '/innovations/another-best-innovation')
       end
@@ -142,11 +143,10 @@ describe 'Breadcrumbs', type: :feature do
       click_on('Go to The Best Innovation Ever')
       expect(page).to have_css("#pr-view-introduction", visible: true)
       within(:css, '#breadcrumbs') do
-        expect(page).to have_content('Home')
+        expect(page).to have_css('.fa-arrow-left')
         expect(page).to have_content('Search')
-        expect(page).to have_content('The Best Innovation Ever')
-        expect(page).to have_link(href: '/')
-        expect(page).to_not have_link(href: '/innovations/the-best-innovation-ever')
+        expect(page).to have_no_content('The Best Innovation Ever')
+        expect(page).to have_link(href: '/search?query=the%20best')
       end
 
       find('a[href="/search?query=the%20best"]').click
@@ -209,11 +209,9 @@ describe 'Breadcrumbs', type: :feature do
       expect(page).to have_css("#pr-view-introduction", visible: true)
       expect(page).to have_current_path(practice_path(@user_practice))
       within(:css, '#breadcrumbs') do
-        expect(page).to have_content('Home')
         expect(page).to have_content('VISN index')
         expect(page).to have_content('2')
-        expect(page).to have_content('The Best Innovation Ever')
-        expect(page).to have_link(href: '/')
+        expect(page).to have_no_content('The Best Innovation Ever')
         expect(page).to have_link(href: '/visns')
         expect(page).to have_link(href: '/visns/2?query=best')
         expect(page).to_not have_link(href: '/innovations/the-best-innovation-ever')
@@ -235,11 +233,9 @@ describe 'Breadcrumbs', type: :feature do
       find('a[href="/innovations/the-best-innovation-ever"]').click
       expect(page).to have_css("#pr-view-introduction", visible: true)
       within(:css, '#breadcrumbs') do
-        expect(page).to have_content('Home')
         expect(page).to have_content('Facility index')
         expect(page).to have_content('A first facility Test Common Name')
-        expect(page).to have_content('The Best Innovation Ever')
-        expect(page).to have_link(href: '/')
+        expect(page).to have_no_content('The Best Innovation Ever')
         expect(page).to have_link(href: '/facilities')
         expect(page).to have_link(href: '/facilities/a-first-facility-test-common-name')
         expect(page).to_not have_link(href: '/innovations/the-best-innovation-ever')
@@ -253,8 +249,9 @@ describe 'Breadcrumbs', type: :feature do
       visit practice_path(@user_practice)
 
       within(:css, '#breadcrumbs') do
+        expect(page).to have_css('.fa-arrow-left')
         expect(page).to have_content('Home')
-        expect(page).to have_content('The Best Innovation Ever')
+        expect(page).to have_no_content('The Best Innovation Ever')
       end
     end
 
@@ -262,17 +259,18 @@ describe 'Breadcrumbs', type: :feature do
       visit practice_path(@user_practice)
 
       within(:css, '#breadcrumbs') do
+        expect(page).to have_css('.fa-arrow-left')
         expect(page).to have_content('Home')
-        expect(page).to have_content('The Best Innovation Ever')
+        expect(page).to have_no_content('The Best Innovation Ever')
       end
 
       # Browse to a different practice's show page
       visit practice_path(@user_practice2)
 
       within(:css, '#breadcrumbs') do
+        expect(page).to have_css('.fa-arrow-left')
         expect(page).to have_content('Home')
-        expect(page).to_not have_content('The Best Innovation Ever')
-        expect(page).to have_content('Another Best Innovation')
+        expect(page).to have_no_content('Best Innovation')
       end
     end
   end


### PR DESCRIPTION
### JIRA issue link
[DM-3138](https://agile6.atlassian.net/browse/DM-3138)

## Description - what does this code do?
This PR addresses the following:
- adds the step indicator to the innovation editor pages
- removes breadcrumbs from innovation editor pages

## Testing done - how did you test it/steps on how can another person can test it 

1. Log in as a user that can edit an innovation
2. Go to the editor pages of an innovation
3. Ensure the "last updated..." text matches the format in [Figma](https://www.figma.com/file/ccwLbt94U9QGfnuFCwOXzY/VA-Diffusion-Marketplace---Final-Designs?node-id=680%3A1021)
4. Ensure the step indicator designs matches the format in [Figma](https://www.figma.com/file/ccwLbt94U9QGfnuFCwOXzY/VA-Diffusion-Marketplace---Final-Designs?node-id=680%3A1021)
Note: The metrics page needs to be updated. This will be done in a separate story.

## Screenshots, Gifs, Videos from application (if applicable)

<img width="998" alt="Screen Shot 2022-02-08 at 12 00 01 PM" src="https://user-images.githubusercontent.com/20211771/153047845-7c5ca6c4-32c5-4079-8371-438dbc6da343.png">

## Link to mock-ups/mock ups (image file if you have it) (if applicable)
[Figma](https://www.figma.com/file/ccwLbt94U9QGfnuFCwOXzY/VA-Diffusion-Marketplace---Final-Designs?node-id=680%3A1021)

## Acceptance criteria
- [X] Add Progress bar
- [X] remove breadcrumbs on editor pages


## Definition of done
- [ ] Unit tests written (if applicable)
- [X] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [X] A link has been provided to the originating JIRA issue
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs