### PR TITLE
Dm 3112

### DIFF
--- a/app/assets/stylesheets/dm/pages/_search.scss
+++ b/app/assets/stylesheets/dm/pages/_search.scss
@@ -12,7 +12,7 @@
     top: 2.1em !important;
   }
 
-  .usa-combo-box__list-option:not([data-value*="VISN"]) {
+  .usa-combo-box__list-option:not([data-value*="VISN-id"]) {
     padding-left: 24px !important;
   }
 

--- a/app/controllers/clinical_resource_hubs_controller.rb
+++ b/app/controllers/clinical_resource_hubs_controller.rb
@@ -6,7 +6,7 @@ class ClinicalResourceHubsController < ApplicationController
 
   private
   def set_crh
-    @visn = Visn.find_by!(number: params[:id])
+    @visn = Visn.find_by!(number: params[:number])
     @crh = ClinicalResourceHub.find_by!(visn: @visn) if @visn.present?
   end
 end

--- a/app/controllers/clinical_resource_hubs_controller.rb
+++ b/app/controllers/clinical_resource_hubs_controller.rb
@@ -6,7 +6,7 @@ class ClinicalResourceHubsController < ApplicationController
 
   private
   def set_crh
-    @visn = Visn.find_by!(number: params[:number])
+    @visn = params[:id].present? ? Visn.find_by!(number: params[:id]) : Visn.find_by!(number: params[:number])
     @crh = ClinicalResourceHub.find_by!(visn: @visn) if @visn.present?
   end
 end

--- a/app/controllers/practices_controller.rb
+++ b/app/controllers/practices_controller.rb
@@ -158,7 +158,7 @@ class PracticesController < ApplicationController
   end
 
   def search
-    @clinical_resource_hubs = ClinicalResourceHub.all
+    @clinical_resource_hubs = ClinicalResourceHub.cached_clinical_resource_hubs
     # combine the va_facilities query with the CRH query, sort them by 'official_station_name', group them by their VISN's number, and then sort by VISN number
     @visn_grouped_facilities = (@va_facilities.includes(:visn) + @clinical_resource_hubs.includes([:visn])).sort_by(&:official_station_name.downcase).group_by { |f| f.visn.number }.sort_by { |vgf| vgf[0] }
     @practices = helpers.is_user_a_guest? ? Practice.searchable_public_practices : Practice.searchable_practices

--- a/app/controllers/practices_controller.rb
+++ b/app/controllers/practices_controller.rb
@@ -158,7 +158,9 @@ class PracticesController < ApplicationController
   end
 
   def search
-    @visn_grouped_facilities = @va_facilities.includes([:visn]).group_by { |f| f.visn.number }.sort_by { |vgf| vgf[0] }
+    @clinical_resource_hubs = ClinicalResourceHub.all
+    # combine the va_facilities query with the CRH query, sort them by 'official_station_name', group them by their VISN's number, and then sort by VISN number
+    @visn_grouped_facilities = (@va_facilities.includes(:visn) + @clinical_resource_hubs.includes([:visn])).sort_by(&:official_station_name.downcase).group_by { |f| f.visn.number }.sort_by { |vgf| vgf[0] }
     @practices = helpers.is_user_a_guest? ? Practice.searchable_public_practices : Practice.searchable_practices
     # due to some practices/search.js.erb functions being reused for other pages (VISNs/VA Facilities), set the @practices_json variable to nil unless it's being used for the practices/search page
     @practices_json = cached_json_practices

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -103,13 +103,14 @@ module ApplicationHelper
     if practice.initiating_facility_type?
       if practice.facility? && practice.practice_origin_facilities.present?
         fac_type = Practice.initiating_facility_types[practice.initiating_facility_type]
-        locs = practice.practice_origin_facilities.where(facility_type: fac_type)
+        locs = practice.practice_origin_facilities.includes(:va_facility, :clinical_resource_hub).where(facility_type: fac_type)
         facility_names = String.new
         locs.each_with_index do |loc, index|
-          official_station_name = loc.va_facility.official_station_name
-          common_name = loc.va_facility.common_name
+          has_va_facility = loc.va_facility.present?
+          official_station_name = has_va_facility ? loc.va_facility.official_station_name : loc.clinical_resource_hub.official_station_name
+          common_name = loc.va_facility.common_name if has_va_facility
 
-          facility_names += "#{facility_name_with_common_name(official_station_name, common_name) if loc.va_facility_id.present?}#{', ' if locs.size != index + 1 && locs.size > 1}"
+          facility_names += "#{has_va_facility ? facility_name_with_common_name(official_station_name, common_name) : official_station_name}#{', ' if locs.size != index + 1 && locs.size > 1}"
         end
         facility_names
       elsif practice.initiating_facility?

--- a/app/models/clinical_resource_hub.rb
+++ b/app/models/clinical_resource_hub.rb
@@ -1,6 +1,7 @@
 class ClinicalResourceHub < ApplicationRecord
   belongs_to :visn
-  has_many :diffusion_histories
+  has_many :diffusion_histories, dependent: :destroy
+  has_many :practice_origin_facilities, dependent: :destroy
 
   def to_param
     visn.number.to_s

--- a/app/models/clinical_resource_hub.rb
+++ b/app/models/clinical_resource_hub.rb
@@ -3,7 +3,38 @@ class ClinicalResourceHub < ApplicationRecord
   has_many :diffusion_histories, dependent: :destroy
   has_many :practice_origin_facilities, dependent: :destroy
 
+  before_save :clear_clinical_resource_hubs_cache_on_save
+  before_destroy :clear_clinical_resource_hubs_cache_on_destroy
+  after_save :reset_clinical_resource_hubs_cache
+  after_destroy :reset_clinical_resource_hubs_cache
+
+  attr_accessor :reset_cached_clinical_resource_hubs
+
   def to_param
     visn.number.to_s
+  end
+
+  def clear_clinical_resource_hubs_cache
+    Rails.cache.delete('clinical_resource_hubs')
+  end
+
+  def reset_clinical_resource_hubs_cache
+    clear_clinical_resource_hubs_cache if self.reset_cached_clinical_resource_hubs
+  end
+
+  def clear_clinical_resource_hubs_cache_on_save
+    if self.changed?
+      self.reset_cached_clinical_resource_hubs = true
+    end
+  end
+
+  def clear_clinical_resource_hubs_cache_on_destroy
+    self.reset_cached_clinical_resource_hubs = true
+  end
+
+  def self.cached_clinical_resource_hubs
+    Rails.cache.fetch('clinical_resource_hubs') do
+      ClinicalResourceHub.all
+    end
   end
 end

--- a/app/models/concerns/diffusion_history_validator.rb
+++ b/app/models/concerns/diffusion_history_validator.rb
@@ -1,9 +1,12 @@
 class DiffusionHistoryValidator < ActiveModel::Validator
   def validate(record)
     is_valid = record.va_facility_id.present? || record.clinical_resource_hub_id.present?
+    has_multiple_relationships = (record.va_facility_id.present? && record.clinical_resource_hub_id.present?) || (record.va_facility_id.present? && record.clinical_resource_hub_id.present?)
     begin
-      unless is_valid
-        raise StandardError.new 'No facility or CRH present'
+      if !is_valid
+        raise StandardError.new 'Error! A DiffusionHistory must belong to either a VaFacility or a ClinicalResourceHub.'
+      elsif has_multiple_relationships
+        raise StandardError.new 'Error! A DiffusionHistory can belong to either a VaFacility or a ClinicalResourceHub, but not both.'
       end
     rescue => e
       record.errors.add(:url, e.message)

--- a/app/models/concerns/practice_origin_facility_validator.rb
+++ b/app/models/concerns/practice_origin_facility_validator.rb
@@ -1,9 +1,12 @@
 class PracticeOriginFacilityValidator < ActiveModel::Validator
   def validate(record)
-    is_valid = (record.va_facility_id.present? && record.clinical_resource_hub_id.nil?) || (record.va_facility_id.nil? && record.clinical_resource_hub_id.present?)
+    is_valid = record.va_facility_id.present? || record.clinical_resource_hub_id.present?
+    has_multiple_relationships = (record.va_facility_id.present? && record.clinical_resource_hub_id.present?) || (record.va_facility_id.present? && record.clinical_resource_hub_id.present?)
     begin
-      unless is_valid
-        raise StandardError.new 'Error! A practice_origin_facility can be associated with either a va_facility or a clinical_resource_hub, but not both.'
+      if !is_valid
+        raise StandardError.new 'Error! A DiffusionHistory must belong to either a VaFacility or a ClinicalResourceHub.'
+      elsif has_multiple_relationships
+        raise StandardError.new 'Error! A PracticeOriginFacility can belong to either a VaFacility or a ClinicalResourceHub, but not both.'
       end
     rescue => e
       record.errors.add(:url, e.message)

--- a/app/models/concerns/practice_origin_facility_validator.rb
+++ b/app/models/concerns/practice_origin_facility_validator.rb
@@ -1,0 +1,12 @@
+class PracticeOriginFacilityValidator < ActiveModel::Validator
+  def validate(record)
+    is_valid = (record.va_facility_id.present? && record.clinical_resource_hub_id.nil?) || (record.va_facility_id.nil? && record.clinical_resource_hub_id.present?)
+    begin
+      unless is_valid
+        raise StandardError.new 'Error! A practice_origin_facility can be associated with either a va_facility or a clinical_resource_hub, but not both.'
+      end
+    rescue => e
+      record.errors.add(:url, e.message)
+    end
+  end
+end

--- a/app/models/diffusion_history.rb
+++ b/app/models/diffusion_history.rb
@@ -4,7 +4,7 @@ class DiffusionHistory < ApplicationRecord
   belongs_to :clinical_resource_hub, optional: true
 
 
-  validates_with DiffusionHistoryValidator, on: [:create, :update] #check CRH exists or facility exists
+  validates_with DiffusionHistoryValidator, on: [:create, :update] # check CRH exists or facility exists
 
 
   has_many :diffusion_history_statuses, dependent: :destroy
@@ -22,6 +22,4 @@ class DiffusionHistory < ApplicationRecord
   def clear_searchable_practices_cache
     practice.clear_searchable_cache
   end
-
-
 end

--- a/app/models/practice_origin_facility.rb
+++ b/app/models/practice_origin_facility.rb
@@ -1,4 +1,16 @@
 class PracticeOriginFacility <  ApplicationRecord
+  include ActiveModel::Dirty
+
   belongs_to :practice
-  belongs_to :va_facility
+  belongs_to :va_facility, optional: true
+  belongs_to :clinical_resource_hub, optional: true
+
+  after_save :clear_searchable_practices_cache
+  after_destroy :clear_searchable_practices_cache
+
+  validates_with PracticeOriginFacilityValidator, on: [:create, :update] # make sure only one of the optional foreign keys is populated at any given time, either va_facility or clinical_resource_hub
+
+  def clear_searchable_practices_cache
+    practice.clear_searchable_cache
+  end
 end

--- a/app/models/va_facility.rb
+++ b/app/models/va_facility.rb
@@ -2,7 +2,8 @@ class VaFacility < ApplicationRecord
   extend FriendlyId
   friendly_id :common_name, use: :slugged
   belongs_to :visn
-  has_many :diffusion_histories
+  has_many :diffusion_histories, dependent: :destroy
+  has_many :practice_origin_facilities, dependent: :destroy
   before_save :clear_va_facility_cache_on_save
   after_save :reset_va_facility_cache
 

--- a/app/views/practices/_search.js.erb
+++ b/app/views/practices/_search.js.erb
@@ -1,7 +1,7 @@
 // only initialize the following variables while on the search page
 if (window.location.pathname === '/search') {
     var practices = <%= @practices_json %>;
-    var facilities = <%= raw @va_facilities.to_json %>;
+    var facilities = <%= raw (@va_facilities + @clinical_resource_hubs).to_json %>;
     var visns = <%= raw @visns.to_json %>;
     var adoptions = <%= raw @diffusion_histories.to_json %>;
     var results = null;
@@ -322,7 +322,7 @@ function searchPracticesPage() {
 
         var originFacilityArray = originatingFacility ? [] : null;
 
-        if (originatingFacility && originatingFacility.includes('VISN')) {
+        if (originatingFacility && originatingFacility.includes('VISN-')) {
             // Collect any practice that either has the selected VISN as an origin facility, or has an origin facility that belongs to the selected VISN
 
             // Add the VISN to the array
@@ -334,15 +334,23 @@ function searchPracticesPage() {
 
             // Now add the facilities
             visnFacilities.forEach(function(vf) {
-                originFacilityArray.push({'origin_facilities': "=\"" + vf.station_number + "\""});
+                if (vf.hasOwnProperty('station_number')) {
+                    originFacilityArray.push({'origin_facilities': "=\"" + vf.station_number + "\""});
+                } else {
+                    originFacilityArray.push({'origin_facilities': "=\"" + vf.official_station_name + "\""});
+                }
             });
-        } else if (originatingFacility && !originatingFacility.includes('VISN')){
+        } else if (originatingFacility && !originatingFacility.includes('VISN-')){
             // Collect the practices that have an origin facility matching the selected facility
             var foundOriginatingFacility = facilities.find(function(f) {
-                return originatingFacility === f.station_number;
+                if (f.hasOwnProperty('station_number')) {
+                    return originatingFacility === f.station_number;
+                } else {
+                    return originatingFacility === f.official_station_name;
+                }
             });
 
-            originFacilityArray.push({'origin_facilities': "=\"" + foundOriginatingFacility.station_number + "\""});
+            originFacilityArray.push({'origin_facilities': "=\"" + (foundOriginatingFacility.hasOwnProperty('station_number') ? foundOriginatingFacility.station_number : foundOriginatingFacility.official_station_name) + "\""});
         }
 
         function getAdoptionFacilities(stationNumbers, facilityIds) {

--- a/app/views/practices/_search.js.erb
+++ b/app/views/practices/_search.js.erb
@@ -67,7 +67,11 @@ function getVisn(visnsArray, facility) {
 
 function getVaFacility(facilitiesArray, facility) {
     return facilitiesArray.find(function(f) {
-        return facility === f.station_number;
+        if (f.station_number) {
+            return facility === f.station_number;
+        } else {
+            return facility === f.official_station_name;
+        }
     });
 }
 
@@ -356,10 +360,13 @@ function searchPracticesPage() {
         function getAdoptionFacilities(stationNumbers, facilityIds) {
             adoptions.forEach(function(a) {
                 stationNumbers.forEach(function(sn) {
-                    if (a.facility_number === sn) {
-                        return facilityIds.push({'adoption_facilities': "=\"" + sn + "\""});
+                    if (a.va_facility_number && a.va_facility_number === sn) {
+                        facilityIds.push({'adoption_facilities': "=\"" + sn + "\""});
+                    } else if (a.clinical_resource_hub_name && a.clinical_resource_hub_name === sn) {
+                        facilityIds.push({'adoption_facilities': "=\"" + sn + "\""});
                     }
                 });
+                return facilityIds;
             });
         }
 
@@ -367,22 +374,26 @@ function searchPracticesPage() {
             var filteredFacilities;
             var stationNumbers = [];
             var adoptionFacilityArray = [];
-            if (adoptingFacility.includes('VISN')) {
+            if (adoptingFacility.includes('VISN-')) {
                 var adoptingFacilityVisn = getVisn(visns, adoptingFacility);
 
                 // Collect any practice that has a diffusion history with a facility that belongs to the selected VISN
                 filteredFacilities = getVaFacilitiesByVisn(facilities, adoptingFacilityVisn)
 
                 filteredFacilities.forEach(function(ff) {
-                    stationNumbers.push(ff.station_number);
-                })
+                    if (ff.station_number) {
+                        stationNumbers.push(ff.station_number);
+                    } else {
+                        stationNumbers.push(ff.official_station_name);
+                    }
+                });
 
                 getAdoptionFacilities(stationNumbers, adoptionFacilityArray);
             } else {
                 // Collect any practice that has a diffusion history with a facility that matches the selected facility
-                var foundAdoptingFacility = getVaFacility(facilities, adoptingFacility)
+                var foundAdoptingFacility = getVaFacility(facilities, adoptingFacility);
 
-                stationNumbers.push(foundAdoptingFacility.station_number);
+                foundAdoptingFacility.station_number ? stationNumbers.push(foundAdoptingFacility.station_number) : stationNumbers.push(foundAdoptingFacility.official_station_name)
                 getAdoptionFacilities(stationNumbers, adoptionFacilityArray);
             }
         }

--- a/app/views/practices/search_partials/_visn_facility_combo_box.html.erb
+++ b/app/views/practices/search_partials/_visn_facility_combo_box.html.erb
@@ -11,10 +11,10 @@
       <option value="VISN-id-<%= i + 1 %>">
         VISN-<%= visn_number %>
       </option>
-      <%# now that the facilities are grouped by VISN, sort them by OfficialStationName %>
-      <% group_array[1].sort_by { |facility| facility.official_station_name }.each do |f| %>
-        <option class="margin-left-1" value="<%= f.station_number %>">
-          <%= facility_name_with_common_name(f.official_station_name, f.common_name) %>
+
+      <% group_array[1].each do |f| %>
+        <option class="margin-left-1" value="<%= f.has_attribute?('station_number') ? f.station_number : f.official_station_name %>">
+          <%= f.official_station_name.include?('VISN') ? f.official_station_name : facility_name_with_common_name(f.official_station_name, f.common_name) %>
         </option>
       <% end %>
     <% end %>

--- a/app/views/practices/show/introduction/_origin_facility_text.html.erb
+++ b/app/views/practices/show/introduction/_origin_facility_text.html.erb
@@ -9,8 +9,13 @@
   <span class="origin-facilities-display-text">
     <% origin_facilities.each_with_index do |pof, index| %>
       <% facility = pof.va_facility %>
-      <%= link_to "#{facility_name_with_common_name(facility.official_station_name, facility.common_name)}", va_facility_path(pof.va_facility), class: "usa-link",
+      <% if facility.present? %>
+        <%= link_to "#{facility_name_with_common_name(facility.official_station_name, facility.common_name)}", va_facility_path(pof.va_facility), class: "usa-link",
           target: '_blank' %><%= ', ' unless index + 1 === origin_facilities_count %>
+      <% else %>
+        <%= link_to "#{pof.clinical_resource_hub.official_station_name}", clinical_resource_hub_path(pof.clinical_resource_hub), class: "usa-link",
+                    target: '_blank' %><%= ', ' unless index + 1 === origin_facilities_count %>
+      <% end %>
     <% end %>
   </span>
 <% elsif @practice.visn? %>

--- a/db/migrate/20220111151820_create_clinical_resource_hubs.rb
+++ b/db/migrate/20220111151820_create_clinical_resource_hubs.rb
@@ -2,7 +2,7 @@ class CreateClinicalResourceHubs < ActiveRecord::Migration[5.2]
   def change
     create_table :clinical_resource_hubs do |t|
       t.belongs_to :visn, foreign_key: true
-      t.string :name
+      t.string :official_station_name
       t.timestamps
     end
   end

--- a/db/migrate/20220112155536_add_clinical_resource_hub_foreign_key_to_diffusion_histories.rb
+++ b/db/migrate/20220112155536_add_clinical_resource_hub_foreign_key_to_diffusion_histories.rb
@@ -1,5 +1,0 @@
-class AddClinicalResourceHubForeignKeyToDiffusionHistories < ActiveRecord::Migration[5.2]
-  def change
-    add_reference :diffusion_histories, :clinical_resource_hub, foreign_key: true
-  end
-end

--- a/db/migrate/20220112155536_add_clinical_resource_hub_foreign_key_to_diffusion_histories_and_practice_origin_facilities.rb
+++ b/db/migrate/20220112155536_add_clinical_resource_hub_foreign_key_to_diffusion_histories_and_practice_origin_facilities.rb
@@ -1,0 +1,6 @@
+class AddClinicalResourceHubForeignKeyToDiffusionHistoriesAndPracticeOriginFacilities < ActiveRecord::Migration[5.2]
+  def change
+    add_reference :diffusion_histories, :clinical_resource_hub, foreign_key: true
+    add_reference :practice_origin_facilities, :clinical_resource_hub, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -236,7 +236,7 @@ ActiveRecord::Schema.define(version: 2022_01_12_155536) do
 
   create_table "clinical_resource_hubs", force: :cascade do |t|
     t.bigint "visn_id"
-    t.string "name"
+    t.string "official_station_name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["visn_id"], name: "index_clinical_resource_hubs_on_visn_id"
@@ -767,6 +767,8 @@ ActiveRecord::Schema.define(version: 2022_01_12_155536) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "va_facility_id"
+    t.bigint "clinical_resource_hub_id"
+    t.index ["clinical_resource_hub_id"], name: "index_practice_origin_facilities_on_clinical_resource_hub_id"
     t.index ["practice_id"], name: "index_practice_origin_facilities_on_practice_id"
     t.index ["va_facility_id"], name: "index_practice_origin_facilities_on_va_facility_id"
   end
@@ -1410,6 +1412,7 @@ ActiveRecord::Schema.define(version: 2022_01_12_155536) do
   add_foreign_key "practice_management_practices", "practices"
   add_foreign_key "practice_metrics", "practices"
   add_foreign_key "practice_multimedia", "practices"
+  add_foreign_key "practice_origin_facilities", "clinical_resource_hubs"
   add_foreign_key "practice_origin_facilities", "practices"
   add_foreign_key "practice_origin_facilities", "va_facilities"
   add_foreign_key "practice_partner_practices", "practice_partners"

--- a/lib/modules/practice_utils.rb
+++ b/lib/modules/practice_utils.rb
@@ -27,12 +27,12 @@ module PracticeUtils
       practice_hash['retired'] = practice.retired
       practice_hash['initiating_facility_name'] = helpers.origin_display(practice)
       practice_hash['initiating_facility'] = practice.initiating_facility
-      origin_facilities = practice.practice_origin_facilities.collect { |pof| pof.va_facility.present? ? pof.va_facility.station_number : pof.clinical_resource_hub.official_station_name }
+      origin_facilities = practice.practice_origin_facilities.includes([:va_facility, :clinical_resource_hub]).collect { |pof| pof.va_facility.present? ? pof.va_facility.station_number : pof.clinical_resource_hub.official_station_name }
       practice_hash['origin_facilities'] = origin_facilities
       practice_hash['user_favorited'] = current_user.favorite_practice_ids.include?(practice.id) if current_user.present?
 
       # get diffusion history facilities
-      adoptions = practice.diffusion_histories.includes([:va_facility]).collect { |dh| dh.va_facility.station_number }
+      adoptions = practice.diffusion_histories.includes([:va_facility, :clinical_resource_hub]).collect { |dh| dh.va_facility.present? ? dh.va_facility.station_number : dh.clinical_resource_hub.official_station_name }
       practice_hash['adoption_facilities'] = adoptions
       practice_hash['adoption_count'] = adoptions.size
 

--- a/lib/modules/practice_utils.rb
+++ b/lib/modules/practice_utils.rb
@@ -27,12 +27,12 @@ module PracticeUtils
       practice_hash['retired'] = practice.retired
       practice_hash['initiating_facility_name'] = helpers.origin_display(practice)
       practice_hash['initiating_facility'] = practice.initiating_facility
-      origin_facilities = practice.practice_origin_facilities.collect{ |pof| pof.va_facility.station_number }
+      origin_facilities = practice.practice_origin_facilities.collect { |pof| pof.va_facility.present? ? pof.va_facility.station_number : pof.clinical_resource_hub.official_station_name }
       practice_hash['origin_facilities'] = origin_facilities
       practice_hash['user_favorited'] = current_user.favorite_practice_ids.include?(practice.id) if current_user.present?
 
       # get diffusion history facilities
-      adoptions = practice.diffusion_histories.includes([:va_facility]).collect{ |dh| dh.va_facility.station_number }
+      adoptions = practice.diffusion_histories.includes([:va_facility]).collect { |dh| dh.va_facility.station_number }
       practice_hash['adoption_facilities'] = adoptions
       practice_hash['adoption_count'] = adoptions.size
 

--- a/lib/tasks/clinical_resource_hubs.rake
+++ b/lib/tasks/clinical_resource_hubs.rake
@@ -8,7 +8,7 @@ namespace :clinical_resource_hubs do
       visn = Visn.where(number: v["visn_number"]).first
       ClinicalResourceHub.create!(
           visn_id: visn.id,
-          name: v["name"]
+          official_station_name: v["name"]
       )
     end
     puts "All Clinical Resource Hubs have been added to the DB!"

--- a/spec/features/crh_spec.rb
+++ b/spec/features/crh_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 describe 'Clinical_Resource_Hubs', type: :feature do
   before do
     @visn_1 = Visn.create!(name: 'visn_1', number: 1)
-    @crh = ClinicalResourceHub.create!(name: 'crh1', visn_id: @visn_1.id)
+    @crh = ClinicalResourceHub.create!(official_station_name: 'VISN 1 Clinical Resource Hub', visn_id: @visn_1.id)
   end
 
   describe 'CRH show page' do
@@ -14,5 +14,39 @@ describe 'Clinical_Resource_Hubs', type: :feature do
         expect(page).to_not have_content('We\'re sorry, we can\'t find the page you\'re looking for. It might have been removed, changed names, or is otherwise unavailable.')
       end
     end
+  end
+
+  describe 'Cache' do
+    it 'should reset if a CRH is created, updated, or destroyed' do
+      # update a CRH
+      @crh.update_attributes(official_station_name: 'Updated VISN 1 Clinical Resource Hub')
+      expect(cache_keys).to_not include('clinical_resource_hubs')
+
+      visit_search_page
+      expect(cache_keys).to include('clinical_resource_hubs')
+
+
+      # create a CRH
+      ClinicalResourceHub.create!(official_station_name: 'VISN 2 Clinical Resource Hub', visn_id: @visn_1.id)
+      expect(cache_keys).to_not include('clinical_resource_hubs')
+
+      visit_search_page
+      expect(cache_keys).to include('clinical_resource_hubs')
+
+      # destroy a CRH
+      @crh.destroy
+      expect(cache_keys).to_not include('clinical_resource_hubs')
+
+      visit_search_page
+      expect(cache_keys).to include('clinical_resource_hubs')
+    end
+  end
+
+  def cache_keys
+    Rails.cache.redis.keys
+  end
+
+  def visit_search_page
+    visit '/search'
   end
 end


### PR DESCRIPTION
### JIRA issue link
https://agile6.atlassian.net/browse/DM-3112

## Description - what does this code do?
Adds the ability to search/filter by Clinical Resource Hubs

## Testing done - how did you test it/steps on how can another person can test it 
_**Prerequisite**_
1. Spin up a rails console in the terminal and create as many `PracticeOriginFacilities` and `DiffusionHistories` as you want, and make sure you assign them a `clinical_resource_hub_id`, not a `va_facility_id` (I added validations that will not allow them to have both foreign keys at the same time).

_**Functionality**_
1. Visit the search page.
2. Use both the originating and adopting facility filters to confirm they are working as intended and returning results based on the `PracticeOriginFacilities` and `DiffusionHistories` you created in the setup portion of the repro steps.
3. Now keyword search for the Clinical Resource Hubs that are associated with the `PracticeOriginFacilities` and `DiffusionHistories` you created and make sure the results are correct.
4. _**BONUS:**_ Play around with different combinations of keyword/filters to make sure everything still works as intended.

_**Search Page Load Speed Comparisons**_
Search page load times on STG (main branch, public site, no query, 10 trial runs, submitting empty string on search forms (homepage and header), using URL bar, clicking on "Browse all innovations"):
**6.80s
8.07s
6.56s
3.29s
7.80s
7.60s
6.17s
7.35s
5.85s
6.17s**
Average: **6.57s**

Search page load times on STG (main branch, public site, "health" query, 10 trial runs, submitting search forms (homepage and header), using URL bar):
**6.04s
6.24s
5.91s
6.17s
5.92s
6.69s
6.30s
6.30s
5.97s
6.28s**
Average: **6.18s**

Search page load times on STG (DM-3112 branch, public site, no query, 10 trial runs, submitting empty string on search forms (homepage and header), using URL bar, clicking on "Browse all innovations"):
**5.77s
5.81s
5.59s
5.98s
5.87s
5.57s
5.65s
5.56s
6.35s
5.82s**
Average: **5.80s**

Search page load times on STG (DM-3112 branch, public site, "health" query, 10 trial runs, submitting search forms (homepage and header), using URL bar):
**6.30s
5.39s
5.65s
5.72s
6.03s
5.86s
5.79s
5.71s
6.49s
5.91s**
Average: **5.89s**

## Screenshots, Gifs, Videos from application (if applicable)


## Link to mock-ups/mock ups (image file if you have it) (if applicable)


## Acceptance criteria
- Make it a Search Filter for adopting facility
- Make it a search filter for originating facility
- Update copy to say “Filter by facility, CRH, etc.)
- Make sure it doesn’t massively impact search speeds

## Definition of done
- [X] Unit tests written (if applicable)
- [] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [X] A link has been provided to the originating JIRA issue
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs