### PR TITLE
Extend s3 signer cache expiration to 60 mins

### DIFF
--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -2,7 +2,7 @@ class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
 
   def signer
-    Rails.cache.fetch('s3_signer', expires_in: 5.minutes) do
+    Rails.cache.fetch('s3_signer', expires_in: 60.minutes) do
       s3_bucket = Aws::S3::Bucket.new(ENV['S3_BUCKET_NAME'])
       WT::S3Signer.for_s3_bucket(s3_bucket, expires_in: 84000)
     end


### PR DESCRIPTION
### JIRA issue link
N/A

## Description - what does this code do?
Expires the s3 signer cache in 60 minutes rather than 5 minutes

## Testing done - how did you test it/steps on how can another person can test it 
Ensure you can still crop images successfully and images continue to load as expected

## Screenshots, Gifs, Videos from application (if applicable)


## Link to mock-ups/mock ups (image file if you have it) (if applicable)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Unit tests written (if applicable)
- [ ] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating JIRA issue
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs