### PR TITLE
dm-fix-middleware

### DIFF
--- a/lib/middleware/ntlm-sso.rb
+++ b/lib/middleware/ntlm-sso.rb
@@ -26,7 +26,7 @@ class NTLMAuthentication
 
     unless public_ips.include?(request.env["HTTP_X_FORWARDED_FOR"].split(',').first)
       auth = Rack::Auth::NTLMSSO.new(@app)
-      auth.call(env)
+      return auth.call(env)
     end
     @app.call(env)
   end


### PR DESCRIPTION
Added return statement for internal auth.

### JIRA issue link
NA

## Description - what does this code do?
Adds the return statement so internal users can be authenticated.  Without the return statement... internal users fall in to the public access method.. and are public users.

## Testing done - how did you test it/steps on how can another person can test it 


## Screenshots, Gifs, Videos from application (if applicable)


## Link to mock-ups/mock ups (image file if you have it) (if applicable)


## Acceptance criteria
- internal users get logged in via ldap and have internal permissions.

## Definition of done
- [ ] Unit tests written (if applicable)
- [ ] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating JIRA issue
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs