### PR TITLE
Remove deprecated Contact editor page routing

### DIFF
--- a/app/controllers/practices_controller.rb
+++ b/app/controllers/practices_controller.rb
@@ -3,7 +3,7 @@ class PracticesController < ApplicationController
   prepend_before_action :skip_timeout, only: [:session_time_remaining]
   before_action :set_practice, only: [:show, :edit, :update, :destroy, :highlight, :un_highlight, :feature,
                                       :un_feature, :favorite, :instructions, :overview, :impact, :resources, :documentation,
-                                      :departments, :timeline, :risk_and_mitigation, :contact, :checklist, :publication_validation, :adoptions,
+                                      :departments, :timeline, :risk_and_mitigation, :checklist, :publication_validation, :adoptions,
                                       :create_or_update_diffusion_history, :implementation, :introduction, :about, :metrics, :editors,
                                       :extend_editor_session_time, :session_time_remaining, :close_edit_session]
   before_action :set_facility_data, only: [:show]
@@ -13,11 +13,11 @@ class PracticesController < ApplicationController
   before_action :authenticate_user!, except: [:show, :search, :index]
   before_action :can_view_practice, only: [:show, :edit, :update, :destroy]
   before_action :can_create_practice, only: :create
-  before_action :can_edit_practice, only: [:edit, :update, :instructions, :overview, :contact, :published, :publication_validation, :adoptions, :about, :editors, :introduction, :implementation, :metrics]
+  before_action :can_edit_practice, only: [:edit, :update, :instructions, :overview, :published, :publication_validation, :adoptions, :about, :editors, :introduction, :implementation, :metrics]
   before_action :set_date_initiated_params, only: [:update, :publication_validation]
   before_action :is_enabled, only: [:show]
   before_action :set_current_session, only: [:extend_editor_session_time, :session_time_remaining, :close_edit_session]
-  before_action :practice_locked_for_editing, only: [:editors, :introduction, :overview, :contact, :adoptions, :about, :implementation]
+  before_action :practice_locked_for_editing, only: [:editors, :introduction, :overview, :adoptions, :about, :implementation]
   before_action :fetch_visns, only: [:show, :search, :introduction]
   before_action :fetch_va_facilities, only: [:show, :search, :metrics, :introduction]
 
@@ -387,11 +387,6 @@ class PracticesController < ApplicationController
   # /practices/slug/risk_and_mitigation
   def risk_and_mitigation
     redirect_to_instructions_path
-  end
-
-  # /practices/slug/contact
-  def contact
-    render 'practices/form/contact'
   end
 
   # /practices/slug/about

--- a/app/helpers/navigation_helper.rb
+++ b/app/helpers/navigation_helper.rb
@@ -154,11 +154,6 @@ module NavigationHelper
         empty_breadcrumbs
       end
 
-      # Contact breadcrumbs
-      if action == 'contact'
-        empty_breadcrumbs
-      end
-
       # About breadcrumbs
       if action == 'about'
         empty_breadcrumbs

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -33,7 +33,6 @@ Rails.application.routes.draw do
     get '/edit/departments', action: 'departments', as: 'departments'
     get '/edit/timeline', action: 'timeline', as: 'timeline'
     get '/edit/risk_and_mitigation', action: 'risk_and_mitigation', as: 'risk_and_mitigation'
-    get '/edit/contact', action: 'contact', as: 'contact'
     get '/edit/checklist', action: 'checklist', as: 'checklist'
     get '/edit/adoptions', action: 'adoptions', as: 'adoptions'
     post '/edit/create_or_update_diffusion_history/', action: 'create_or_update_diffusion_history', as: 'create_or_update_diffusion_history'
@@ -64,7 +63,6 @@ Rails.application.routes.draw do
   get '/practices/:id/edit/adoptions', to: redirect('/innovations/%{id}/edit/adoptions', status: 302)
   get '/practices/:id/edit/overview', to: redirect('/innovations/%{id}/edit/overview', status: 302)
   get '/practices/:id/edit/implementation', to: redirect('/innovations/%{id}/edit/implementation', status: 302)
-  get '/practices/:id/edit/contact', to: redirect('/innovations/%{id}/edit/contact', status: 302)
   get '/practices/:id/edit/about', to: redirect('/innovations/%{id}/edit/about', status: 302)
 
   resources :practice_partners, path: :partners

--- a/spec/features/practice_editor/session_spec.rb
+++ b/spec/features/practice_editor/session_spec.rb
@@ -34,9 +34,6 @@ describe 'Practice editor sessions', type: :feature do
     visit practice_overview_path(@practice)
     expect(page).to have_content(locked_msg)
 
-    visit practice_contact_path(@practice)
-    expect(page).to have_content(locked_msg)
-
     visit practice_about_path(@practice)
     expect(page).to have_content(locked_msg)
   end

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -148,19 +148,6 @@ describe 'Search', type: :feature do
     find('#practice-editor-save-button', visible: false).click
   end
 
-  def publish_practice(practice)
-    update_practice_introduction(practice)
-    visit(practice_adoptions_path(practice))
-    find('#add_adoption_button').click
-    find("label[for*='status_completed']").click
-    find('#editor_facility_select').click
-    find("#editor_facility_select--list--option-0").click
-    find('#adoption_form_submit').click
-    visit(practice_contact_path(practice))
-    fill_in('practice_support_network_email', with: 'dm@va.gov')
-    click_button('Publish')
-  end
-
   def cache_keys
     Rails.cache.redis.keys
   end


### PR DESCRIPTION
### JIRA issue link
https://agile6.atlassian.net/browse/DM-3178

## Description - what does this code do?
This PR is a follow up to #468 / DM-3178. DM-3178 combined the Contact and About editor pages. This PR removes some related code in the practices controller, routing, and breadcrumb nav.

## Testing done - how did you test it/steps on how can another person can test it 
1. Sign in as a user that can edit an innovation
2. Navigate to innovations/#{practice name}/edit/contact. You should receive an error

## Screenshots, Gifs, Videos from application (if applicable)


## Link to mock-ups/mock ups (image file if you have it) (if applicable)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Unit tests written (if applicable)
- [ ] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating JIRA issue
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs