### PR TITLE
Fixed modal flicker issue for editing guide modal and cleaned up code

### DIFF
--- a/app/assets/javascripts/_header_utilities.es6
+++ b/app/assets/javascripts/_header_utilities.es6
@@ -3,7 +3,7 @@
 
   function _preventCrisisLineModalFlickerOnPageLoad() {
     $(document).arrive('header', { existing: true }, () => {
-      $('#va-crisis-line-modal').find('.usa-modal').removeClass('display-none');
+      removeDisplayNoneFromModal('#va-crisis-line-modal');
     });
   }
 

--- a/app/assets/javascripts/_practice_editor_header.es6
+++ b/app/assets/javascripts/_practice_editor_header.es6
@@ -2,7 +2,7 @@
     function preventHeaderModalFlickerOnPageLoad() {
         $(document).arrive('header', { existing: true }, () => {
             removeDisplayNoneFromModal('#dm-practice-editor-close-modal');
-            removeDisplayNoneFromModal('#editing-guide-modal');
+            removeDisplayNoneFromModal('#dm-editing-guide-modal');
         });
     }
 

--- a/app/assets/javascripts/_practice_editor_header.es6
+++ b/app/assets/javascripts/_practice_editor_header.es6
@@ -1,20 +1,14 @@
 (($) => {
-  function preventCloseModalFlickerOnPageLoad() {
-    $(document).arrive("header", { existing: true }, () => {
-      $("#dm-practice-editor-close-modal").find(".usa-modal--lg").removeClass("display-none");
-    });
-  }
+    function preventHeaderModalFlickerOnPageLoad() {
+        $(document).arrive('header', { existing: true }, () => {
+            removeDisplayNoneFromModal('#dm-practice-editor-close-modal');
+            removeDisplayNoneFromModal('#editing-guide-modal');
+        });
+    }
 
-  function preventEditingGuideModalFlickerOnPageLoad() {
-    $(document).arrive('header', { existing: true }, () => {
-      $('#editing-guide-modal').find('.usa-modal').removeClass('display-none');
-    });
-  }
+    function initPracticeEditorHeaderFns() {
+        preventHeaderModalFlickerOnPageLoad();
+    }
 
-  function initPracticeEditorHeaderFns() {
-    preventCloseModalFlickerOnPageLoad();
-    preventEditingGuideModalFlickerOnPageLoad();
-  }
-
-  $(document).on("turbolinks:load", initPracticeEditorHeaderFns);
+    $(document).on("turbolinks:load", initPracticeEditorHeaderFns);
 })(window.jQuery);

--- a/app/assets/javascripts/_terms_and_conditions.es6
+++ b/app/assets/javascripts/_terms_and_conditions.es6
@@ -3,9 +3,7 @@
 
   function _preventTermsAndConditionsFlickerOnPageLoad() {
     $(document).arrive("header", { existing: true }, () => {
-      $("#dm-terms-and-conditions-modal")
-        .find(".usa-modal")
-        .removeClass("display-none");
+      removeDisplayNoneFromModal("#dm-terms-and-conditions-modal");
     });
   }
 

--- a/app/assets/javascripts/shared/_utilityFunctions.es6
+++ b/app/assets/javascripts/shared/_utilityFunctions.es6
@@ -9,3 +9,7 @@ function removeClassFromElement(ele, eleClass) {
 function changeFormActionUrl(ele, actionUrl) {
     $(ele).attr('action', actionUrl);
 }
+
+function removeDisplayNoneFromModal(modalEle) {
+    $(modalEle).find('.usa-modal').removeClass('display-none');
+}

--- a/app/views/practices/shared/_editing_guide_modal.html.erb
+++ b/app/views/practices/shared/_editing_guide_modal.html.erb
@@ -1,4 +1,4 @@
-<div class="usa-modal usa-modal--lg" id="dm-editing-guide-modal" aria-labelledby="dm-editing-guide-modal-heading"
+<div class="usa-modal usa-modal--lg display-none" id="dm-editing-guide-modal" aria-labelledby="dm-editing-guide-modal-heading"
     aria-describedby="dm-editing-guide-modal-description">
     <div class="usa-modal__content">
         <div class="usa-modal__main">

--- a/app/views/visns/_show.js.erb
+++ b/app/views/visns/_show.js.erb
@@ -437,7 +437,7 @@ function submitFormOnPageLoadWithCreatedPracticesAsDefault() {
 
 function preventComplexityModalFlickerOnPageLoad() {
     $(document).arrive('.visn-facilities-table', { existing: true }, () => {
-        $('#facility-complexity-modal').find('.usa-modal').removeClass('display-none');
+        removeDisplayNoneFromModal('#facility-complexity-modal');
     });
 }
 


### PR DESCRIPTION
### JIRA issue link


## Description - what does this code do?
Fixes modal flicker issue for editing guide modal and cleans up modal flicker code.

## Testing done - how did you test it/steps on how can another person can test it 
1. Log in as an admin-level user and visit the homepage. Make sure the crisis line and terms & conditions modals do not flicker. You can refresh the page multiple times to confirm.
2. Visit the practice editor introduction page for any practice and make sure both the editing guide and close modals do not flicker. You can refresh the page multiple times to confirm.
3. Visit the show page for any VISN and make sure the complexity modal does not flicker. You can refresh the page multiple times to confirm.

## Screenshots, Gifs, Videos from application (if applicable)


## Link to mock-ups/mock ups (image file if you have it) (if applicable)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Unit tests written (if applicable)
- [ ] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating JIRA issue
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs