### PR TITLE
DM-3454: Added STA3N and originating facilities to QUERI adoption download

### DIFF
--- a/app/helpers/active_admin_helpers.rb
+++ b/app/helpers/active_admin_helpers.rb
@@ -19,7 +19,7 @@ module ActiveAdminHelpers
     facility_data = VaFacility.cached_va_facilities.get_relevant_attributes
     practice_diffusion_histories = p.diffusion_histories.exclude_clinical_resource_hubs.map { |dh|
       selected_facility = facility_data.select { |fd| fd.station_number === dh.va_facility.station_number }
-
+      origin_facilities = origin_display_name(Practice.find_by(id: dh.practice_id))
       dh_status = dh.diffusion_history_statuses.first
       {
         facility_name: selected_facility[0].official_station_name,
@@ -29,9 +29,11 @@ module ActiveAdminHelpers
         status: dh_status.status == 'Completed' || dh_status.status == 'Implemented' || dh_status.status == 'Complete' ? 'Successful' : dh_status.status,
         rurality: selected_facility[0].rurality,
         complexity: selected_facility[0].fy17_parent_station_complexity_level,
+        sta3n: selected_facility[0].sta3n,
         station_number: selected_facility[0].station_number,
         visn: selected_facility[0].visn,
-        practice_name: dh.practice.name
+        practice_name: dh.practice.name,
+        origin_facilities: origin_facilities
       }
     }
     sorted_diffusion_histories = practice_diffusion_histories.sort_by { |pdh| [pdh[:state], pdh[:facility_name]] }
@@ -182,7 +184,9 @@ module ActiveAdminHelpers
                      options[:add_practice_name] ? 'Practice' : nil,
                     'State',
                     'Location',
+                    'Originating Facility',
                     'VISN',
+                    'STA3N',
                     'Station Number',
                     'Adoption Date',
                     'Adoption Status',
@@ -198,7 +202,9 @@ module ActiveAdminHelpers
                           hash[:practice_name],
                           hash[:state],
                           adoption_facility_name(hash),
+                          hash[:origin_facilities],
                           hash[:visn].number,
+                          hash[:sta3n],
                           hash[:station_number],
                           adoption_date(hash),
                           adoption_status(hash),
@@ -211,7 +217,9 @@ module ActiveAdminHelpers
         sheet.add_row [
                         data_array[:state],
                         adoption_facility_name(data_array),
+                        data_array[:origin_facilities],
                         data_array[:visn].number,
+                        data_array[:sta3n],
                         data_array[:station_number],
                         adoption_date(data_array),
                         adoption_status(data_array),

--- a/app/helpers/active_admin_helpers.rb
+++ b/app/helpers/active_admin_helpers.rb
@@ -184,7 +184,7 @@ module ActiveAdminHelpers
                      options[:add_practice_name] ? 'Practice' : nil,
                     'State',
                     'Location',
-                    'Originating Facility',
+                    'Originating Facilities',
                     'VISN',
                     'STA3N',
                     'Station Number',

--- a/app/models/va_facility.rb
+++ b/app/models/va_facility.rb
@@ -17,7 +17,7 @@ class VaFacility < ApplicationRecord
   scope :get_complexity, -> { order(:fy17_parent_station_complexity_level).pluck(:fy17_parent_station_complexity_level).uniq }
   scope :get_relevant_attributes, -> {
       select(:street_address_state, :official_station_name, :id, :visn_id, :common_name, :station_number, :latitude,
-      :longitude, :slug, :fy17_parent_station_complexity_level, :rurality, :classification, :station_phone_number)
+      :longitude, :slug, :fy17_parent_station_complexity_level, :rurality, :classification, :station_phone_number, :sta3n)
   }
   scope :order_by_station_name, -> { order(:official_station_name) }
   scope :order_by_state_and_station_name, -> { order(:street_address_state, :official_station_name) }


### PR DESCRIPTION
### JIRA issue link
[DM-3454](https://agile6.atlassian.net/browse/DM-3454?atlOrigin=eyJpIjoiOTViODI3NDQ1Yzc5NDJmMmI5N2ZiNjk5YzFlNzNhNDYiLCJwIjoiaiJ9)

## Description - what does this code do?
Added STA3N and originating facilities to QUERI adoption download in admin panel

## Testing done - how did you test it/steps on how can another person can test it 
1. Log in as an admin
2. Create multiple origin locations for a particular practice that has been adopted
3. Go to `/admin/adoptions`
4. Click on `QUERI Download` button
5. Check that STA3N and Originating Facilities columns have been created and populated, i.e. multiple originating facilities are in a comma-delimited list within the Originating Facilities column
6. Verify all other data is correct

## Screenshots, Gifs, Videos from application (if applicable)
![Screen Shot 2022-07-06 at 3 14 51 PM](https://user-images.githubusercontent.com/5402927/177652482-fdbcbf4e-6f16-42e8-adc9-f46a516dec06.png)


## Link to mock-ups/mock ups (image file if you have it) (if applicable)
N/A

## Acceptance criteria
- Add Originating Facility (some have more than one) for the adopted Innovation to Adoptions QUERI Dataset
- Add STA3N to Adoptions QUERI dataset (Parent)
-We should be seeing 136 out of 141 Facilities 

## Definition of done
- [ ] Unit tests written (if applicable)
- [ ] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating JIRA issue
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs