### PR TITLE
DM-3473: Ensure that PageBuilder links use appropriate target and styling

### DIFF
--- a/app/assets/javascripts/_page_show.es6
+++ b/app/assets/javascripts/_page_show.es6
@@ -58,10 +58,37 @@
       });
     }
 
+    // Style external links and set to open in a new tab (508 accessibility)
+    function identifyExternalLinks() {
+        // identify external by HREF content
+        let extLinks = $('.dm-page-content').find("a:not([href*='marketplace.va.gov'])").not("[href^='/']");
+        
+        extLinks.each(function() {
+            let currentLink = $(this);
+
+            function isImageLink(link){
+                return link.find("img").length > 0
+            };
+
+            function isButton(link){
+                return link.hasClass("usa-button");
+            }
+
+            // Open in a new tab
+            currentLink.attr("target", "_blank");
+
+            // Do not apply visual styling to buttons and links
+            if ( !isImageLink(currentLink) && !isButton(currentLink) ) {
+                currentLink.addClass("usa-link usa-link--external");
+            }
+        });
+    }
+
     function execPageBuilderFunctions() {
         browsePageBuilderPageHappy();
         removeBottomMarginFromLastAccordionHeading();
         containerizeSubpageHyperlinkCards();
+        identifyExternalLinks();
     }
 
     $document.on('turbolinks:load', execPageBuilderFunctions);

--- a/app/assets/javascripts/_page_show.es6
+++ b/app/assets/javascripts/_page_show.es6
@@ -58,35 +58,14 @@
       });
     }
 
-    function isImageLink(link){
-        return link.find("img").length > 0
-    };
-
-    function isButton(link){
-        return link.hasClass("usa-button") || link.is("[class*='btn']") || link.is("[class*='button']");
-    }
-
-    function isIcon(link){
-        return link.children("i").length > 0;
-    }
-
-    function isPracticeLink(link){
-        return link.hasClass("dm-practice-link");
-    }
-
-    // Remediate internal links on old PageBuilder pages
+    // Remediate internal links on PageBuilder paragraph and accordion components
     function remediateInternalLinksTarget(){
-        let intLinks = $('.dm-page-content').find("a[href*='marketplace.va.gov'], a[href^='/']");
+        let intLinks = $('.page-paragraph-component, .page-accordion-component').find("a[href*='marketplace.va.gov'], a[href^='/'],a[href^='.']");
 
         intLinks.each(function(){
             let currentLink = $(this);
-            // Add USWDS link styling text links only
-            if (!isImageLink(currentLink) && !isButton(currentLink) && !isIcon(currentLink) && !isPracticeLink(currentLink)){
-                currentLink.addClass("usa-link");
-            }
-
-            // Remediate any internal links created by 'Open link in: New Window'
-            if (currentLink.is("[target='_blank']")){
+            currentLink.addClass("usa-link");
+            if (currentLink.is("[target='_blank']")) {
                 currentLink.attr("target","")
             }
         })
@@ -95,18 +74,13 @@
     // Style PageBuilder external links and set to open in a new tab (508 accessibility)
     function identifyExternalLinks() {
         // identify external by HREF content
-        let extLinks = $('.dm-page-content').find("a:not([href*='marketplace.va.gov'])").not("[href^='/']");
+        let extLinks = $('.page-paragraph-component, .page-accordion-component').find("a:not([href*='marketplace.va.gov'])").not("[href^='/']").not("[href^='.']");
         
         extLinks.each(function() {
             let currentLink = $(this);
 
-            // Open in a new tab
             currentLink.attr("target", "_blank");
-
-            // Do not apply visual styling to buttons and links
-            if ( !isImageLink(currentLink) && !isButton(currentLink) ) {
-                currentLink.addClass("usa-link usa-link--external");
-            }
+            currentLink.addClass("usa-link usa-link--external");
         });
     }
 

--- a/app/assets/javascripts/_page_show.es6
+++ b/app/assets/javascripts/_page_show.es6
@@ -66,7 +66,7 @@
             let currentLink = $(this);
             currentLink.addClass("usa-link");
             if (currentLink.is("[target='_blank']")) {
-                currentLink.attr("target","")
+                currentLink.attr("target","");
             }
         })
     }

--- a/app/assets/javascripts/_page_show.es6
+++ b/app/assets/javascripts/_page_show.es6
@@ -63,11 +63,15 @@
     };
 
     function isButton(link){
-        return link.hasClass("usa-button");
+        return link.hasClass("usa-button") || link.is("[class*='btn']") || link.is("[class*='button']");
     }
 
     function isIcon(link){
         return link.children("i").length > 0;
+    }
+
+    function isPracticeLink(link){
+        return link.hasClass("dm-practice-link");
     }
 
     // Remediate internal links on old PageBuilder pages
@@ -77,7 +81,7 @@
         intLinks.each(function(){
             let currentLink = $(this);
             // Add USWDS link styling text links only
-            if (!isImageLink(currentLink) && !isButton(currentLink) && !isIcon(currentLink)){
+            if (!isImageLink(currentLink) && !isButton(currentLink) && !isIcon(currentLink) && !isPracticeLink(currentLink)){
                 currentLink.addClass("usa-link");
             }
 

--- a/app/assets/javascripts/_page_show.es6
+++ b/app/assets/javascripts/_page_show.es6
@@ -58,21 +58,43 @@
       });
     }
 
-    // Style external links and set to open in a new tab (508 accessibility)
+    function isImageLink(link){
+        return link.find("img").length > 0
+    };
+
+    function isButton(link){
+        return link.hasClass("usa-button");
+    }
+
+    function isIcon(link){
+        return link.children("i").length > 0;
+    }
+
+    // Remediate internal links on old PageBuilder pages
+    function remediateInternalLinksTarget(){
+        let intLinks = $('.dm-page-content').find("a[href*='marketplace.va.gov'], a[href^='/']");
+
+        intLinks.each(function(){
+            let currentLink = $(this);
+            // Add USWDS link styling text links only
+            if (!isImageLink(currentLink) && !isButton(currentLink) && !isIcon(currentLink)){
+                currentLink.addClass("usa-link");
+            }
+
+            // Remediate any internal links created by 'Open link in: New Window'
+            if (currentLink.is("[target='_blank']")){
+                currentLink.attr("target","")
+            }
+        })
+    }
+
+    // Style PageBuilder external links and set to open in a new tab (508 accessibility)
     function identifyExternalLinks() {
         // identify external by HREF content
         let extLinks = $('.dm-page-content').find("a:not([href*='marketplace.va.gov'])").not("[href^='/']");
         
         extLinks.each(function() {
             let currentLink = $(this);
-
-            function isImageLink(link){
-                return link.find("img").length > 0
-            };
-
-            function isButton(link){
-                return link.hasClass("usa-button");
-            }
 
             // Open in a new tab
             currentLink.attr("target", "_blank");
@@ -88,8 +110,10 @@
         browsePageBuilderPageHappy();
         removeBottomMarginFromLastAccordionHeading();
         containerizeSubpageHyperlinkCards();
+        remediateInternalLinksTarget();
         identifyExternalLinks();
     }
 
     $document.on('turbolinks:load', execPageBuilderFunctions);
 })(window.jQuery);
+

--- a/app/assets/javascripts/active_admin.js
+++ b/app/assets/javascripts/active_admin.js
@@ -186,8 +186,8 @@ const MAX_DESCRIPTION_LENGTH = 140;
   function _modifyTinyMCELinkEditor() {
     $(document).arrive('.tox-dialog__title', function(e) {
       if ($('.tox-dialog__title').text() == "Insert/Edit Link" ) {
-        var UrlField = $('.tox-form label:contains("URL")')
-        UrlField.append('<span class="inline-hints">(For external URLs, use full URL i.e. https://google.com)</span>')
+        var UrlField = $('.tox-form label:contains("URL")');
+        UrlField.append('<span class="inline-hints">(For external URLs, use full URL i.e. https://google.com)</span>');
         var openLinkInDropdown = $('.tox-label:contains("Open link in")').parent();
         openLinkInDropdown.css("display","none");
       }

--- a/app/assets/javascripts/active_admin.js
+++ b/app/assets/javascripts/active_admin.js
@@ -181,12 +181,24 @@ const MAX_DESCRIPTION_LENGTH = 140;
     })
   }
 
+  // Remove content creator's ability to choose whether 
+  // links open in a new tab or current tab
+  function _removeTinyMCEOpenLinkInDropdown() {
+    $(document).arrive('.tox-dialog__title', function(e) {
+      if ($('.tox-dialog__title').text() == "Insert/Edit Link" ) {
+        var openLinkInDropdown = $('.tox-label:contains("Open link in")').parent();
+        openLinkInDropdown.css("display","none");
+      }
+    })
+  }
+
   function _loadPageBuilderFns() {
     var $body = $('body');
     if ($body.hasClass('admin_pages') && $body.hasClass('edit')) {
       _addTinyMCEOnSelection();
       _preventDuplicateTinyMCEColorSelectors();
       _initializeTinyMCEOnDragAndDrop();
+      _removeTinyMCEOpenLinkInDropdown();
       _modifySubmitBtnIDonPageBuilder();
     }
   }

--- a/app/assets/javascripts/active_admin.js
+++ b/app/assets/javascripts/active_admin.js
@@ -183,9 +183,11 @@ const MAX_DESCRIPTION_LENGTH = 140;
 
   // Remove content creator's ability to choose whether 
   // links open in a new tab or current tab
-  function _removeTinyMCEOpenLinkInDropdown() {
+  function _modifyTinyMCELinkEditor() {
     $(document).arrive('.tox-dialog__title', function(e) {
       if ($('.tox-dialog__title').text() == "Insert/Edit Link" ) {
+        var UrlField = $('.tox-form label:contains("URL")')
+        UrlField.append('<span class="inline-hints">(For external URLs, use full URL i.e. https://google.com)</span>')
         var openLinkInDropdown = $('.tox-label:contains("Open link in")').parent();
         openLinkInDropdown.css("display","none");
       }
@@ -198,7 +200,7 @@ const MAX_DESCRIPTION_LENGTH = 140;
       _addTinyMCEOnSelection();
       _preventDuplicateTinyMCEColorSelectors();
       _initializeTinyMCEOnDragAndDrop();
-      _removeTinyMCEOpenLinkInDropdown();
+      _modifyTinyMCELinkEditor();
       _modifySubmitBtnIDonPageBuilder();
     }
   }

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -126,7 +126,7 @@ module ApplicationHelper
   end
 
   def get_link_target_attribute(url)
-    if url.include?(ENV.fetch('HOSTNAME'))
+    if url.include?(ENV.fetch('HOSTNAME')) || url.start_with?('/') || url.start_with?('.')
       ''
     else
       '_blank'

--- a/app/views/page/show.html.erb
+++ b/app/views/page/show.html.erb
@@ -19,7 +19,7 @@
 
         <%# Page Header and Paragraph %>
         <% if (pc.component_type == 'PageHeaderComponent' || pc.component_type == 'PageParagraphComponent') && component.text.present? %>
-          <div class="margin-bottom-4-important <%= page_narrow_classes %><%= ' margin-bottom-0' if last_component === index %>">
+          <div class="page-paragraph-component margin-bottom-4-important <%= page_narrow_classes %><%= ' margin-bottom-0' if last_component === index %>">
             <%= component.text.html_safe %>
           </div>
         <% end %>
@@ -56,7 +56,7 @@
 
           <%# Accordion %>
         <% when 'PageAccordionComponent' %>
-          <div class="<%= page_narrow_classes %> margin-bottom-3<%= ' margin-bottom-0' if last_component === index %>">
+          <div class="page-accordion-component <%= page_narrow_classes %> margin-bottom-3<%= ' margin-bottom-0' if last_component === index %>">
             <div class="usa-accordion">
               <h2 class="usa-accordion__heading margin-bottom-2">
                 <button class="usa-accordion__button font-sans-sm"

--- a/app/views/page/show.html.erb
+++ b/app/views/page/show.html.erb
@@ -90,7 +90,7 @@
         <% when 'PageImageComponent' %>
           <div class="grid-row margin-bottom-3 <%= get_grid_alignment_css_class(component.alignment.downcase) %> <%= page_narrow_classes %><%= ' margin-bottom-0' if last_component === index %>">
             <% if component.url.present? %>
-              <a href="<%= component.url %>" target="<%= component.url.chars.first === '/' ? '' : '_blank' %>" title="Go to <%= component.url %>">
+              <a href="<%= component.url %>" target="<%= get_link_target_attribute(component.url) %>" title="Go to <%= component.url %>">
                 <%= render partial: "page/page_image", locals: { component: component } %>
               </a>
             <% else %>

--- a/spec/features/pages/show_page_spec.rb
+++ b/spec/features/pages/show_page_spec.rb
@@ -32,7 +32,7 @@ describe 'Page Builder - Show', type: :feature do
     downloadable_file = File.new(File.join(Rails.root, '/spec/assets/dummy.pdf'))
     downloadable_file_component = PageDownloadableFileComponent.create(attachment: downloadable_file, description: 'Test file')
     paragraph_component = PageParagraphComponent.create(text: "<div><p><a href='https://marketplace.va.gov/about'>about the marketplace</a></p><p><a href='https://wikipedia.org/'>an external link</a></p></div>")
-    legacy_paragraph_component = PageParagraphComponent.create(text: "<div><p><a href='/about' target='_blank'>relative internal link</a></p><p><a href='https://marketplace.va.gov/' target='_blank'>absolute internal link</a></p></div>")
+    legacy_paragraph_component = PageParagraphComponent.create(text: "<div><p><a href='../../about' target='_blank'>relative internal link with dot</a></p><p><a href='/about' target='_blank'>relative internal link with slash</a></p><p><a href='https://marketplace.va.gov/' target='_blank'>absolute internal link</a></p></div>")
     PageComponent.create(page: @page, component: practice_list_component, created_at: Time.now)
     PageComponent.create(page: @page, component: subpage_hyperlink_component, created_at: Time.now)
     PageComponent.create(page: @page, component: image_component, created_at: Time.now)
@@ -123,10 +123,12 @@ describe 'Page Builder - Show', type: :feature do
   end
 
   it 'remediates legacy internal links with incorrect target' do
-    rel_link = page.find_link('relative internal link')
+    rel_link_dot = page.find_link('relative internal link with dot')
+    rel_link_slash = page.find_link('relative internal link with slash')
     absolute_link = page.find_link('absolute internal link')
 
-    expect(rel_link[:target]).not_to eq('_blank')
+    expect(rel_link_dot[:target]).not_to eq('_blank')
+    expect(rel_link_slash[:target]).not_to eq('_blank')
     expect(absolute_link[:target]).not_to eq('_blank')
   end
 

--- a/spec/features/pages/show_page_spec.rb
+++ b/spec/features/pages/show_page_spec.rb
@@ -27,6 +27,9 @@ describe 'Page Builder - Show', type: :feature do
     image_path_2 = File.join(Rails.root, '/spec/assets/SpongeBob.png')
     image_file_2 = File.new(image_path_2)
     image_component_2 = PageImageComponent.create(alignment: 'center', alt_text: 'image with link', page_image: image_file_2, url: 'https://va.gov')
+    image_path_3 = File.join(Rails.root, '/spec/assets/acceptable_img.jpg')
+    image_file_3 = File.new(image_path_3)
+    image_component_3 = PageImageComponent.create(alignment: 'center', alt_text: 'image with internal link', page_image: image_file_3, url: '/about')
     cta_component = PageCtaComponent.create(url: 'https://www.google.com', button_text:'Search now', cta_text: 'Curious about programming languages?')
     cta_component_internal = PageCtaComponent.create(url: '/innnovations/vione', button_text: 'Internal CTA', cta_text: 'Explore innovations')
     youtube_video_component = PageYouTubePlayerComponent.create(url: 'https://www.youtube.com/watch?v=C0DPdy98e4c', caption: 'Test Video')
@@ -38,6 +41,7 @@ describe 'Page Builder - Show', type: :feature do
     PageComponent.create(page: @page, component: subpage_hyperlink_component, created_at: Time.now)
     PageComponent.create(page: @page, component: image_component, created_at: Time.now)
     PageComponent.create(page: @page, component: image_component_2, created_at: Time.now)
+    PageComponent.create(page: @page, component: image_component_3, created_at: Time.now)
     PageComponent.create(page: @page, component: cta_component, created_at: Time.now)
     PageComponent.create(page: @page, component: cta_component_internal, created_at: Time.now)
     PageComponent.create(page: @page, component: youtube_video_component, created_at: Time.now)
@@ -94,8 +98,13 @@ describe 'Page Builder - Show', type: :feature do
     page.should have_css('.flex-justify-center')
 
     # get the parent element of the image's URL
-    link = page.find("img[src*='SpongeBob.png']").find(:xpath, '..')
-    link[:href].should == "https://va.gov/"
+    external_link = page.find("img[src*='SpongeBob.png']").find(:xpath, '..')
+    expect(external_link[:href]).to eq('https://va.gov/')
+    expect(external_link[:target]).to eq('_blank')
+
+    internal_link = page.find("img[src*='acceptable_img.jpg']").find(:xpath, '..')
+    expect(URI.parse(internal_link[:href]).path).to eq('/about')
+    expect(internal_link[:target]).not_to eq('_blank')
   end
 
   it 'Should display the call to action' do
@@ -105,7 +114,7 @@ describe 'Page Builder - Show', type: :feature do
     expect(page).to have_content('Curious about programming languages?')
 
     internal_cta = page.find_link('Internal CTA')
-    expect(URI.parse(internal_link[:href]).path).to eq('/innnovations/vione')
+    expect(URI.parse(internal_cta[:href]).path).to eq('/innnovations/vione')
     expect(internal_cta[:target]).to_not eq('_blank')
   end
 

--- a/spec/features/pages/show_page_spec.rb
+++ b/spec/features/pages/show_page_spec.rb
@@ -90,12 +90,12 @@ describe 'Page Builder - Show', type: :feature do
 
   it 'Should display the page image' do
     expect(page).to have_css("img[src*='charmander.png']")
-    page.should have_css('.flex-justify-end')
+    expect(page).to have_css('.flex-justify-end')
   end
 
   it 'should display the page image with a url' do
     expect(page).to have_css("img[src*='SpongeBob.png']")
-    page.should have_css('.flex-justify-center')
+    expect(page).to have_css('.flex-justify-center')
 
     # get the parent element of the image's URL
     external_link = page.find("img[src*='SpongeBob.png']").find(:xpath, '..')

--- a/spec/features/pages/show_page_spec.rb
+++ b/spec/features/pages/show_page_spec.rb
@@ -32,7 +32,7 @@ describe 'Page Builder - Show', type: :feature do
     downloadable_file = File.new(File.join(Rails.root, '/spec/assets/dummy.pdf'))
     downloadable_file_component = PageDownloadableFileComponent.create(attachment: downloadable_file, description: 'Test file')
     paragraph_component = PageParagraphComponent.create(text: "<div><p><a href='https://marketplace.va.gov/about'>about the marketplace</a></p><p><a href='https://wikipedia.org/'>an external link</a></p></div>")
-    legacy_paragraph_component = PageParagraphComponent.create(text: "<div><p><a href='/about' target='_blank'>relative internal link</a></p><p><a href='https://marektplace.va.gov/' target='_blank'>absolute internal link</a></p></div>")
+    legacy_paragraph_component = PageParagraphComponent.create(text: "<div><p><a href='/about' target='_blank'>relative internal link</a></p><p><a href='https://marketplace.va.gov/' target='_blank'>absolute internal link</a></p></div>")
     PageComponent.create(page: @page, component: practice_list_component, created_at: Time.now)
     PageComponent.create(page: @page, component: subpage_hyperlink_component, created_at: Time.now)
     PageComponent.create(page: @page, component: image_component, created_at: Time.now)

--- a/spec/features/pages/show_page_spec.rb
+++ b/spec/features/pages/show_page_spec.rb
@@ -28,6 +28,7 @@ describe 'Page Builder - Show', type: :feature do
     image_file_2 = File.new(image_path_2)
     image_component_2 = PageImageComponent.create(alignment: 'center', alt_text: 'image with link', page_image: image_file_2, url: 'https://va.gov')
     cta_component = PageCtaComponent.create(url: 'https://www.google.com', button_text:'Search now', cta_text: 'Curious about programming languages?')
+    cta_component_internal = PageCtaComponent.create(url: '/innnovations/vione', button_text: 'Internal CTA', cta_text: 'Explore innovations')
     youtube_video_component = PageYouTubePlayerComponent.create(url: 'https://www.youtube.com/watch?v=C0DPdy98e4c', caption: 'Test Video')
     downloadable_file = File.new(File.join(Rails.root, '/spec/assets/dummy.pdf'))
     downloadable_file_component = PageDownloadableFileComponent.create(attachment: downloadable_file, description: 'Test file')
@@ -38,6 +39,7 @@ describe 'Page Builder - Show', type: :feature do
     PageComponent.create(page: @page, component: image_component, created_at: Time.now)
     PageComponent.create(page: @page, component: image_component_2, created_at: Time.now)
     PageComponent.create(page: @page, component: cta_component, created_at: Time.now)
+    PageComponent.create(page: @page, component: cta_component_internal, created_at: Time.now)
     PageComponent.create(page: @page, component: youtube_video_component, created_at: Time.now)
     PageComponent.create(page: @page, component: downloadable_file_component, created_at: Time.now)
     PageComponent.create(page: @page, component: paragraph_component, created_at: Time.now)
@@ -97,9 +99,14 @@ describe 'Page Builder - Show', type: :feature do
   end
 
   it 'Should display the call to action' do
-    expect(find_all('.usa-button').last[:href]).to include('https://www.google.com')
+    external_cta = page.find_link('Search now')
+    expect(external_cta[:href]).to eq('https://www.google.com/')
+    expect(external_cta[:target]).to eq('_blank')
     expect(page).to have_content('Curious about programming languages?')
-    expect(page).to have_content('Search now')
+
+    internal_cta = page.find_link('Internal CTA')
+    expect(URI.parse(internal_link[:href]).path).to eq('/innnovations/vione')
+    expect(internal_cta[:target]).to_not eq('_blank')
   end
 
   it 'Should display the YouTube video' do

--- a/spec/features/pages/show_page_spec.rb
+++ b/spec/features/pages/show_page_spec.rb
@@ -31,6 +31,7 @@ describe 'Page Builder - Show', type: :feature do
     youtube_video_component = PageYouTubePlayerComponent.create(url: 'https://www.youtube.com/watch?v=C0DPdy98e4c', caption: 'Test Video')
     downloadable_file = File.new(File.join(Rails.root, '/spec/assets/dummy.pdf'))
     downloadable_file_component = PageDownloadableFileComponent.create(attachment: downloadable_file, description: 'Test file')
+    paragraph_component = PageParagraphComponent.create(text: "<div><p><a href='https://marketplace.va.gov/about'>about the marketplace</a></p><p><a href='https://wikipedia.org/'>an external link</a></p></div>")
     PageComponent.create(page: @page, component: practice_list_component, created_at: Time.now)
     PageComponent.create(page: @page, component: subpage_hyperlink_component, created_at: Time.now)
     PageComponent.create(page: @page, component: image_component, created_at: Time.now)
@@ -38,6 +39,7 @@ describe 'Page Builder - Show', type: :feature do
     PageComponent.create(page: @page, component: cta_component, created_at: Time.now)
     PageComponent.create(page: @page, component: youtube_video_component, created_at: Time.now)
     PageComponent.create(page: @page, component: downloadable_file_component, created_at: Time.now)
+    PageComponent.create(page: @page, component: paragraph_component, created_at: Time.now)
     # must be logged in to view pages
     login_as(user, scope: :user, run_callbacks: false)
     visit '/programming/ruby-rocks'
@@ -106,6 +108,16 @@ describe 'Page Builder - Show', type: :feature do
   it 'Should display the downloadable file' do
     expect(page).to have_css('.usa-link--external')
     expect(page).to have_content('Test file')
+  end
+
+  it 'styles external links and opens them in a new tab' do
+    internal_link = page.find_link('about the marketplace')
+    external_link = page.find_link('an external link')
+
+    expect(external_link[:class]).to eq('usa-link--external')
+    expect(external_link[:target]).to eq('_blank')
+    expect(internal_link[:class]).not_to eq('usa-link--external')
+    expect(internal_link[:target]).not_to eq('_blank')
   end
 
   it 'Should not display a warning banner on the Chrome browser' do

--- a/spec/features/pages/show_page_spec.rb
+++ b/spec/features/pages/show_page_spec.rb
@@ -32,6 +32,7 @@ describe 'Page Builder - Show', type: :feature do
     downloadable_file = File.new(File.join(Rails.root, '/spec/assets/dummy.pdf'))
     downloadable_file_component = PageDownloadableFileComponent.create(attachment: downloadable_file, description: 'Test file')
     paragraph_component = PageParagraphComponent.create(text: "<div><p><a href='https://marketplace.va.gov/about'>about the marketplace</a></p><p><a href='https://wikipedia.org/'>an external link</a></p></div>")
+    legacy_paragraph_component = PageParagraphComponent.create(text: "<div><p><a href='/about' target='_blank'>relative internal link</a></p><p><a href='https://marektplace.va.gov/' target='_blank'>absolute internal link</a></p></div>")
     PageComponent.create(page: @page, component: practice_list_component, created_at: Time.now)
     PageComponent.create(page: @page, component: subpage_hyperlink_component, created_at: Time.now)
     PageComponent.create(page: @page, component: image_component, created_at: Time.now)
@@ -40,6 +41,7 @@ describe 'Page Builder - Show', type: :feature do
     PageComponent.create(page: @page, component: youtube_video_component, created_at: Time.now)
     PageComponent.create(page: @page, component: downloadable_file_component, created_at: Time.now)
     PageComponent.create(page: @page, component: paragraph_component, created_at: Time.now)
+    PageComponent.create(page: @page, component: legacy_paragraph_component, created_at: Time.now)
     # must be logged in to view pages
     login_as(user, scope: :user, run_callbacks: false)
     visit '/programming/ruby-rocks'
@@ -114,10 +116,18 @@ describe 'Page Builder - Show', type: :feature do
     internal_link = page.find_link('about the marketplace')
     external_link = page.find_link('an external link')
 
-    expect(external_link[:class]).to eq('usa-link--external')
+    expect(external_link[:class]).to eq('usa-link usa-link--external')
     expect(external_link[:target]).to eq('_blank')
-    expect(internal_link[:class]).not_to eq('usa-link--external')
+    expect(internal_link[:class]).not_to eq('usa-link usa-link--external')
     expect(internal_link[:target]).not_to eq('_blank')
+  end
+
+  it 'remediates legacy internal links with incorrect target' do
+    rel_link = page.find_link('relative internal link')
+    absolute_link = page.find_link('absolute internal link')
+
+    expect(rel_link[:target]).not_to eq('_blank')
+    expect(absolute_link[:target]).not_to eq('_blank')
   end
 
   it 'Should not display a warning banner on the Chrome browser' do


### PR DESCRIPTION
### JIRA issue link
[DM-3473](https://agile6.atlassian.net/browse/DM-3473?atlOrigin=eyJpIjoiYzgyYTc0YjNjZTI1NDI3ZGE3ZjBhYjQ3YTlkMjYxMzgiLCJwIjoiaiJ9)

## Description - what does this code do?
This code handles accessibility best practices for Page Builder links. 
- Remove "Open link in" option from TinyMCE editor 
  - Remediate legacy data without a db update (e.g.internal links set to open in a new tab; external links set to open in the same tab)
- Identify external links
  - Apply USWDS styling so these links receive an icon
  -  set to open in a new tab
- Identify internal links
  - add `.usa-link` styling so that links get `:hover` and `:visited` styles
  - unset any instances of `target='_blank'`

I looked into a Rails approach to doing this but decided to take the JS route. Hopefully this means we won't need to remember to reimplement accessible link behavior as we work on new page builder components.

## Testing done - how did you test it/steps on how can another person can test it 
### In any environment
1. Log in as an admin
2. Edit a page
3. Add a paragraph component and select some text
4. Click on link icon. There should be no "Open link in" dropdown

### In local dev
1. open `active_admin.js` and comment out `_removeTinyMCEOpenLinkInDropdown();` in line 201. 
2. Log is an an admin
3. Create a new page with the following components:
	- paragraph component
  	  - internal link (marketplace.va.gov). Set to open in new tab. 
  	  - internal link (marketplace.va.gov). Set to open in same tab
  	  - internal link (/about). Set to open in new tab
  	  - internal link (/about). Set to open in same tab
  	  - external link. Set to open in same tab
  	- CTA with an external link
  	- Image with an external link
  	- Downloadable file
  	- Practices
  	- Subpage hyperlink
4. Save and publish the page
5. Visit published page and click on each link. 
  - All internal links should open in the same tab
  - All external links
    - should open in a new tab
    - should have "usa-link--external styling" (e.g. icon) UNLESS they are an image or button

## Screenshots, Gifs, Videos from application (if applicable)
### Before
![link-dropdown-before](https://user-images.githubusercontent.com/5402927/179636429-460b61b2-2bb1-4f34-83e7-319772947f34.png)
![content-before](https://user-images.githubusercontent.com/5402927/179636575-eb8c767c-0743-44e5-bc26-7d8ca1bf668d.png)

### After
![link-dropdown-after](https://user-images.githubusercontent.com/5402927/179636432-5c301c15-f40d-402f-a2e5-0260b18afe84.png)
![Screen Shot 2022-07-15 at 3 13 23 PM](https://user-images.githubusercontent.com/5402927/179636456-8f17c362-f43d-42e1-a242-5c349734a00e.png)
![content-after](https://user-images.githubusercontent.com/5402927/179636579-8bdfbf72-efbc-4687-a0c1-f4a534b54c26.png)

## Link to mock-ups/mock ups (image file if you have it) (if applicable)


## Acceptance criteria
- Make internal links in PB automatically open in same tab
- Make external links in PB open in new tab
- Take “Open link in…” dropdown out

## Definition of done
- [ ] Unit tests written (if applicable)
- [x] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating JIRA issue
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs