### PR TITLE
Add CRH creation to full import task

### DIFF
--- a/lib/tasks/dm.rake
+++ b/lib/tasks/dm.rake
@@ -18,6 +18,7 @@ namespace :dm do
     Rake::Task['visns:create_visns_and_transfer_data'].execute
     Rake::Task['va_facilities:create_or_update_va_facilities'].execute
     Rake::Task['visns:create_visn_liaisons_and_transfer_data'].execute
+    Rake::Task['clinical_resource_hubs:create_clinical_resource_hubs'].execute
     Rake::Task['diffusion_history:all'].execute
     Rake::Task['go_fish_practices:assign_go_fish_badge'].execute
     Rake::Task['shark_tank_practices:assign_shark_tank_badge'].execute


### PR DESCRIPTION
### JIRA issue link
[DM-3477](https://agile6.atlassian.net/browse/DM-3477?atlOrigin=eyJpIjoiMTMwYjE2OWJjNDVlNGI5NTkyMTVmZGIzNzdlZjJlMTMiLCJwIjoiaiJ9)

## Description - what does this code do?
This PR adds clinical resource hub creation to the `full_import` task used in local dev. This fixes a local development issue where the VISN index threw an error for public users.

## Testing done - how did you test it/steps on how can another person can test it 
1. In your local dev environment run `rails dm:reset_up` (this destroys the current data and runs `full_import`).
2. As a public user, click on the VISN index. No errors should occur and several VISNs should be visible.
3. Go to the Facilities Index. Several Clinical Resource Hubs should be visible at the bottom of the list.

## Screenshots, Gifs, Videos from application (if applicable)


## Link to mock-ups/mock ups (image file if you have it) (if applicable)


## Acceptance criteria

## Definition of done
- [ ] Unit tests written (if applicable)
- [ ] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating JIRA issue
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs