### PR TITLE
Run tests with a headless driver

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -152,7 +152,6 @@ end
 
 # Capybara.javascript_driver = :webkit
 # Capybara.default_driver = :sniffybara
-Capybara.default_driver = :selenium_chrome
+# Capybara.default_driver = :selenium_chrome # Uncomment to debug feature tests 
+Capybara.default_driver = :selenium_chrome_headless
 Capybara.enable_aria_label = true
-
-# Capybara.javascript_driver = :chrome


### PR DESCRIPTION
### JIRA issue link


## Description - what does this code do?
This is a small tweak for developer experience. By running our tests with `:selenium_chrome_headless`, developers can run tests locally without the browser taking over the mouse. This increases our ability to multitask while tests are running. My initial tests indicate that test suite times and flaky test rates are similar. 

I commented out `:selenium_chrome` and left it in the code because it may still provide utility while debugging tests locally. For example, a developer can debug a flaky test by adding `byebug` to the middle of a test and inspect markup in the browser.

## Testing done - how did you test it/steps on how can another person can test it 
1. Run `bundle exec rspec` in your local dev environment.
2. You should be able to use Chrome for other work while running the test suite.

## Screenshots, Gifs, Videos from application (if applicable)


## Link to mock-ups/mock ups (image file if you have it) (if applicable)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Unit tests written (if applicable)
- [ ] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating JIRA issue
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs