### PR TITLE
DM-3514: Update header logo for WGB compliance

### DIFF
--- a/app/assets/stylesheets/dm/pages/_partials/_header.scss
+++ b/app/assets/stylesheets/dm/pages/_partials/_header.scss
@@ -1,4 +1,12 @@
 #dm-nav-header {
+  .header-logo-link{
+    color: color($theme-color-primary-darker);
+
+    .header-logo-va {
+    border-right: 2px solid color($theme-color-primary-darker);
+    }
+  }
+
   .dm-header--mobile-searchbar {
     .dm-navbar-search-form {
       @include u-margin-bottom(4);

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -6,12 +6,12 @@
   <div class="usa-navbar padding-x-0 margin-0 desktop:width-full">
     <div class="usa-logo">
       <em class="usa-logo__text">
-        <a class="display-flex" href="/" title="Home" aria-label="Home">
-          <img class="width-4 height-4 margin-top-2px" src="<%= asset_path( 'va-seal.png' ) %>" alt="Seal of the Department of Veterans Affairs"/>
-          <p class="margin-0 margin-left-1 text-ink line-height-sans-1 padding-top-2px">
-            <span class="text-bold font-sans-sm desktop:font-sans-lg">Diffusion Marketplace</span><br>
-            <span class="font-sans-3xs text-light desktop:font-sans-sm">Department of Veterans Affairs</span>
-          </p>
+        <a class="display-flex header-logo-link" href="/" title="Home" aria-label="Home">
+          <span class='header-logo-va padding-right-2 desktop:font-sans-2xl font-sans-xl'>VA</span>
+          <span class='padding-left-2 desktop:font-sans-lg font-sans-sm flex-align-self-center'>
+          <span class="">Diffusion</span><br>
+          <span>Marketplace</span>
+          </span>
         </a>
       </em>
     </div>

--- a/spec/features/shared/header_spec.rb
+++ b/spec/features/shared/header_spec.rb
@@ -19,8 +19,7 @@ describe 'Diffusion Marketplace header', type: :feature, js: true do
   describe 'header logo' do
     it 'should exist' do
       within('header.usa-header') do
-        expect(page).to have_content('Diffusion Marketplace')
-        expect(page).to have_content('Department of Veterans Affairs')
+        expect(page).to have_content(/VA\nDiffusion\nMarketplace/)
         expect(page).to have_link(href: '/')
       end
     end


### PR DESCRIPTION
### JIRA issue link
https://agile6.atlassian.net/browse/DM-3514

## Description - what does this code do?
- This code removes the VA logo from the header, in compliance with WGB. See #538 / DM-3459 for related WGB compliance work in footer.

## Testing done - how did you test it/steps on how can another person can test it 
1. Open website and look at header. There should be no VA seal. 
2. Resize the page to tablet and mobile widths. The proportion of "VA" to "Diffusion Marketplace" should change slightly in the mobile width.

## Screenshots, Gifs, Videos from application (if applicable)
### Before
![Screen Shot 2022-08-16 at 8 56 45 AM](https://user-images.githubusercontent.com/5402927/184924946-5ef2a300-275d-43bc-8b69-a3aff82d18e8.png)
![Screen Shot 2022-08-16 at 8 56 37 AM](https://user-images.githubusercontent.com/5402927/184924949-5e887585-4982-4055-b2a9-e560d07dc75c.png)


### After
![Screen Shot 2022-08-16 at 8 56 23 AM](https://user-images.githubusercontent.com/5402927/184924921-4e6491be-b043-4c78-8ba0-c11d45cffef1.png)
![Screen Shot 2022-08-16 at 8 56 17 AM](https://user-images.githubusercontent.com/5402927/184924928-fcb6b15f-12e5-4660-8976-001861d53fc8.png)

## Link to mock-ups/mock ups (image file if you have it) (if applicable)
https://www.figma.com/file/dkvSpADVqwN5KKByF1TVIa/Design-System---VA-DM?node-id=1305%3A1714

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Unit tests written (if applicable)
- [x] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating JIRA issue
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs