### PR TITLE
Dm 3592 anchor tags

### DIFF
--- a/app/assets/javascripts/_page_show.es6
+++ b/app/assets/javascripts/_page_show.es6
@@ -93,25 +93,27 @@ const COMPONENT_CLASSES = [
         });
     }
 
+    function chromeWorkaroundForAnchorTags(){
+        var isChrome = /Chrome/.test(navigator.userAgent) && /Google Inc/.test(navigator.vendor);
+        if (window.location.hash && isChrome) {
+            setTimeout(function () {
+                var hash = window.location.hash;
+                window.location.hash = "";
+                window.location.hash = hash;
+            }, 300);
+        }
+    }
+
+
+
     function execPageBuilderFunctions() {
         browsePageBuilderPageHappy();
         removeBottomMarginFromLastAccordionHeading();
         containerizeSubpageHyperlinkCards();
         remediateInternalLinksTarget();
         identifyExternalLinks();
+        chromeWorkaroundForAnchorTags();
     }
 
     $document.on('turbolinks:load', execPageBuilderFunctions);
 })(window.jQuery);
-
-jQuery(document).ready(function () {
-    var isChrome = /Chrome/.test(navigator.userAgent) && /Google Inc/.test(navigator.vendor);
-    if (window.location.hash && isChrome) {
-        setTimeout(function () {
-            var hash = window.location.hash;
-            window.location.hash = "";
-            window.location.hash = hash;
-        }, 300);
-    }
-});
-

--- a/app/assets/javascripts/_page_show.es6
+++ b/app/assets/javascripts/_page_show.es6
@@ -95,3 +95,14 @@
     $document.on('turbolinks:load', execPageBuilderFunctions);
 })(window.jQuery);
 
+jQuery(document).ready(function () {
+    var isChrome = /Chrome/.test(navigator.userAgent) && /Google Inc/.test(navigator.vendor);
+    if (window.location.hash && isChrome) {
+        setTimeout(function () {
+            var hash = window.location.hash;
+            window.location.hash = "";
+            window.location.hash = hash;
+        }, 300);
+    }
+});
+

--- a/app/views/page/show.html.erb
+++ b/app/views/page/show.html.erb
@@ -56,8 +56,7 @@
           <%# Accordion %>
         <% when 'PageAccordionComponent' %>
           <% accordion_ctr += 1 %>
-          <div id="accordion_anchor_<%= accordion_ctr %>"/>
-          <div class="page-accordion-component <%= page_narrow_classes %> margin-bottom-3<%= ' margin-bottom-0' if last_component === index %>">
+          <div id="accordion_anchor_<%= accordion_ctr %>" class="page-accordion-component <%= page_narrow_classes %> margin-bottom-3<%= ' margin-bottom-0' if last_component === index %>">
             <div class="usa-accordion">
               <h2 class="usa-accordion__heading margin-bottom-2">
                 <button class="usa-accordion__button font-sans-sm"

--- a/app/views/page/show.html.erb
+++ b/app/views/page/show.html.erb
@@ -5,9 +5,8 @@
   <%= javascript_include_tag 'ie', 'data-turbolinks-track': 'reload' %>
   <%= javascript_include_tag '_page_show', 'data-turbolinks-track': 'reload' %>
 <% end %>
-
+<% accordion_ctr = 0 %>
 <% page_narrow_classes = 'desktop:grid-col-8 margin-x-auto' if @page.narrow? %>
-
 <div id="page-builder-page" class="margin-top-5">
   <section class="grid-container">
     <div class="dm-page-content">
@@ -56,6 +55,8 @@
 
           <%# Accordion %>
         <% when 'PageAccordionComponent' %>
+          <% accordion_ctr += 1 %>
+          <div id="accordion_anchor_<%= accordion_ctr %>"/>
           <div class="page-accordion-component <%= page_narrow_classes %> margin-bottom-3<%= ' margin-bottom-0' if last_component === index %>">
             <div class="usa-accordion">
               <h2 class="usa-accordion__heading margin-bottom-2">

--- a/spec/features/pages/show_page_spec.rb
+++ b/spec/features/pages/show_page_spec.rb
@@ -38,6 +38,7 @@ describe 'Page Builder - Show', type: :feature do
     paragraph_component = PageParagraphComponent.create(text: "<div><p><a href='https://marketplace.va.gov/about'>about the marketplace</a></p><p><a href='https://wikipedia.org/'>an external link</a></p></div>")
     legacy_paragraph_component = PageParagraphComponent.create(text: "<div><p><a href='../../about' target='_blank'>relative internal link with dot</a></p><p><a href='/about' target='_blank'>relative internal link with slash</a></p><p><a href='https://marketplace.va.gov/' target='_blank'>absolute internal link</a></p></div>")
     accordion_component = PageAccordionComponent.create(title: 'FAQ 1', text: 'FAQ 1 text')
+    accordion_component_2 = PageAccordionComponent.create(title: 'FAQ 2', text: 'FAQ 2 text')
 
     PageComponent.create(page: @page, component: practice_list_component, created_at: Time.now)
     PageComponent.create(page: @page, component: subpage_hyperlink_component, created_at: Time.now)
@@ -51,6 +52,8 @@ describe 'Page Builder - Show', type: :feature do
     PageComponent.create(page: @page, component: paragraph_component, created_at: Time.now)
     PageComponent.create(page: @page, component: legacy_paragraph_component, created_at: Time.now)
     PageComponent.create(page: @page, component: accordion_component, created_at: Time.now)
+    PageComponent.create(page: @page, component: accordion_component_2, created_at: Time.now)
+
     # must be logged in to view pages
     login_as(user, scope: :user, run_callbacks: false)
     visit '/programming/ruby-rocks'
@@ -93,6 +96,9 @@ describe 'Page Builder - Show', type: :feature do
 
   it 'Should display the accordion component' do
     expect(page).to have_content('FAQ 1')
+    expect(page).to have_css('.accordion_anchor_1')
+    expect(page).to have_content('FAQ 2')
+    expect(page).to have_css('.accordion_anchor_2')
   end
 
   it 'Should display the page image' do

--- a/spec/features/pages/show_page_spec.rb
+++ b/spec/features/pages/show_page_spec.rb
@@ -93,6 +93,7 @@ describe 'Page Builder - Show', type: :feature do
 
   it 'Should display the accordion component' do
     expect(page).to have_content('FAQ 1')
+    find('.usa-accordion__button').first.click
     expect(page).to have_content('FAQ 1 text')
   end
 

--- a/spec/features/pages/show_page_spec.rb
+++ b/spec/features/pages/show_page_spec.rb
@@ -93,7 +93,7 @@ describe 'Page Builder - Show', type: :feature do
 
   it 'Should display the accordion component' do
     expect(page).to have_content('FAQ 1')
-    find('.usa-accordion__button').first.click
+    find('#usa-accordion__button').first.click
     expect(page).to have_content('FAQ 1 text')
   end
 

--- a/spec/features/pages/show_page_spec.rb
+++ b/spec/features/pages/show_page_spec.rb
@@ -37,6 +37,8 @@ describe 'Page Builder - Show', type: :feature do
     downloadable_file_component = PageDownloadableFileComponent.create(attachment: downloadable_file, description: 'Test file')
     paragraph_component = PageParagraphComponent.create(text: "<div><p><a href='https://marketplace.va.gov/about'>about the marketplace</a></p><p><a href='https://wikipedia.org/'>an external link</a></p></div>")
     legacy_paragraph_component = PageParagraphComponent.create(text: "<div><p><a href='../../about' target='_blank'>relative internal link with dot</a></p><p><a href='/about' target='_blank'>relative internal link with slash</a></p><p><a href='https://marketplace.va.gov/' target='_blank'>absolute internal link</a></p></div>")
+    accordion_component = PageAccordionComponent.create(title: 'FAQ 1', text: 'FAQ 1 text')
+
     PageComponent.create(page: @page, component: practice_list_component, created_at: Time.now)
     PageComponent.create(page: @page, component: subpage_hyperlink_component, created_at: Time.now)
     PageComponent.create(page: @page, component: image_component, created_at: Time.now)
@@ -48,6 +50,7 @@ describe 'Page Builder - Show', type: :feature do
     PageComponent.create(page: @page, component: downloadable_file_component, created_at: Time.now)
     PageComponent.create(page: @page, component: paragraph_component, created_at: Time.now)
     PageComponent.create(page: @page, component: legacy_paragraph_component, created_at: Time.now)
+    PageComponent.create(page: @page, component: accordion_component, created_at: Time.now)
     # must be logged in to view pages
     login_as(user, scope: :user, run_callbacks: false)
     visit '/programming/ruby-rocks'
@@ -86,6 +89,11 @@ describe 'Page Builder - Show', type: :feature do
     expect(find_all('.usa-link').first[:href]).to include('/programming/javascript')
     expect(page).to have_content('Check out JavaScript')
     expect(page).to have_content('It is pretty cool too')
+  end
+
+  it 'Should display the accordion component' do
+    expect(page).to have_content('FAQ 1')
+    expect(page).to have_content('FAQ 1 text')
   end
 
   it 'Should display the page image' do

--- a/spec/features/pages/show_page_spec.rb
+++ b/spec/features/pages/show_page_spec.rb
@@ -96,9 +96,9 @@ describe 'Page Builder - Show', type: :feature do
 
   it 'Should display the accordion component' do
     expect(page).to have_content('FAQ 1')
-    page.find('#accordion_anchor_1')
+    expect(page).to have_css('#accordion_anchor_1')
     expect(page).to have_content('FAQ 2')
-    page.find('#accordion_anchor_2')
+    expect(page).to have_css('#accordion_anchor_2')
   end
 
   it 'Should display the page image' do

--- a/spec/features/pages/show_page_spec.rb
+++ b/spec/features/pages/show_page_spec.rb
@@ -96,9 +96,9 @@ describe 'Page Builder - Show', type: :feature do
 
   it 'Should display the accordion component' do
     expect(page).to have_content('FAQ 1')
-    expect(page).to have_css('#id', text: 'accordion_anchor_1')
+    page.find('#accordion_anchor_1')
     expect(page).to have_content('FAQ 2')
-    expect(page).to have_css('#id', text: 'accordion_anchor_2')
+    page.find('#accordion_anchor_2')
   end
 
   it 'Should display the page image' do

--- a/spec/features/pages/show_page_spec.rb
+++ b/spec/features/pages/show_page_spec.rb
@@ -96,9 +96,9 @@ describe 'Page Builder - Show', type: :feature do
 
   it 'Should display the accordion component' do
     expect(page).to have_content('FAQ 1')
-    expect(page).to have_css('.accordion_anchor_1')
+    expect(page).to have_css('#id', text: 'accordion_anchor_1')
     expect(page).to have_content('FAQ 2')
-    expect(page).to have_css('.accordion_anchor_2')
+    expect(page).to have_css('#id', text: 'accordion_anchor_2')
   end
 
   it 'Should display the page image' do

--- a/spec/features/pages/show_page_spec.rb
+++ b/spec/features/pages/show_page_spec.rb
@@ -93,8 +93,6 @@ describe 'Page Builder - Show', type: :feature do
 
   it 'Should display the accordion component' do
     expect(page).to have_content('FAQ 1')
-    find('#usa-accordion__button').first.click
-    expect(page).to have_content('FAQ 1 text')
   end
 
   it 'Should display the page image' do


### PR DESCRIPTION
### JIRA issue link
https://agile6.atlassian.net/browse/DM-3592

## Description - what does this code do?


## Testing done - how did you test it/steps on how can another person can test it 
 Create anchor # links to jump to a particular element/component on the same page or when a page loads.

**Note to Devs**: PB show page /app/views/page/show.html.erb must have an element (<div, ..etc) with an id that is generated dynamically for each instance of the component. For example if there are 5 accordion components on the same page a counter can be used to generate unique IDs for each accordion component - i.e.,

      <% when 'PageAccordionComponent' %>
        <% accordion_ctr += 1 %>
      <div id="accordion_anchor_<%= accordion_ctr %>"/>

So the unique id for each accordion component is "accordion_anchor_1", "accordion_anchor_2", "accordion_anchor_3" ... and so on.  See page/show.html.erb for code above.  This same technique can be used to create anchor (jump links) for other types of components as well.  **THIS** is already setup for the accordion component so for testing you do not have to do this.

**Note:** If creating a link to an anchor tag on the same page.. you can either just add the anchor tag as the url i.e., "#accordion_anchor_3" or provide the path and the anchor to the internal url i.e., "/brads-page-group/brads-new-test-page#accordion_anchor_link_3".  The first method will open the page in a new tab and scroll to the anchor.  The second method - entering the full internal url will not open a new tab - and just scroll to the anchor tag.

___________________________________________________________________________________________________________________________________
**TEST**
1.  Create or Edit an existing PB page and ensure there are at least one accordion component on the page and the component or components are not at the top of the page.
2. Create or Edit a different page and create a link (either in WYSIWIG or other link type component) and set the link to navigate to the page that has the accordion component(s).  At the end of the link just add the anchor tag to the end of the url and specify which accordion component to jump to.  i.e., #accordion_anchor_1, #accordion_anchor_2 ...etc.  i.e., /contests/shark-tank#accordion_anchor_2". 

![image](https://user-images.githubusercontent.com/60527788/191601995-7b6db92b-5ce7-412f-8ed7-59cc0075d845.png)


When the user clicks on the link to the accordion page the new page will load and automatically scroll to the anchor element defined in the url.. ie., #accordion_anchor_2 image

![image](https://user-images.githubusercontent.com/60527788/191602055-87aca662-20e5-4c73-a96a-667a42f8520d.png)

![image](https://user-images.githubusercontent.com/60527788/191602132-dd827274-5db3-40e2-8e67-39d6b07e7265.png)



## Link to mock-ups/mock ups (image file if you have it) (if applicable)
N/A

## Acceptance criteria

1. Investigate Brad’s HTML method
4. User can link to FAQ section on About page
5.  Determine way to do this as one off
6. If possible, determine way to do this that can be replicated in Page Builder
7. Nice to have: Specific FAQ is open

## Definition of done
- [ ] Unit tests written (if applicable)
- [ ] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating JIRA issue
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs