### PR TITLE
DM-3626: Refactored grid column setup for 'CompoundBody' component

### DIFF
--- a/app/assets/stylesheets/dm/components/page_component.scss
+++ b/app/assets/stylesheets/dm/components/page_component.scss
@@ -79,7 +79,7 @@
   .page-compound-body-component {
     display: grid;
     grid-template-columns: repeat(12, 1fr);
-    gap: 2px;
+    column-gap: 24px;
 
     .grid-item-text {
       grid-column: 1 / 13;
@@ -90,18 +90,18 @@
       }
 
       @media screen and (min-width: 1024px) {
-        grid-column: 1 / 6;
+        grid-column: 1 / 7;
         grid-row: 1 / 1;
 
         &.no-images {
-          grid-column: 1 / 7;
+          grid-column: 1 / 9;
         }
 
         &.right-align {
-          grid-column: 8 / 13;
+          grid-column: 7 / 13;
 
           &.no-images {
-            grid-column: 7 / 13;
+            grid-column: 5 / 13;
           }
         }
       }
@@ -113,12 +113,12 @@
       @include u-margin-bottom(4);
 
       @media screen and (min-width: 1024px) {
-        grid-column: 9 / 13;
+        grid-column: 8 / 13;
         grid-row: 1 / 1;
         @include u-margin-bottom(0);
 
         &.left-align {
-          grid-column: 1 / 5;
+          grid-column: 1 / 6;
         }
       }
 

--- a/app/views/page/_compound_body_component.html.erb
+++ b/app/views/page/_compound_body_component.html.erb
@@ -50,7 +50,7 @@
 <%# Images %>
 <% if images.present? %>
   <div class="grid-item-images<%= ' left-align' if component.text_alignment === 'Right' %><%= ' margin-bottom-0' if no_text %>">
-    <div class="grid-row grid-gap-2px">
+    <div class="grid-row desktop:grid-gap-3">
       <% images.each_with_index do |image, index| %>
         <%
           signed_image = image.image_s3_presigned_url(:thumb)

--- a/spec/features/pages/show_page_spec.rb
+++ b/spec/features/pages/show_page_spec.rb
@@ -250,11 +250,11 @@ describe 'Page Builder - Show', type: :feature do
       add_compound_body_component_and_fill_in_fields
       save_page
       expect(page).to have_content('Page was successfully updated.')
-      # With no PageComponentImages present, the CompoundBodyComponent text should take up six columns
+      # With no PageComponentImages present, the CompoundBodyComponent text should take up eight columns
       visit '/programming/javascript'
       expect(page).to have_selector('div.page-compound-body-component.margin-bottom-0.margin-top-4')
       within(:css, '.page-compound-body-component') do
-        expect(find('.grid-item-text').matches_style?('grid-column' => '1 / 7')).to be(true)
+        expect(find('.grid-item-text').matches_style?('grid-column' => '1 / 9')).to be(true)
         expect(page).to have_selector('h2', class: 'usa-prose-h2')
         expect(page).to have_text('Cool Title')
         expect(page).to have_text('Lorem ipsum dolor sit amet, consectetur adipiscing elit.')
@@ -276,16 +276,16 @@ describe 'Page Builder - Show', type: :feature do
       )
       save_page
       expect(page).to have_content('Page was successfully updated.')
-      # With one PageComponentImage present, the CompoundBodyComponent text should now only take up five columns.
-      # The associated PageComponentImage should take up four columns.
+      # With one PageComponentImage present, the CompoundBodyComponent text should now only take up six columns.
+      # The associated PageComponentImage should take up five columns.
       visit '/programming/javascript'
       expect(page).to be_accessible.according_to :wcag2a, :section508
       # Make sure the updated CompoundBodyComponent fields are represented
       within(:css, '.page-compound-body-component') do
         # Right-aligned text
         expect(page).to have_selector('div.grid-item-text.right-align')
-        # Five columns worth of text, but on the right side of the grid now
-        expect(find('.grid-item-text').matches_style?('grid-column' => '8 / 13')).to be(true)
+        # Six columns worth of text, but on the right side of the grid now
+        expect(find('.grid-item-text').matches_style?('grid-column' => '7 / 13')).to be(true)
         # The larger title gets 'h1' styling
         expect(page).to have_selector('h2', class: 'usa-prose-h1')
         # Link with link text


### PR DESCRIPTION
### JIRA issue link
https://agile6.atlassian.net/browse/DM-3626

## Description - what does this code do?
Makes adjustments to the column widths for the `PageCompoundBodyComponent`

## Testing done - how did you test it/steps on how can another person can test it 
1. Log in as an admin and create/edit a Page via `/admin/pages`.
2. Add two or more "Text and Images" components. For at least one of them, be sure to NOT add any images.
3. Once you've got them added to the Page, visit that Page's show page and confirm the following:
   - For a `PageCompoundBodyComponent` that only has text, that text should take up eight columns.
   - For a `PageCompoundBodyComponent` that has text AND image(s), the text should take up six columns, the image(s) should take up five columns, and there should be one column of space in between them.
   - Each column should have a gutter size of `24px`.

## Screenshots, Gifs, Videos from application (if applicable)
![](https://user-images.githubusercontent.com/34111449/195678774-d0035bbe-6976-4ae6-8eaa-c2bc19b48f70.png)
![](https://user-images.githubusercontent.com/34111449/195678788-ef8f40c5-f522-48c9-8b86-d92e69574b0b.png)

## Link to mock-ups/mock ups (image file if you have it) (if applicable)


## Acceptance criteria
- Grid for component should have a 24px gutter (grid gap)
- “Featured” component styling should match current homepage design 
- Text should stretch 6 columns, image should stretch 5 columns, and there should be one column for spacing
- Have Design check to make sure it’s right

## Definition of done
- [ ] Unit tests written (if applicable)
- [ ] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [X] A link has been provided to the originating JIRA issue
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs