### PR TITLE
Dm compound body spacing fix

### DIFF
--- a/app/admin/pages.rb
+++ b/app/admin/pages.rb
@@ -47,8 +47,8 @@ ActiveAdmin.register Page do
                     :text_alignment,
                     :url_link_text,
                     :large_title,
-                    :margin_bottom,
-                    :margin_top,
+                    :padding_bottom,
+                    :padding_top,
                     :published_date,
                     practices: []
                   ],
@@ -167,10 +167,10 @@ ActiveAdmin.register Page do
 
             # Display name
             para component&.display_name if pc.component_type == 'PageDownloadableFileComponent' && component&.display_name.present?
-            # Margin bottom
-            para "Margin bottom: #{component&.margin_bottom}" if pc.component_type == 'PageCompoundBodyComponent'
-            # Margin top
-            para "Margin top: #{component&.margin_top}" if pc.component_type == 'PageCompoundBodyComponent'
+            # Padding bottom
+            para "Padding bottom: #{component&.padding_bottom}" if pc.component_type == 'PageCompoundBodyComponent'
+            # Padding top
+            para "Padding top: #{component&.padding_top}" if pc.component_type == 'PageCompoundBodyComponent'
             # PageComponentImages
             if pc.page_component_images.present?
               para 'Images:'

--- a/app/assets/stylesheets/dm/components/page_component.scss
+++ b/app/assets/stylesheets/dm/components/page_component.scss
@@ -76,6 +76,7 @@
     }
   }
 
+  // Per design, these styles should mimic the homepage's 'Featured' innovation and 'Featured' topic styles as much as possible (10/14/2022)
   .page-compound-body-component {
     display: grid;
     grid-template-columns: repeat(12, 1fr);

--- a/app/models/page_compound_body_component.rb
+++ b/app/models/page_compound_body_component.rb
@@ -5,7 +5,7 @@ class PageCompoundBodyComponent < ApplicationRecord
     in: %w[Left Right],
     message: "%{value} is not a valid text alignment"
   }
-  validates :margin_bottom, :margin_top, allow_blank: true, inclusion: {
+  validates :padding_bottom, :padding_top, allow_blank: true, inclusion: {
     in: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
     message: "%{value} is not a valid %{attribute} size"
   }

--- a/app/views/active_admin/resource/_page_compound_body_component_form.html.arb
+++ b/app/views/active_admin/resource/_page_compound_body_component_form.html.arb
@@ -97,7 +97,7 @@ html = Arbre::Context.new do
           end
 
           para class: 'inline-hints' do
-            span "Choose the bottom padding for this 'Compound Body' component (option are based on USWDS units:"
+            span "Choose the bottom padding for this 'Compound Body' component (options are based on USWDS units)"
             a 'USWDS padding units',
               href: uswds_padding_link,
               class: 'usa-link usa-link--external',
@@ -119,7 +119,7 @@ html = Arbre::Context.new do
           end
 
           para class: 'inline-hints' do
-            span "Choose the top padding for this 'Compound Body' component (option are based on USWDS units:"
+            span "Choose the top padding for this 'Compound Body' component (options are based on USWDS units)"
             a 'USWDS padding units',
               href: uswds_padding_link,
               class: 'usa-link usa-link--external',

--- a/app/views/active_admin/resource/_page_compound_body_component_form.html.arb
+++ b/app/views/active_admin/resource/_page_compound_body_component_form.html.arb
@@ -81,50 +81,50 @@ html = Arbre::Context.new do
           para 'Enter the text that will displayed for the link to the URL above', class: 'inline-hints'
         end
 
-        uswds_margin_units = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
-        uswds_margin_link = 'https://designsystem.digital.gov/utilities/margin-and-padding/'
+        uswds_padding_units = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+        uswds_padding_link = 'https://designsystem.digital.gov/utilities/margin-and-padding/'
 
-        # Margin bottom
-        li class: 'select input margin-bottom-container',
-           id: "page_page_components_attributes_#{placeholder}_component_attributes_margin_bottom_input" do
-          label 'Margin bottom', for: "page_page_components_attributes_#{placeholder}_component_attributes_margin_bottom", class: 'label'
-          select value: component&.margin_bottom || nil,
-                 id: "page_page_components_attributes_#{placeholder}_component_attributes_margin_bottom",
-                 name: "page[page_components_attributes][#{placeholder}][component_attributes][margin_bottom]" do
-            uswds_margin_units.each do |unit|
-              option "#{unit}", selected: component&.margin_bottom === unit
+        # Padding bottom
+        li class: 'select input padding-bottom-container',
+           id: "page_page_components_attributes_#{placeholder}_component_attributes_padding_bottom_input" do
+          label 'Padding bottom', for: "page_page_components_attributes_#{placeholder}_component_attributes_padding_bottom", class: 'label'
+          select value: component&.padding_bottom || nil,
+                 id: "page_page_components_attributes_#{placeholder}_component_attributes_padding_bottom",
+                 name: "page[page_components_attributes][#{placeholder}][component_attributes][padding_bottom]" do
+            uswds_padding_units.each do |unit|
+              option "#{unit}", selected: component&.padding_bottom === unit
             end
           end
 
           para class: 'inline-hints' do
-            span "Choose the bottom margin for this 'Compound Body' component (option are based on USWDS units:"
-            a 'USWDS margin units',
-              href: uswds_margin_link,
+            span "Choose the bottom padding for this 'Compound Body' component (option are based on USWDS units:"
+            a 'USWDS padding units',
+              href: uswds_padding_link,
               class: 'usa-link usa-link--external',
               target: '_blank'
-            span "Ex: '3' would equate to 'margin-bottom-3'. Defaults to 0."
+            span "Ex: '3' would equate to 'padding-bottom-3'. Defaults to 0."
           end
         end
 
-        # Margin top
-        li class: 'select input margin-top-container',
-           id: "page_page_components_attributes_#{placeholder}_component_attributes_margin_top_input" do
-          label 'Margin top', for: "page_page_components_attributes_#{placeholder}_component_attributes_margin_top", class: 'label'
-          select value: component&.margin_top || nil,
-                 id: "page_page_components_attributes_#{placeholder}_component_attributes_margin_top",
-                 name: "page[page_components_attributes][#{placeholder}][component_attributes][margin_top]" do
-            uswds_margin_units.each do |unit|
-              option "#{unit}", selected: component&.margin_top === unit
+        # Padding top
+        li class: 'select input padding-top-container',
+           id: "page_page_components_attributes_#{placeholder}_component_attributes_padding_top_input" do
+          label 'Padding top', for: "page_page_components_attributes_#{placeholder}_component_attributes_padding_top", class: 'label'
+          select value: component&.padding_top || nil,
+                 id: "page_page_components_attributes_#{placeholder}_component_attributes_padding_top",
+                 name: "page[page_components_attributes][#{placeholder}][component_attributes][padding_top]" do
+            uswds_padding_units.each do |unit|
+              option "#{unit}", selected: component&.padding_top === unit
             end
           end
 
           para class: 'inline-hints' do
-            span "Choose the top margin for this 'Compound Body' component (option are based on USWDS units:"
-            a 'USWDS margin units',
-              href: uswds_margin_link,
+            span "Choose the top padding for this 'Compound Body' component (option are based on USWDS units:"
+            a 'USWDS padding units',
+              href: uswds_padding_link,
               class: 'usa-link usa-link--external',
               target: '_blank'
-            span "Ex: '3' would equate to 'margin-top-3'. Defaults to 0."
+            span "Ex: '3' would equate to 'padding-top-3'. Defaults to 0."
           end
         end
 

--- a/app/views/page/_compound_body_component.html.erb
+++ b/app/views/page/_compound_body_component.html.erb
@@ -74,12 +74,12 @@
               <% else %>
                 <img src="<%= signed_image %>" alt="<%= alt_text %>" class="height-full width-full"/>
               <% end %>
-              <% if caption.present? %>
-                <div class="dm-word-break-break-word dm-hyphens-auto margin-top-105">
-                  <%= caption.html_safe %>
-                </div>
-              <% end %>
             </div>
+            <% if caption.present? %>
+              <div class="dm-word-break-break-word dm-hyphens-auto margin-top-105">
+                <%= caption.html_safe %>
+              </div>
+            <% end %>
           </div>
       <% end %>
     </div>

--- a/app/views/page/show.html.erb
+++ b/app/views/page/show.html.erb
@@ -231,7 +231,7 @@
         <%# Text and Images %>
         <% when 'PageCompoundBodyComponent' %>
           <div
-            class="page-compound-body-component <%= last_component === index ? 'margin-bottom-0' : "margin-bottom-#{component.margin_bottom}" %> <%= "margin-top-#{component.margin_top}" %><%= page_narrow_classes %>">
+            class="page-compound-body-component <%= last_component === index ? 'margin-bottom-0 padding-bottom-0' : "padding-bottom-#{component.padding_bottom}" %> <%= "padding-top-#{component.padding_top}" %><%= page_narrow_classes %>">
             <%= render partial: 'compound_body_component', locals: { component: component } %>
           </div>
         <% end %>

--- a/db/migrate/20221013211727_rename_margin_columns_for_page_compound_body_components.rb
+++ b/db/migrate/20221013211727_rename_margin_columns_for_page_compound_body_components.rb
@@ -1,0 +1,6 @@
+class RenameMarginColumnsForPageCompoundBodyComponents < ActiveRecord::Migration[6.0]
+  def change
+    rename_column :page_compound_body_components, :margin_bottom, :padding_bottom
+    rename_column :page_compound_body_components, :margin_top, :padding_top
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_09_26_221108) do
+ActiveRecord::Schema.define(version: 2022_10_13_211727) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -39,7 +39,7 @@ ActiveRecord::Schema.define(version: 2022_09_26_221108) do
     t.datetime "updated_at", null: false
     t.string "attachment_file_name"
     t.string "attachment_content_type"
-    t.integer "attachment_file_size"
+    t.bigint "attachment_file_size"
     t.datetime "attachment_updated_at"
     t.index ["practice_id"], name: "index_additional_documents_on_practice_id"
   end
@@ -158,7 +158,7 @@ ActiveRecord::Schema.define(version: 2022_09_26_221108) do
     t.datetime "updated_at", null: false
     t.string "attachment_file_name"
     t.string "attachment_content_type"
-    t.integer "attachment_file_size"
+    t.bigint "attachment_file_size"
     t.datetime "attachment_updated_at"
     t.index ["practice_id"], name: "index_business_case_files_on_practice_id"
   end
@@ -193,7 +193,7 @@ ActiveRecord::Schema.define(version: 2022_09_26_221108) do
     t.datetime "updated_at", null: false
     t.string "attachment_file_name"
     t.string "attachment_content_type"
-    t.integer "attachment_file_size"
+    t.bigint "attachment_file_size"
     t.datetime "attachment_updated_at"
     t.index ["practice_id"], name: "index_checklist_files_on_practice_id"
   end
@@ -391,7 +391,7 @@ ActiveRecord::Schema.define(version: 2022_09_26_221108) do
     t.datetime "updated_at", null: false
     t.string "attachment_file_name"
     t.string "attachment_content_type"
-    t.integer "attachment_file_size"
+    t.bigint "attachment_file_size"
     t.datetime "attachment_updated_at"
     t.index ["practice_id"], name: "index_financial_files_on_practice_id"
   end
@@ -430,7 +430,7 @@ ActiveRecord::Schema.define(version: 2022_09_26_221108) do
     t.datetime "updated_at", null: false
     t.string "attachment_file_name"
     t.string "attachment_content_type"
-    t.integer "attachment_file_size"
+    t.bigint "attachment_file_size"
     t.datetime "attachment_updated_at"
     t.boolean "is_main_display_image", default: false
     t.index ["practice_id"], name: "index_impact_photos_on_practice_id"
@@ -445,7 +445,7 @@ ActiveRecord::Schema.define(version: 2022_09_26_221108) do
     t.datetime "updated_at", null: false
     t.string "attachment_file_name"
     t.string "attachment_content_type"
-    t.integer "attachment_file_size"
+    t.bigint "attachment_file_size"
     t.datetime "attachment_updated_at"
     t.index ["practice_id"], name: "index_implementation_timeline_files_on_practice_id"
   end
@@ -549,8 +549,8 @@ ActiveRecord::Schema.define(version: 2022_09_26_221108) do
     t.string "url_link_text"
     t.string "title_header"
     t.string "text_alignment"
-    t.integer "margin_top"
-    t.integer "margin_bottom"
+    t.integer "padding_top"
+    t.integer "padding_bottom"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["page_component_id"], name: "index_page_compound_body_components_on_page_component_id"
@@ -574,7 +574,7 @@ ActiveRecord::Schema.define(version: 2022_09_26_221108) do
     t.datetime "updated_at", null: false
     t.string "attachment_file_name"
     t.string "attachment_content_type"
-    t.integer "attachment_file_size"
+    t.bigint "attachment_file_size"
     t.datetime "attachment_updated_at"
     t.index ["page_component_id"], name: "index_page_downloadable_file_components_on_page_component_id"
   end
@@ -642,7 +642,7 @@ ActiveRecord::Schema.define(version: 2022_09_26_221108) do
     t.datetime "updated_at", null: false
     t.string "page_image_file_name"
     t.string "page_image_content_type"
-    t.integer "page_image_file_size"
+    t.bigint "page_image_file_size"
     t.datetime "page_image_updated_at"
     t.string "url"
     t.index ["page_component_id"], name: "index_page_image_components_on_page_component_id"
@@ -734,7 +734,7 @@ ActiveRecord::Schema.define(version: 2022_09_26_221108) do
     t.datetime "updated_at", null: false
     t.string "attachment_file_name"
     t.string "attachment_content_type"
-    t.integer "attachment_file_size"
+    t.bigint "attachment_file_size"
     t.datetime "attachment_updated_at"
     t.index ["practice_id"], name: "index_photo_files_on_practice_id"
   end
@@ -757,7 +757,7 @@ ActiveRecord::Schema.define(version: 2022_09_26_221108) do
     t.datetime "updated_at", null: false
     t.string "avatar_file_name"
     t.string "avatar_content_type"
-    t.integer "avatar_file_size"
+    t.bigint "avatar_file_size"
     t.datetime "avatar_updated_at"
     t.index ["practice_id"], name: "index_practice_creators_on_practice_id"
     t.index ["user_id"], name: "index_practice_creators_on_user_id"
@@ -826,7 +826,7 @@ ActiveRecord::Schema.define(version: 2022_09_26_221108) do
     t.datetime "updated_at", null: false
     t.string "attachment_file_name"
     t.string "attachment_content_type"
-    t.integer "attachment_file_size"
+    t.bigint "attachment_file_size"
     t.datetime "attachment_updated_at"
     t.string "name"
     t.string "description"
@@ -890,7 +890,7 @@ ActiveRecord::Schema.define(version: 2022_09_26_221108) do
     t.datetime "updated_at", null: false
     t.string "attachment_file_name"
     t.string "attachment_content_type"
-    t.integer "attachment_file_size"
+    t.bigint "attachment_file_size"
     t.datetime "attachment_updated_at"
     t.string "name"
     t.string "description"
@@ -914,7 +914,7 @@ ActiveRecord::Schema.define(version: 2022_09_26_221108) do
     t.datetime "updated_at", null: false
     t.string "attachment_file_name"
     t.string "attachment_content_type"
-    t.integer "attachment_file_size"
+    t.bigint "attachment_file_size"
     t.datetime "attachment_updated_at"
     t.index ["practice_id"], name: "index_practice_resources_on_practice_id"
   end
@@ -926,7 +926,7 @@ ActiveRecord::Schema.define(version: 2022_09_26_221108) do
     t.datetime "updated_at", null: false
     t.string "attachment_file_name"
     t.string "attachment_content_type"
-    t.integer "attachment_file_size"
+    t.bigint "attachment_file_size"
     t.datetime "attachment_updated_at"
     t.string "name"
     t.string "description"
@@ -943,7 +943,7 @@ ActiveRecord::Schema.define(version: 2022_09_26_221108) do
     t.datetime "updated_at", null: false
     t.string "attachment_file_name"
     t.string "attachment_content_type"
-    t.integer "attachment_file_size"
+    t.bigint "attachment_file_size"
     t.datetime "attachment_updated_at"
     t.string "name"
     t.string "description"
@@ -1035,11 +1035,11 @@ ActiveRecord::Schema.define(version: 2022_09_26_221108) do
     t.datetime "updated_at", null: false
     t.string "main_display_image_file_name"
     t.string "main_display_image_content_type"
-    t.integer "main_display_image_file_size"
+    t.bigint "main_display_image_file_size"
     t.datetime "main_display_image_updated_at"
     t.string "origin_picture_file_name"
     t.string "origin_picture_content_type"
-    t.integer "origin_picture_file_size"
+    t.bigint "origin_picture_file_size"
     t.datetime "origin_picture_updated_at"
     t.bigint "user_id"
     t.boolean "published", default: false
@@ -1064,7 +1064,7 @@ ActiveRecord::Schema.define(version: 2022_09_26_221108) do
     t.boolean "hidden", default: false, null: false
     t.string "highlight_attachment_file_name"
     t.string "highlight_attachment_content_type"
-    t.integer "highlight_attachment_file_size"
+    t.bigint "highlight_attachment_file_size"
     t.datetime "highlight_attachment_updated_at"
     t.boolean "is_public", default: false
     t.text "main_display_image_alt_text"
@@ -1081,7 +1081,7 @@ ActiveRecord::Schema.define(version: 2022_09_26_221108) do
     t.datetime "updated_at", null: false
     t.string "attachment_file_name"
     t.string "attachment_content_type"
-    t.integer "attachment_file_size"
+    t.bigint "attachment_file_size"
     t.datetime "attachment_updated_at"
     t.index ["practice_id"], name: "index_publication_files_on_practice_id"
   end
@@ -1141,7 +1141,7 @@ ActiveRecord::Schema.define(version: 2022_09_26_221108) do
     t.datetime "updated_at", null: false
     t.string "attachment_file_name"
     t.string "attachment_content_type"
-    t.integer "attachment_file_size"
+    t.bigint "attachment_file_size"
     t.datetime "attachment_updated_at"
     t.index ["practice_id"], name: "index_survey_result_files_on_practice_id"
   end
@@ -1166,7 +1166,7 @@ ActiveRecord::Schema.define(version: 2022_09_26_221108) do
     t.datetime "updated_at", null: false
     t.string "attachment_file_name"
     t.string "attachment_content_type"
-    t.integer "attachment_file_size"
+    t.bigint "attachment_file_size"
     t.datetime "attachment_updated_at"
     t.index ["practice_id"], name: "index_toolkit_files_on_practice_id"
   end
@@ -1181,7 +1181,7 @@ ActiveRecord::Schema.define(version: 2022_09_26_221108) do
     t.datetime "updated_at", null: false
     t.string "attachment_file_name"
     t.string "attachment_content_type"
-    t.integer "attachment_file_size"
+    t.bigint "attachment_file_size"
     t.datetime "attachment_updated_at"
   end
 
@@ -1232,7 +1232,7 @@ ActiveRecord::Schema.define(version: 2022_09_26_221108) do
     t.text "bio"
     t.string "avatar_file_name"
     t.string "avatar_content_type"
-    t.integer "avatar_file_size"
+    t.bigint "avatar_file_size"
     t.datetime "avatar_updated_at"
     t.string "location"
     t.string "facility"
@@ -1275,7 +1275,7 @@ ActiveRecord::Schema.define(version: 2022_09_26_221108) do
     t.datetime "updated_at", null: false
     t.string "avatar_file_name"
     t.string "avatar_content_type"
-    t.integer "avatar_file_size"
+    t.bigint "avatar_file_size"
     t.datetime "avatar_updated_at"
   end
 
@@ -1382,7 +1382,7 @@ ActiveRecord::Schema.define(version: 2022_09_26_221108) do
     t.datetime "updated_at", null: false
     t.string "attachment_file_name"
     t.string "attachment_content_type"
-    t.integer "attachment_file_size"
+    t.bigint "attachment_file_size"
     t.datetime "attachment_updated_at"
     t.index ["practice_id"], name: "index_video_files_on_practice_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -39,7 +39,7 @@ ActiveRecord::Schema.define(version: 2022_10_13_211727) do
     t.datetime "updated_at", null: false
     t.string "attachment_file_name"
     t.string "attachment_content_type"
-    t.bigint "attachment_file_size"
+    t.integer "attachment_file_size"
     t.datetime "attachment_updated_at"
     t.index ["practice_id"], name: "index_additional_documents_on_practice_id"
   end
@@ -158,7 +158,7 @@ ActiveRecord::Schema.define(version: 2022_10_13_211727) do
     t.datetime "updated_at", null: false
     t.string "attachment_file_name"
     t.string "attachment_content_type"
-    t.bigint "attachment_file_size"
+    t.integer "attachment_file_size"
     t.datetime "attachment_updated_at"
     t.index ["practice_id"], name: "index_business_case_files_on_practice_id"
   end
@@ -193,7 +193,7 @@ ActiveRecord::Schema.define(version: 2022_10_13_211727) do
     t.datetime "updated_at", null: false
     t.string "attachment_file_name"
     t.string "attachment_content_type"
-    t.bigint "attachment_file_size"
+    t.integer "attachment_file_size"
     t.datetime "attachment_updated_at"
     t.index ["practice_id"], name: "index_checklist_files_on_practice_id"
   end
@@ -391,7 +391,7 @@ ActiveRecord::Schema.define(version: 2022_10_13_211727) do
     t.datetime "updated_at", null: false
     t.string "attachment_file_name"
     t.string "attachment_content_type"
-    t.bigint "attachment_file_size"
+    t.integer "attachment_file_size"
     t.datetime "attachment_updated_at"
     t.index ["practice_id"], name: "index_financial_files_on_practice_id"
   end
@@ -430,7 +430,7 @@ ActiveRecord::Schema.define(version: 2022_10_13_211727) do
     t.datetime "updated_at", null: false
     t.string "attachment_file_name"
     t.string "attachment_content_type"
-    t.bigint "attachment_file_size"
+    t.integer "attachment_file_size"
     t.datetime "attachment_updated_at"
     t.boolean "is_main_display_image", default: false
     t.index ["practice_id"], name: "index_impact_photos_on_practice_id"
@@ -445,7 +445,7 @@ ActiveRecord::Schema.define(version: 2022_10_13_211727) do
     t.datetime "updated_at", null: false
     t.string "attachment_file_name"
     t.string "attachment_content_type"
-    t.bigint "attachment_file_size"
+    t.integer "attachment_file_size"
     t.datetime "attachment_updated_at"
     t.index ["practice_id"], name: "index_implementation_timeline_files_on_practice_id"
   end
@@ -574,7 +574,7 @@ ActiveRecord::Schema.define(version: 2022_10_13_211727) do
     t.datetime "updated_at", null: false
     t.string "attachment_file_name"
     t.string "attachment_content_type"
-    t.bigint "attachment_file_size"
+    t.integer "attachment_file_size"
     t.datetime "attachment_updated_at"
     t.index ["page_component_id"], name: "index_page_downloadable_file_components_on_page_component_id"
   end
@@ -642,7 +642,7 @@ ActiveRecord::Schema.define(version: 2022_10_13_211727) do
     t.datetime "updated_at", null: false
     t.string "page_image_file_name"
     t.string "page_image_content_type"
-    t.bigint "page_image_file_size"
+    t.integer "page_image_file_size"
     t.datetime "page_image_updated_at"
     t.string "url"
     t.index ["page_component_id"], name: "index_page_image_components_on_page_component_id"
@@ -734,7 +734,7 @@ ActiveRecord::Schema.define(version: 2022_10_13_211727) do
     t.datetime "updated_at", null: false
     t.string "attachment_file_name"
     t.string "attachment_content_type"
-    t.bigint "attachment_file_size"
+    t.integer "attachment_file_size"
     t.datetime "attachment_updated_at"
     t.index ["practice_id"], name: "index_photo_files_on_practice_id"
   end
@@ -757,7 +757,7 @@ ActiveRecord::Schema.define(version: 2022_10_13_211727) do
     t.datetime "updated_at", null: false
     t.string "avatar_file_name"
     t.string "avatar_content_type"
-    t.bigint "avatar_file_size"
+    t.integer "avatar_file_size"
     t.datetime "avatar_updated_at"
     t.index ["practice_id"], name: "index_practice_creators_on_practice_id"
     t.index ["user_id"], name: "index_practice_creators_on_user_id"
@@ -826,7 +826,7 @@ ActiveRecord::Schema.define(version: 2022_10_13_211727) do
     t.datetime "updated_at", null: false
     t.string "attachment_file_name"
     t.string "attachment_content_type"
-    t.bigint "attachment_file_size"
+    t.integer "attachment_file_size"
     t.datetime "attachment_updated_at"
     t.string "name"
     t.string "description"
@@ -890,7 +890,7 @@ ActiveRecord::Schema.define(version: 2022_10_13_211727) do
     t.datetime "updated_at", null: false
     t.string "attachment_file_name"
     t.string "attachment_content_type"
-    t.bigint "attachment_file_size"
+    t.integer "attachment_file_size"
     t.datetime "attachment_updated_at"
     t.string "name"
     t.string "description"
@@ -914,7 +914,7 @@ ActiveRecord::Schema.define(version: 2022_10_13_211727) do
     t.datetime "updated_at", null: false
     t.string "attachment_file_name"
     t.string "attachment_content_type"
-    t.bigint "attachment_file_size"
+    t.integer "attachment_file_size"
     t.datetime "attachment_updated_at"
     t.index ["practice_id"], name: "index_practice_resources_on_practice_id"
   end
@@ -926,7 +926,7 @@ ActiveRecord::Schema.define(version: 2022_10_13_211727) do
     t.datetime "updated_at", null: false
     t.string "attachment_file_name"
     t.string "attachment_content_type"
-    t.bigint "attachment_file_size"
+    t.integer "attachment_file_size"
     t.datetime "attachment_updated_at"
     t.string "name"
     t.string "description"
@@ -943,7 +943,7 @@ ActiveRecord::Schema.define(version: 2022_10_13_211727) do
     t.datetime "updated_at", null: false
     t.string "attachment_file_name"
     t.string "attachment_content_type"
-    t.bigint "attachment_file_size"
+    t.integer "attachment_file_size"
     t.datetime "attachment_updated_at"
     t.string "name"
     t.string "description"
@@ -1035,11 +1035,11 @@ ActiveRecord::Schema.define(version: 2022_10_13_211727) do
     t.datetime "updated_at", null: false
     t.string "main_display_image_file_name"
     t.string "main_display_image_content_type"
-    t.bigint "main_display_image_file_size"
+    t.integer "main_display_image_file_size"
     t.datetime "main_display_image_updated_at"
     t.string "origin_picture_file_name"
     t.string "origin_picture_content_type"
-    t.bigint "origin_picture_file_size"
+    t.integer "origin_picture_file_size"
     t.datetime "origin_picture_updated_at"
     t.bigint "user_id"
     t.boolean "published", default: false
@@ -1064,7 +1064,7 @@ ActiveRecord::Schema.define(version: 2022_10_13_211727) do
     t.boolean "hidden", default: false, null: false
     t.string "highlight_attachment_file_name"
     t.string "highlight_attachment_content_type"
-    t.bigint "highlight_attachment_file_size"
+    t.integer "highlight_attachment_file_size"
     t.datetime "highlight_attachment_updated_at"
     t.boolean "is_public", default: false
     t.text "main_display_image_alt_text"
@@ -1081,7 +1081,7 @@ ActiveRecord::Schema.define(version: 2022_10_13_211727) do
     t.datetime "updated_at", null: false
     t.string "attachment_file_name"
     t.string "attachment_content_type"
-    t.bigint "attachment_file_size"
+    t.integer "attachment_file_size"
     t.datetime "attachment_updated_at"
     t.index ["practice_id"], name: "index_publication_files_on_practice_id"
   end
@@ -1141,7 +1141,7 @@ ActiveRecord::Schema.define(version: 2022_10_13_211727) do
     t.datetime "updated_at", null: false
     t.string "attachment_file_name"
     t.string "attachment_content_type"
-    t.bigint "attachment_file_size"
+    t.integer "attachment_file_size"
     t.datetime "attachment_updated_at"
     t.index ["practice_id"], name: "index_survey_result_files_on_practice_id"
   end
@@ -1166,7 +1166,7 @@ ActiveRecord::Schema.define(version: 2022_10_13_211727) do
     t.datetime "updated_at", null: false
     t.string "attachment_file_name"
     t.string "attachment_content_type"
-    t.bigint "attachment_file_size"
+    t.integer "attachment_file_size"
     t.datetime "attachment_updated_at"
     t.index ["practice_id"], name: "index_toolkit_files_on_practice_id"
   end
@@ -1181,7 +1181,7 @@ ActiveRecord::Schema.define(version: 2022_10_13_211727) do
     t.datetime "updated_at", null: false
     t.string "attachment_file_name"
     t.string "attachment_content_type"
-    t.bigint "attachment_file_size"
+    t.integer "attachment_file_size"
     t.datetime "attachment_updated_at"
   end
 
@@ -1232,7 +1232,7 @@ ActiveRecord::Schema.define(version: 2022_10_13_211727) do
     t.text "bio"
     t.string "avatar_file_name"
     t.string "avatar_content_type"
-    t.bigint "avatar_file_size"
+    t.integer "avatar_file_size"
     t.datetime "avatar_updated_at"
     t.string "location"
     t.string "facility"
@@ -1275,7 +1275,7 @@ ActiveRecord::Schema.define(version: 2022_10_13_211727) do
     t.datetime "updated_at", null: false
     t.string "avatar_file_name"
     t.string "avatar_content_type"
-    t.bigint "avatar_file_size"
+    t.integer "avatar_file_size"
     t.datetime "avatar_updated_at"
   end
 
@@ -1382,7 +1382,7 @@ ActiveRecord::Schema.define(version: 2022_10_13_211727) do
     t.datetime "updated_at", null: false
     t.string "attachment_file_name"
     t.string "attachment_content_type"
-    t.bigint "attachment_file_size"
+    t.integer "attachment_file_size"
     t.datetime "attachment_updated_at"
     t.index ["practice_id"], name: "index_video_files_on_practice_id"
   end

--- a/spec/features/admin/admin_page_spec.rb
+++ b/spec/features/admin/admin_page_spec.rb
@@ -301,8 +301,8 @@ describe 'Page Builder', type: :feature do
     end
     fill_in("page_page_components_attributes_#{component_index}_component_attributes_url", with: '/')
     fill_in("page_page_components_attributes_#{component_index}_component_attributes_url_link_text", with: url_link_text)
-    select(1, from: "page_page_components_attributes_#{component_index}_component_attributes_margin_bottom")
-    select(4, from: "page_page_components_attributes_#{component_index}_component_attributes_margin_top")
+    select(1, from: "page_page_components_attributes_#{component_index}_component_attributes_padding_bottom")
+    select(4, from: "page_page_components_attributes_#{component_index}_component_attributes_padding_top")
   end
 
   def fill_in_optional_page_component_image_fields(

--- a/spec/features/pages/show_page_spec.rb
+++ b/spec/features/pages/show_page_spec.rb
@@ -354,8 +354,8 @@ describe 'Page Builder - Show', type: :feature do
     within_frame(all('.tox-edit-area__iframe')[0]) do
       find('body').set('Lorem ipsum dolor sit amet, consectetur adipiscing elit.')
     end
-    select(0, from: 'page_page_components_attributes_0_component_attributes_margin_bottom')
-    select(4, from: 'page_page_components_attributes_0_component_attributes_margin_top')
+    select(0, from: 'page_page_components_attributes_0_component_attributes_padding_bottom')
+    select(4, from: 'page_page_components_attributes_0_component_attributes_padding_top')
   end
 
   def add_page_component_image_to_component(

--- a/spec/features/pages/show_page_spec.rb
+++ b/spec/features/pages/show_page_spec.rb
@@ -252,7 +252,7 @@ describe 'Page Builder - Show', type: :feature do
       expect(page).to have_content('Page was successfully updated.')
       # With no PageComponentImages present, the CompoundBodyComponent text should take up six columns
       visit '/programming/javascript'
-      expect(page).to have_selector('div.page-compound-body-component.margin-bottom-0.margin-top-4')
+      expect(page).to have_selector('div.page-compound-body-component.margin-bottom-0.padding-bottom-0.padding-top-4')
       within(:css, '.page-compound-body-component') do
         expect(find('.grid-item-text').matches_style?('grid-column' => '1 / 7')).to be(true)
         expect(page).to have_selector('h2', class: 'usa-prose-h2')
@@ -292,7 +292,7 @@ describe 'Page Builder - Show', type: :feature do
         expect(page).to have_link('A link to the homepage', href: '/')
         # Make sure the new PageComponentImage is present and any completed fields are displayed
         expect(page).to have_selector('div.grid-item-images.left-align')
-        within(:css, '.image-container') do
+        within(:css, '.grid-item-images') do
           expect(find('img')['src']).to include('charmander.png')
           expect(find('img')['alt']).to eq('A cute charmander')
           expect(page).to have_link(href: '/search')

--- a/spec/models/page_compound_body_component_spec.rb
+++ b/spec/models/page_compound_body_component_spec.rb
@@ -28,46 +28,46 @@ RSpec.describe PageCompoundBodyComponent, type: :model do
       end
     end
 
-    context 'margin_bottom' do
+    context 'padding_bottom' do
       it 'should be valid if it is a value between 0 and 10 (rails type casts, so strings work as well), inclusively' do
-        # Invalid margin_bottoms
-        @component.margin_bottom = 12
+        # Invalid padding_bottom
+        @component.padding_bottom = 12
         expect_invalid_record(
           @component,
-          :margin_bottom,
-          '12 is not a valid Margin bottom size'
+          :padding_bottom,
+          '12 is not a valid Padding bottom size'
         )
 
-        @component.margin_bottom = -4
+        @component.padding_bottom = -4
         expect_invalid_record(
           @component,
-          :margin_bottom,
-          '-4 is not a valid Margin bottom size'
+          :padding_bottom,
+          '-4 is not a valid Padding bottom size'
         )
-        # Valid margin_bottom
-        @component.margin_bottom = 7
+        # Valid padding_bottom
+        @component.padding_bottom = 7
         expect_valid_record(@component)
       end
     end
 
-    context 'margin_top' do
+    context 'padding_top' do
       it 'should be valid if it is a value between 0 and 10 (rails type casts, so strings work as well), inclusively' do
-        # Invalid margin_tops
-        @component.margin_top = -1
+        # Invalid padding_top
+        @component.padding_top = -1
         expect_invalid_record(
           @component,
-          :margin_top,
-          '-1 is not a valid Margin top size'
+          :padding_top,
+          '-1 is not a valid Padding top size'
         )
 
-        @component.margin_top = 11
+        @component.padding_top = 11
         expect_invalid_record(
           @component,
-          :margin_top,
-          '11 is not a valid Margin top size'
+          :padding_top,
+          '11 is not a valid Padding top size'
         )
-        # Valid margin_top
-        @component.margin_top = 10
+        # Valid padding_top
+        @component.padding_top = 10
         expect_valid_record(@component)
       end
     end


### PR DESCRIPTION
### JIRA issue link
### Spacing
https://agile6.atlassian.net/browse/DM-3640
### Caption issue
https://agile6.atlassian.net/browse/DM-3638

## Description - what does this code do?
1. Changes the `margin_bottom` and `margin_top` columns for the `PageCompoundBodyComponent` to `padding_bottom` and `padding_top`, in order to allow for stackable spacing between multiple `PageCompoundBodyComponent`'s.
2. Fixes the issue where the caption for a `PageCompoundBodyComponent`'s `PageComponentImage` was not being included in the overall height of the container for the text and image.

## Testing done - how did you test it/steps on how can another person can test it 
_**PREREQUISITE:**_ Run `rails db:migrate` in the terminal.
### Spacing
1. Log in as an admin and visit `/admin/pages` and either create or edit a page.
2. Select two or more "Text and Images" components.
3. Scroll down and you should now see "MARGIN BOTTOM" and "MARGIN TOP" have now been replaced with "PADDING BOTTOM" and "PADDING TOP." Other than text, the functionality should've remained the same.
4. Add bottom and top padding to both components, and then save.
5. Visit the `Page`'s show page and inspect the two new `PageCompoundBodyComponent`s. You should see that the bottom and top spacing is now additive (ex: `padding-bottom: 32px` for the top component + `padding-top: 56px` for the bottom component = an overall spacing of `88` between the two components).

### Caption
1. Go back to the edit page of the `Page` you just created/edited.
2. For one (or both) of the newly created `PageCompoundBodyComponent`s, add an image (or two or three), and add a caption for all of the images, then save.
3. Go back to the `Page`'s show page and make sure the caption is included in the overall height of the component's container.

## Screenshots, Gifs, Videos from application (if applicable)
### Spacing
![](https://media.giphy.com/media/DxrYbNsV6XqIoUSFNL/giphy.gif)
### Caption
![](https://media.giphy.com/media/zOq4gVdV3n7n2VvjOj/giphy.gif)
![](https://user-images.githubusercontent.com/34111449/195915426-dcfc3613-258c-4cb9-bd42-bcb1872756da.png)

## Link to mock-ups/mock ups (image file if you have it) (if applicable)


## Acceptance criteria
### Spacing
- Check padding between components
- Basically, switch margin styles to padding in order to prevent margin collapse, which is when two sibling elements have a colliding margin, the high number wins (ex: margin-bottom: 32px and margin-top: 56px = margin-top: 56px), as opposed to padding, where the numbers are additive (ex: padding-bottom: 32px and padding-top: 56px = 88px of overall padding between the elements)
### Caption
- Fix issue with caption text overlapping other elements on the page.

## Definition of done
- [ ] Unit tests written (if applicable)
- [ ] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [X] A link has been provided to the originating JIRA issue
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs