### PR TITLE
Add DAP GA analytics snippet to app template

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -183,4 +183,11 @@ module ApplicationHelper
     end
     location_list
   end
+
+  def ga_private?
+    params["controller"] == "admin" || # all admin pages
+    (params["controller"] == "page" && !@page&.published?) || # unpublished PageBuilder pages
+    (params["controller"] == "practices" && !["show", "index"].include?(params["action"])) || # practice editor pages
+    (params["controller"] == "practices" && params["action"] == "show" && !@practice.is_public) # internal or unpublished practices
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -184,7 +184,7 @@ module ApplicationHelper
     location_list
   end
 
-  def ga_private?
+  def private_path? # https://github.com/digital-analytics-program/gov-wide-code#appropriate-placement
     params["controller"] == "users" || # all user pages
     params["controller"] == "system/status" || # status page
     params["controller"] == "admin" || # all admin pages

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -185,6 +185,8 @@ module ApplicationHelper
   end
 
   def ga_private?
+    params["controller"] == "users" || # all user pages
+    params["controller"] == "system/status" || # status page
     params["controller"] == "admin" || # all admin pages
     (params["controller"] == "page" && !@page&.published?) || # unpublished PageBuilder pages
     (params["controller"] == "practices" && !["show", "index"].include?(params["action"])) || # practice editor pages

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -189,7 +189,7 @@ module ApplicationHelper
     params["controller"] == "system/status" || # status page
     params["controller"] == "admin" || # all admin pages
     (params["controller"] == "page" && !@page&.published?) || # unpublished PageBuilder pages
-    (params["controller"] == "practices" && !["show", "index"].include?(params["action"])) || # practice editor pages
+    (params["controller"] == "practices" && !["show", "index", "search"].include?(params["action"])) || # practice editor pages
     (params["controller"] == "practices" && params["action"] == "show" && !@practice.is_public) # internal or unpublished practices
   end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -48,7 +48,7 @@
 
 
       <!-- DAP GA Analytics -->
-      <% unless ga_private? %>
+      <% unless private_path? %>
         <!-- We participate in the US government's analytics program. See the data at analytics.usa.gov. -->
         <script async type="text/javascript" src="https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=VA" id="_fed_an_ua_tag"></script>
       <% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -45,8 +45,14 @@
           });
         </script>
       <% end %>
-    <% end %>
 
+
+      <!-- DAP GA Analytics -->
+      <% unless ga_private? %>
+        <!-- We participate in the US government's analytics program. See the data at analytics.usa.gov. -->
+        <script async type="text/javascript" src="https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=VA" id="_fed_an_ua_tag"></script>
+      <% end %>
+    <% end %>
     <title>Diffusion Marketplace</title>
     <%= favicon_link_tag asset_path('favicon.ico') %>
     <%= csrf_meta_tags %>

--- a/spec/features/analytics.rb
+++ b/spec/features/analytics.rb
@@ -33,6 +33,16 @@ describe 'DAP Google Analytics', type: :feature do
       expect(page).not_to have_dap_snippet
     end
 
+    it 'on system pages' do
+      visit '/system/status'
+      expect(page).not_to have_dap_snippet
+    end
+
+    it 'on user pages' do
+      visit user_path(@admin)
+      expect(page).not_to have_dap_snippet
+    end
+
     it 'on unpublished pages' do
       Page.create!(title: 'Test', description: 'This is a test page', slug: 'test-page', page_group: @page_group)
       visit '/programming/test-page'

--- a/spec/features/analytics.rb
+++ b/spec/features/analytics.rb
@@ -1,0 +1,56 @@
+require 'rails_helper'
+
+describe 'DAP Google Analytics', type: :feature do
+  before do
+    allow(Rails.env).to receive(:production?).and_return(true)
+    @admin = User.create!(email: 'user@va.gov', password: 'Password123',
+                          password_confirmation: 'Password123', skip_va_validation: true, confirmed_at: Time.now, accepted_terms: true)
+    @admin.add_role(:admin)
+    @page_group = PageGroup.create(name: 'programming', slug: 'programming', description: 'Pages about programming')
+  end
+
+  context 'includes snippet' do
+    it 'on public pages' do
+      public_page = Page.create!(title: 'Test', description: 'This is a public page', slug: 'public-page', page_group: @page_group, published: Time.now)
+      visit '/programming/public-page'
+      expect(page).to have_dap_snippet
+    end
+
+    it 'on public practices' do
+      practice = Practice.create!(name: 'A public practice', approved: true, published: true, tagline: 'Test tagline', user: @admin)
+      visit practice_path(practice)
+    end
+  end
+
+  context 'excludes snippet' do
+    before do
+      login_as(@admin, scope: :user, run_callbacks: false)
+      @unpublished_practice = Practice.create!(name: 'An unpublished practice', approved: true, published: false, tagline: 'Test tagline', user: @admin)
+    end
+
+    it 'on admin pages' do
+      visit '/admin'
+      expect(page).not_to have_dap_snippet
+    end
+
+    it 'on unpublished pages' do
+      Page.create!(title: 'Test', description: 'This is a test page', slug: 'test-page', page_group: @page_group)
+      visit '/programming/test-page'
+      expect(page).not_to have_dap_snippet
+    end
+
+    it 'on practice editor pages' do
+      visit practice_overview_path(@unpublished_practice)
+      expect(page).not_to have_dap_snippet
+    end
+
+    it 'on private practices' do
+      visit practice_path(@unpublished_practice)
+      expect(page).not_to have_dap_snippet
+    end
+  end
+
+  def have_dap_snippet
+    have_xpath '/html/head/script[contains(@src,"dap.digitalgov.gov")]', visible: false
+  end
+end

--- a/spec/features/analytics.rb
+++ b/spec/features/analytics.rb
@@ -19,6 +19,10 @@ describe 'DAP Google Analytics', type: :feature do
     it 'on public practices' do
       practice = Practice.create!(name: 'A public practice', approved: true, published: true, tagline: 'Test tagline', user: @admin)
       visit practice_path(practice)
+      expect(page).to have_dap_snippet
+
+      visit '/search'
+      expect(page).to have_dap_snippet
     end
   end
 


### PR DESCRIPTION
### JIRA issue link
[DM-3628](https://agile6.atlassian.net/browse/DM-3628)

## Description - what does this code do?
- Adds an application helper to define which pages should be excluded from Google Analytics
- Adds a snippet to the application view template

TODO:
- [x] test in dev and staging and loop back to DAP program support
- [ ] release to PROD
- [ ] loop back with DAP program for account registration

## Testing done - how did you test it/steps on how can another person can test it 
1. Go to the homepage. Open the inspector and look for the `<!-- We participate in the US government's analytics program. See the data at analytics.usa.gov. -->` comment in `<head>`.

There should be no snippets in the following:
1. a non-public practice
1. practice editor
1. admin pages
1. unpublished PageBuilder pages

## Screenshots, Gifs, Videos from application (if applicable)


## Link to mock-ups/mock ups (image file if you have it) (if applicable)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Unit tests written (if applicable)
- [x] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating JIRA issue
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs