### PR TITLE
DM-3648

### DIFF
--- a/app/controllers/page_controller.rb
+++ b/app/controllers/page_controller.rb
@@ -115,7 +115,7 @@ class PageController < ApplicationController
     items = []
     ids = []
     position = page_components.first&.position
-    ids << page_components.first.component_id
+    ids << page_components.first&.component_id
 
     # create list for adjacent components of the same type
     page_components.each do |pc|

--- a/app/controllers/page_controller.rb
+++ b/app/controllers/page_controller.rb
@@ -10,9 +10,11 @@ class PageController < ApplicationController
     @practice_list_components = []
     @pagy_type = params.keys.first || nil
     @practice_list_component_index = 0
+    @event_list_component_index = 0
+    @event_list_components = []
     @event_ids = []
-    @event_list_components = {}
-    @news_items_components = {}
+    @news_list_component_index = 0
+    @news_items_components = []
     @news_items_ids = []
     collect_paginated_components(@page_components)
 
@@ -33,6 +35,15 @@ class PageController < ApplicationController
   end
 
   private
+
+  def set_page
+    @page_slug = params[:page_slug] ? params[:page_slug] : 'home'
+    @page = Page.includes(:page_group).find_by(slug: @page_slug.downcase, page_groups: {slug: params[:page_group_friendly_id].downcase})
+  end
+
+  def set_page_components
+    @page_components = @page.page_components
+  end
 
   def build_map_component_markers
     map_components_with_markers = {}
@@ -90,41 +101,39 @@ class PageController < ApplicationController
       news_items << pc if pc.component_type === 'PageNewsComponent'
     end
 
-    set_pagy_practice_list_array(practice_lists)
-    paginate_components(events, "events", 3)
-    paginate_components(news_items, "news", 6)
+    set_pagy_practice_list_array(practice_lists) if practice_lists.present?
+    paginate_components(events, "events", 3) if events.present?
+    paginate_components(news_items, "news", 6) if news_items.present?
   end
 
+  # Paginate adjacent news or event components
   def paginate_components(page_components, component_type, pagination)
     return unless page_components
+
     page_item_list_index = 0
-    params_index = params["#{page_item_list_index}"]
+    params_index = params[page_item_list_index.to_s]
     items = []
     ids = []
+    position = page_components.first&.position
+    ids << page_components.first.component_id
 
+    # create list for adjacent components of the same type
     page_components.each do |pc|
-      items << pc.component
-      ids << pc.component_id
+      if pc.position == position || pc.position == position + 1
+        (items[page_item_list_index] ||= []) << pc.component
+      else
+        # create pagy for previous list
+        add_paginated_list(component_type, page_item_list_index, params_index, items, pagination)
+        # begin a new list
+        page_item_list_index += 1
+        items[page_item_list_index] = [pc.component]
+        ids << pc.component_id
+      end
+      position = pc.position
     end
-
-    pagy_settings, paginated_items = get_pagy_array(items, page_item_list_index, params_index, pagination, component_type)
-
-    if component_type == "events"
-      @event_list_components[0] = { pagy: pagy_settings, events: paginated_items }
-      @event_ids = ids
-    elsif component_type == "news"
-      @news_items_components[0] = { pagy: pagy_settings, news: paginated_items }
-      @news_items_ids = ids
-    end
-  end
-
-  def get_pagy_array(items, page_item_list_index, params_index, pagination, item_class)
-    pagy_array(
-      items,
-      items: pagination,
-      page_param: "#{item_class}-#{page_item_list_index.to_s}",
-      link_extra: "data-remote='true' class='dm-paginated-#{item_class}-#{page_item_list_index}-link dm-paginated-#{page_item_list_index}-#{item_class}-#{params_index.nil? ? 2 : params_index.to_i + 1}-link dm-button--outline-secondary margin-top-105 width-auto'"
-    )
+    # create pagy for the final list
+    add_paginated_list(component_type, page_item_list_index, params_index, items, pagination)
+    set_pagination_start_ids(component_type, ids)
   end
 
   def set_pagy_practice_list_array(page_components)
@@ -147,12 +156,32 @@ class PageController < ApplicationController
     end
   end
 
-  def set_page
-    @page_slug = params[:page_slug] ? params[:page_slug] : 'home'
-    @page = Page.includes(:page_group).find_by(slug: @page_slug.downcase, page_groups: {slug: params[:page_group_friendly_id].downcase})
+  # create a paginated list and add it to page components
+  def add_paginated_list(component_type, page_item_list_index, params_index, items, pagination)
+    pagy_settings, paginated_items = get_pagy_array(items[page_item_list_index], page_item_list_index, params_index, pagination, component_type)
+    case component_type
+    when "events"
+      @event_list_components << { pagy: pagy_settings, events: paginated_items }
+    when "news"
+      @news_items_components << { pagy: pagy_settings, news: paginated_items }
+    end
   end
 
-  def set_page_components
-    @page_components = @page.page_components
+  def get_pagy_array(items, page_item_list_index, params_index, pagination, item_class)
+    pagy_array(
+      items,
+      items: pagination,
+      page_param: "#{item_class}-#{page_item_list_index}",
+      link_extra: "data-remote='true' class='dm-paginated-#{item_class}-#{page_item_list_index}-link dm-paginated-#{page_item_list_index}-#{item_class}-#{params_index.nil? ? 2 : params_index.to_i + 1}-link dm-button--outline-secondary margin-top-105 width-auto'"
+    )
+  end
+
+  def set_pagination_start_ids(component_type, ids)
+    case component_type
+    when "events"
+      @event_ids = ids
+    when "news"
+      @news_items_ids = ids
+    end
   end
 end

--- a/app/views/page/show.html.erb
+++ b/app/views/page/show.html.erb
@@ -88,14 +88,17 @@
           </div>
 
         <%# Event %>
-        <% when 'PageEventComponent'%>
-          <% component_index = 0 %>
-          <% elc = @event_list_components[0] %>
-          <% if component.id == @event_ids.first %>
+        <% when 'PageEventComponent' %>
+          <% if @event_ids.include?(component.id) %>
+            <%
+              component_index = @event_list_component_index
+              elc = @event_list_components[component_index]
+              @event_list_component_index = component_index + 1
+            %>
             <div class="event-component-list dm-paginated-<%= component_index %>-events margin-bottom-4 <%= page_narrow_classes %><%= ' margin-bottom-0' if last_component === index %>">
               <%= render(partial: 'events_list', locals: {events: elc[:events]}) %>
             </div>
-            <% if elc[:pagy].count > 3 %>
+            <% if elc[:pagy].count > 3  %>
               <div class="text-center dm-load-more-events-<%= component_index %>-btn-container">
                 <% link = pagy_link_proc(elc[:pagy]) %>
                 <%=  link.call(elc[:pagy].vars[:page] + 1, 'Load more').html_safe %>
@@ -117,13 +120,16 @@
 
         <%# News %>
         <% when 'PageNewsComponent' %>
-          <% component_index = 0 %>
-          <% nic = @news_items_components[0] %>
-          <% if component.id == @news_items_ids.first %>
+          <% if @news_items_ids.include?(component.id) %>
+            <%
+              component_index = @news_list_component_index
+              nic = @news_items_components[component_index]
+              @news_list_component_index = component_index + 1
+            %>
             <ul class="usa-card-group news-component-list dm-paginated-<%= component_index %>-news <%= page_narrow_classes %><%= ' margin-bottom-0' if last_component === index %>">
               <%= render partial:'news_items_list', locals: {news_items: nic[:news]} %>
             </ul>
-            <% if nic[:pagy].count > nic[:pagy].items %>
+            <% if nic[:pagy].count > 6  %>
               <div class="text-center dm-load-more-news-<%= component_index %>-btn-container" >
                 <% link = pagy_link_proc(nic[:pagy]) %>
                 <%=  link.call(nic[:pagy].vars[:page] + 1, 'Load more').html_safe %>

--- a/spec/features/pages/paginated_components_spec.rb
+++ b/spec/features/pages/paginated_components_spec.rb
@@ -1,108 +1,179 @@
 require 'rails_helper'
 describe 'Page Builder - Show - Paginated Components', type: :feature do
-
-  def create_practice_list_components(num = 1,user,page)
-    @practices = [
-      Practice.create!(name: 'A public practice', approved: true, published: true, tagline: 'Test tagline', user: user),
-      Practice.create!(name: 'A cool practice', approved: true, published: true, tagline: 'Test tagline', user: user),
-      Practice.create!(name: 'An awesome practice', approved: true, published: true, tagline: 'Test tagline', user: user),
-      Practice.create!(name: 'An amazing practice', approved: true, published: true, tagline: 'Test tagline', user: user),
-      Practice.create!(name: 'A beautiful practice', approved: true, published: true, tagline: 'Test tagline', user: user),
-      Practice.create!(name: 'A superb practice', approved: true, published: true, tagline: 'Test tagline', user: user),
-      Practice.create!(name: 'The last practice', approved: true, published: true, tagline: 'Test tagline', user: user)
-    ]
-    pr_ids = @practices.map { |pr| pr[:id].to_s }
-    num.times do
-      practice_list_component = PagePracticeListComponent.create(practices: pr_ids)
-      PageComponent.create(page: page, component: practice_list_component, created_at: Time.now)
-    end
-  end
-
-  def create_event_components(num = 1, page)
-    num.times do
-      event_component =  PageEventComponent.create(title: 'Event', url: 'https://wikipedia.org', text: 'event description')
-      PageComponent.create(page: page, component: event_component, created_at: Time.now)
-    end
-  end
-
-  def create_news_components(num = 1, page)
-    num.times do
-      news_component = PageNewsComponent.create(title: 'News item', url: 'https://wikipedia.org', text: 'news item description', published_date: Date.current.to_s)
-      PageComponent.create(page: page, component: news_component, created_at: Time.now)
-    end
-  end
-
   before do
-    user = User.create!(email: 'sandy.cheeks@va.gov', password: 'Password123',
+    @user = User.create!(email: 'sandy.cheeks@va.gov', password: 'Password123',
                         password_confirmation: 'Password123', skip_va_validation: true, confirmed_at: Time.now, accepted_terms: true)
-    user.add_role(:admin)
-
-
-    page_group = PageGroup.create(name: 'programming', slug: 'programming', description: 'Pages about programming go in this group.')
-    @page = Page.create(page_group: page_group, title: 'ruby', description: 'what a gem', slug: 'ruby-rocks', has_chrome_warning_banner: true, created_at: Time.now, published: Time.now)
-    Page.create(page_group: page_group, title: 'javascript', description: 'cool stuff', slug: 'javascript', created_at: Time.now, published: Time.now)
-
-    create_practice_list_components(2,user,@page)
-    create_event_components(7,@page)
-    create_news_components(13,@page)
+    @user.add_role(:admin)
+    @page_group = PageGroup.create(name: 'programming', slug: 'programming', description: 'Pages about programming go in this group.')
+    @paragraph_component = PageParagraphComponent.create(text: "<div><p>Just some filler text</p></div>")
 
     # must be logged in to view pages
-    login_as(user, scope: :user, run_callbacks: false)
-    visit '/programming/ruby-rocks'
+    login_as(@user, scope: :user, run_callbacks: false)
   end
 
-  it 'paginates event components', js:true do
-    expect(page).to have_css('.page-event-component', count: 3)
-    within('.dm-load-more-events-0-btn-container') do
-      click_on('Load more')
+  context 'Event components only' do
+    before do
+      # event components page with 2 lists
+      @events_page = Page.create(page_group: @page_group, title: 'events only', description: '2 instances of event list components', slug: 'events-only', created_at: Time.now, published: Time.now)
+      create_event_components(7,@events_page)
+      PageComponent.create(page: @events_page, component: @paragraph_component, created_at: Time.now)
+      create_event_components(7,@events_page)
+      visit 'programming/events-only'
     end
 
-    expect(page).to have_css('.page-event-component', count: 6)
-    within('.dm-load-more-events-0-btn-container') do
-      click_on('Load more')
+    it 'renders a Load More button for each list', js: true do
+      expect(page).to have_content('Load more', count: 2)
     end
 
-    expect(page).to have_css('.page-event-component', count: 7)
-    within('.dm-load-more-events-0-btn-container') do
-      expect(page).not_to have_content('Load more')
+    it 'paginates both lists', js: true do
+      expect(page).to have_css('.page-event-component', count: 6)
+
+      # load all events in the first list
+      click_load_more("events", 0)
+
+      expect(page).to have_css('.page-event-component', count: 9)
+      click_load_more("events", 0)
+      expect(page).to have_content('Load more')
+
+      expect(page).to have_css('.page-event-component', count: 10)
+      expect(page).not_to have_css(".dm-load-more-events-0-btn-container > a", text: 'Load more')
+
+      # load all events in the second list
+      click_load_more("events", 1)
+
+      expect(page).to have_css('.page-event-component', count: 13)
+      click_load_more("events", 1)
+
+      expect(page).to have_css('.page-event-component', count: 14)
+      expect(page).not_to have_css(".dm-load-more-events-1-btn-container > a", text: 'Load more')
     end
   end
 
-  it 'paginates news components', js: true do
-    expect(page).to have_css('.page-news-component', count: 6)
-    within('.dm-load-more-news-0-btn-container') do
-      click_on('Load more')
+  context 'News components only' do
+    before do
+      # news components page with 2 lists
+      @news_page = Page.create(page_group: @page_group, title: 'news only', description: '2 instances of news list components', slug: 'news-only', created_at: Time.now, published: Time.now)
+      create_news_components(13,@news_page)
+      PageComponent.create(page: @news_page, component: @paragraph_component, created_at: Time.now)
+      create_news_components(13,@news_page)
+      visit 'programming/news-only'
     end
 
-    expect(page).to have_css('.page-news-component', count: 12)
-    within('.dm-load-more-news-0-btn-container') do
-      click_on('Load more')
-    end
-    expect(page).to have_content('Load more')
-
-    expect(page).to have_css('.page-news-component', count: 13)
-    within('.dm-load-more-news-0-btn-container') do
-       expect(page).not_to have_content('Load more')
+    it 'renders a Load More button for each list', js: true do
+      expect(page).to have_content('Load more', count: 2)
     end
 
+    it 'paginates both lists', js: true do
+      expect(page).to have_css('.page-news-component', count: 12)
+
+      # load all news in the first list
+      click_load_more("news", 0)
+
+      expect(page).to have_css('.page-news-component', count: 18)
+      click_load_more("news", 0)
+      expect(page).to have_content('Load more')
+
+      expect(page).to have_css('.page-news-component', count: 19)
+      expect(page).not_to have_css(".dm-load-more-news-0-btn-container > a", text: 'Load more')
+
+      # load all news in the second list
+      click_load_more("news", 1)
+
+      expect(page).to have_css('.page-news-component', count: 25)
+      click_load_more("news", 1)
+
+      expect(page).to have_css('.page-news-component', count: 26)
+      expect(page).not_to have_css(".dm-load-more-news-1-btn-container > a", text: 'Load more')
+    end
   end
 
-  it 'renders a Load More for each component', js: true do
-    expect(page).to have_content('Load more', count: 4)
+  context 'mixed components' do
+    before do
+      # mixed components page with one of each type of list
+      @mixed_components_page = Page.create(page_group: @page_group, title: 'ruby', description: 'what a gem', slug: 'mixed-components', has_chrome_warning_banner: true, created_at: Time.now, published: Time.now)
+      Page.create(page_group: @page_group, title: 'javascript', description: 'cool stuff', slug: 'javascript', created_at: Time.now, published: Time.now)
+
+      create_event_components(7,@mixed_components_page)
+      PageComponent.create(page: @events_page, component: @paragraph_component, created_at: Time.now)
+      create_news_components(13,@mixed_components_page)
+      PageComponent.create(page: @events_page, component: @paragraph_component, created_at: Time.now)
+      create_practice_list_components(2,@user,@mixed_components_page)
+      visit '/programming/mixed-components'
+    end
+
+    it 'paginates event components', js:true do
+      expect(page).to have_css('.page-event-component', count: 3)
+      click_load_more("events", 0)
+
+      expect(page).to have_css('.page-event-component', count: 6)
+      click_load_more("events", 0)
+
+      expect(page).to have_css('.page-event-component', count: 7)
+      expect(page).not_to have_css(".dm-load-more-events-0-btn-container > a", text: 'Load more')
+    end
+
+    it 'paginates news components', js: true do
+      expect(page).to have_css('.page-news-component', count: 6)
+      click_load_more("news", 0)
+
+      expect(page).to have_css('.page-news-component', count: 12)
+      click_load_more("news", 0)
+      expect(page).to have_content('Load more')
+
+      expect(page).to have_css('.page-news-component', count: 13)
+      expect(page).not_to have_css(".dm-load-more-news-0-btn-container > a", text: 'Load more')
+    end
+
+    it 'renders a Load More for each component', js: true do
+      expect(page).to have_content('Load more', count: 4)
+    end
+
+    it 'paginates multiple practice lists', js:true do
+      expect(page).to have_css('.dm-practice-card-list', count: 2)
+      click_load_more("practices", 0)
+      expect(page).to have_content('The last practice', count: 1)
+      click_load_more("practices", 1)
+      expect(page).to have_content('The last practice', count: 2)
+
+      # Events and News should still have load buttons
+      expect(page).to have_content('Load more', count: 2)
+    end
   end
+end
 
-  it 'paginates multiple practice lists', js:true do
-    expect(page).to have_css('.dm-practice-card-list', count: 2)
-    within('.dm-load-more-practices-0-btn-container') do
-      click_on('Load more')
-    end
-    expect(page).to have_content('The last practice', count: 1)
-    within('.dm-load-more-practices-1-btn-container') do
-      click_on('Load more')
-    end
-    expect(page).to have_content('The last practice', count: 2)
+def create_practice_list_components(num = 1,user,page)
+  @practices = [
+    Practice.create!(name: 'A public practice', approved: true, published: true, tagline: 'Test tagline', user: user),
+    Practice.create!(name: 'A cool practice', approved: true, published: true, tagline: 'Test tagline', user: user),
+    Practice.create!(name: 'An awesome practice', approved: true, published: true, tagline: 'Test tagline', user: user),
+    Practice.create!(name: 'An amazing practice', approved: true, published: true, tagline: 'Test tagline', user: user),
+    Practice.create!(name: 'A beautiful practice', approved: true, published: true, tagline: 'Test tagline', user: user),
+    Practice.create!(name: 'A superb practice', approved: true, published: true, tagline: 'Test tagline', user: user),
+    Practice.create!(name: 'The last practice', approved: true, published: true, tagline: 'Test tagline', user: user)
+  ]
+  pr_ids = @practices.map { |pr| pr[:id].to_s }
+  num.times do
+    practice_list_component = PagePracticeListComponent.create(practices: pr_ids)
+    PageComponent.create(page: page, component: practice_list_component, created_at: Time.now)
+  end
+end
 
-    # Events and News should still have load buttons
-    expect(page).to have_content('Load more', count: 2)
+def create_event_components(num = 1, page)
+  num.times do
+    event_component =  PageEventComponent.create(title: 'Event', url: 'https://wikipedia.org', text: 'event description')
+    PageComponent.create(page: page, component: event_component, created_at: Time.now)
+  end
+end
+
+def create_news_components(num = 1, page)
+  num.times do
+    news_component = PageNewsComponent.create(title: 'News item', url: 'https://wikipedia.org', text: 'news item description', published_date: Date.current.to_s)
+    PageComponent.create(page: page, component: news_component, created_at: Time.now)
+  end
+end
+
+def click_load_more(component_type, index)
+  within(".dm-load-more-#{component_type}-#{index}-btn-container") do
+    click_on('Load more')
   end
 end


### PR DESCRIPTION
### JIRA issue link
[DM-3648](https://agile6.atlassian.net/browse/DM-3648?atlOrigin=eyJpIjoiNmQ0M2ExMDMyNGI0NDliYmE3YjRlNjcwODJhMDRlOTciLCJwIjoiaiJ9)

## Description - what does this code do?
- Enable a PageBuilder editor to use multiple Event and/or News component lists on the same page
- Adds additional testing and refactors spec file

## Testing done - how did you test it/steps on how can another person can test it 

1. Create a new page group and page
2. Create 4 event components
3. Add a header component (e.g. "Online Events)
4. Create 4 event components
5. Save page
6. Open page. Confirm there are two paginated lists of events and that each has a working "Load more" button
7. Return to page editing UI. Create 7 news components 
8. Add a header component (e.g. "Press Releases)
9. Create 7 news components  
10. Save page
11. Open page. Confirm there are two paginated lists of news and that each has a working "Load more" button
12. Return to page editing UI. Create a 2 practice list component with at least 7 practices each.
13. Save page. Open page and confirm that practice list components' "Load more" buttons work.

## Screenshots, Gifs, Videos from application (if applicable)
![Screenshot 2022-12-15 at 5 18 38 PM](https://user-images.githubusercontent.com/5402927/208000039-a7091981-fa67-4c35-bc5e-3cb4ca94f80f.png)
![Screenshot 2022-12-15 at 5 19 51 PM](https://user-images.githubusercontent.com/5402927/208000120-3c2ad847-7ea4-4a09-9a49-c0d66f5ea359.png)


## Link to mock-ups/mock ups (image file if you have it) (if applicable)


## Acceptance criteria
- As a PageBuilder editor, I can create two event lists
- As a PageBuilder editor, I can create two news lists

## Definition of done
- [ ] Unit tests written (if applicable)
- [x] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating JIRA issue
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs