### PR TITLE
DM-3697: Adjust practice origin text styles to better reflect mockups

### DIFF
--- a/app/assets/javascripts/_practice_card_utilities.es6
+++ b/app/assets/javascripts/_practice_card_utilities.es6
@@ -11,9 +11,9 @@ function truncateText() {
     truncateOnArrive('.dm-practice-title', 55);
 
     $('.dm-practice-card-origin-info').each(function(index, element) {
-        $(element).shave(35);
+        $(element).shave(39);
     });
-    truncateOnArrive('.dm-practice-card-origin-info', 35);
+    truncateOnArrive('.dm-practice-card-origin-info', 39);
 
     $('.practice-card-tagline').each(function(index, element) {
         $(element).shave(120)

--- a/app/assets/stylesheets/dm/components/_practice_card.scss
+++ b/app/assets/stylesheets/dm/components/_practice_card.scss
@@ -110,11 +110,10 @@
     align-items: flex-end;
     position: absolute;
     bottom: 18px;
-    margin-right: 24px;
     max-width: 278px;
 
     span {
-      height: 30px;
+      height: 38px;
     }
   }
 

--- a/app/views/practices/_search.js.erb
+++ b/app/views/practices/_search.js.erb
@@ -136,7 +136,7 @@ function buildPracticeCard(result) {
         '<p class="multiline-ellipses-1 font-sans-sm practice-card-tagline">' + result.item.tagline + '</p>' +
         '</div>' +
         '<div class="dm-practice-card-origin margin-bottom-2">' +
-        '<span class="line-clamp-2 font-sans-3xs text-gray-50 multiline-ellipses-3 line-height-sans-205 dm-practice-card-origin-info">' +
+        '<span class="font-sans-2xs text-italic line-height-sans-3 dm-practice-card-origin-info">' +
         'Created in ' + result.item.date_initiated + ' ' + result.item.initiating_facility_name +
         '</span>' +
         '</div>' +

--- a/app/views/shared/_practice_card.html.erb
+++ b/app/views/shared/_practice_card.html.erb
@@ -62,7 +62,7 @@
         <p class="multiline-ellipses-1 font-sans-sm practice-card-tagline"><%= practice.tagline %></p>
       </div>
       <div class="dm-practice-card-origin margin-bottom-2">
-        <span class="line-clamp-2 font-sans-3xs text-gray-50 multiline-ellipses-3 line-height-sans-205 dm-practice-card-origin-info">
+        <span class="font-sans-2xs text-italic line-height-sans-3 dm-practice-card-origin-info">
           Created in <%= practice.date_initiated.present? ? date_format(practice.date_initiated) : '(start date unknown)' %><%= practice.initiating_facility_type.present? ? " #{origin_display(practice)}" : '' %>
         </span>
       </div>


### PR DESCRIPTION
### JIRA issue link
https://agile6.atlassian.net/browse/DM-3697

## Description - what does this code do?
Adjusts practice origin text styles to better reflect mockups

## Testing done - how did you test it/steps on how can another person can test it 
1. Make sure you have at least one practice with multiple originating facilities (2-3 with long names/3-4 with short names).
2. Log in and visit `/search`. Filter for the practice from step 1 and make sure the ellipsis is visible for the origin text and that the text styles match the Figma designs.
3. Edit the practice from step 1 and assign the QUERI practice partner to it. Now visit `/partners/quality-enhancement-research-initiative` and confirm the ellipsis is visible for the origin text and that the text styles match the Figma designs.

## Screenshots, Gifs, Videos from application (if applicable)
![](https://user-images.githubusercontent.com/34111449/213273855-fead541a-f7f9-421d-b7bd-eb46444fece1.png)

## Link to mock-ups/mock ups (image file if you have it) (if applicable)
https://www.figma.com/file/dkvSpADVqwN5KKByF1TVIa/Design-System---VA-DM?node-id=1305%3A334&t=Gm3JO466s0d38ibE-0

## Acceptance criteria
- Running AXE DevTools scan on page should not flag “Elements must have sufficient color contrast” issue
- From Becca: Attaching the updated card design here (the text changes to black with italic styling). The design can also be viewed in Figma, in the Design System file underneath the ‘card’ section

## Definition of done
- [ ] Unit tests written (if applicable)
- [ ] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [X] A link has been provided to the originating JIRA issue
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs