### PR TITLE
dm-3812

### DIFF
--- a/app/assets/javascripts/page/page_map.es6
+++ b/app/assets/javascripts/page/page_map.es6
@@ -48,11 +48,6 @@ function initialize(mapId) {
             markers = handler.addMarkers(componentMapData);
             buildMapMarkers(componentMapData);
         });
-
-    google.maps.event.addListener(handler.getMap(), "idle", function () {
-        $(`#${mapId}`).removeClass("display-none");
-        $(".dm-facilities-show-map-loading-spinner").addClass("display-none");
-    });
 }
 
 $(document).on("turbolinks:load", function () {

--- a/app/assets/javascripts/va_facilities/map.es6
+++ b/app/assets/javascripts/va_facilities/map.es6
@@ -36,11 +36,6 @@ function initialize() {
     markers = handler.addMarkers(mapData);
     buildMapMarkers(mapData);
   });
-
-  google.maps.event.addListener(handler.getMap(), "idle", function () {
-    $("#va_facility_map").removeClass("display-none");
-    $(".dm-facilities-show-map-loading-spinner").addClass("display-none");
-  });
 }
 
 $(document).on("turbolinks:load", function () {

--- a/app/assets/javascripts/visns/maps.es6
+++ b/app/assets/javascripts/visns/maps.es6
@@ -231,13 +231,6 @@ function initialize() {
       });
   }
 
-  if (isVisnsIndexPage) {
-    google.maps.event.addListener(handler.getMap(), 'idle', function () {
-      $("#visns-index-map").removeClass("display-none");
-      $(".dm-loading-spinner").addClass("display-none");
-    });
-  }
-
   google.maps.event.addListener(handler.getMap(), "tilesloaded", function () {
     changeMarkerIconOnInfoWindowClose();
   });

--- a/app/assets/javascripts/visns/maps.es6
+++ b/app/assets/javascripts/visns/maps.es6
@@ -218,7 +218,6 @@ function initialize() {
   function setVisnShowMapEventListener() {
     if (!isVisnsIndexPage) {
       google.maps.event.addListenerOnce(handler.getMap(), "bounds_changed", function () {
-        $(".dm-visn-show-map").removeClass("display-none");
         $(".dm-visn-map-loading-spinner").addClass("display-none");
       });
     }

--- a/app/assets/javascripts/visns/maps.es6
+++ b/app/assets/javascripts/visns/maps.es6
@@ -218,6 +218,7 @@ function initialize() {
   function setVisnShowMapEventListener() {
     if (!isVisnsIndexPage) {
       google.maps.event.addListenerOnce(handler.getMap(), "bounds_changed", function () {
+        $(".dm-visn-show-map").removeClass("display-none");
         $(".dm-visn-map-loading-spinner").addClass("display-none");
       });
     }

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -61,9 +61,9 @@
     <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'false' %>
     <%= javascript_include_tag 'shared/_utilityFunctions', 'data-turbolinks-track': 'reload' %>
     <%= javascript_include_tag "https://maps.googleapis.com/maps/api/js?key=#{ENV['GOOGLE_API_KEY']}&callback=Function.prototype", 'data-turbolinks-track': 'false' %>
-    <%= javascript_include_tag "//cdn.rawgit.com/mahnunchik/markerclustererplus/master/dist/markerclusterer.min.js", 'data-turbolinks-track': 'false' %>
-    <%= javascript_include_tag "//cdn.rawgit.com/printercu/google-maps-utility-library-v3-read-only/master/infobox/src/infobox_packed.js", 'data-turbolinks-track': 'false' %>
-    <%= javascript_include_tag "//cdn.rawgit.com/googlemaps/js-rich-marker/gh-pages/src/richmarker-compiled.js", 'data-turbolinks-track': 'false' %>
+    <%= javascript_include_tag "https://cdn.jsdelivr.net/gh/mahnunchik/markerclustererplus@master/dist/markerclusterer.min.js", 'data-turbolinks-track': 'false' %>
+    <%= javascript_include_tag "https://cdn.jsdelivr.net/gh/printercu/google-maps-utility-library-v3-read-only@master/infobox/src/infobox_packed.js", 'data-turbolinks-track': 'false' %>
+    <%= javascript_include_tag "https://cdn.jsdelivr.net/gh/googlemaps/js-rich-marker/gh-pages/src/richmarker-compiled.js", 'data-turbolinks-track': 'false' %>
     <%= javascript_include_tag 'application', 'data-turbolinks-track': 'false' %>
     <%= javascript_tag 'data-turbolinks-track': 'false' do %>
       <%= render partial: 'layouts/ahoy_event_tracking', formats: [:js] %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -60,7 +60,7 @@
     <meta name="viewport" content= "width=device-width, initial-scale=1, minimum-scale=1">
     <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'false' %>
     <%= javascript_include_tag 'shared/_utilityFunctions', 'data-turbolinks-track': 'reload' %>
-    <%= javascript_include_tag "https://maps.googleapis.com/maps/api/js?key=#{ENV['GOOGLE_API_KEY']}", 'data-turbolinks-track': 'false' %>
+    <%= javascript_include_tag "https://maps.googleapis.com/maps/api/js?key=#{ENV['GOOGLE_API_KEY']}&callback=Function.prototype", 'data-turbolinks-track': 'false' %>
     <%= javascript_include_tag "//cdn.rawgit.com/mahnunchik/markerclustererplus/master/dist/markerclusterer.min.js", 'data-turbolinks-track': 'false' %>
     <%= javascript_include_tag "//cdn.rawgit.com/printercu/google-maps-utility-library-v3-read-only/master/infobox/src/infobox_packed.js", 'data-turbolinks-track': 'false' %>
     <%= javascript_include_tag "//cdn.rawgit.com/googlemaps/js-rich-marker/gh-pages/src/richmarker-compiled.js", 'data-turbolinks-track': 'false' %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -63,7 +63,7 @@
     <%= javascript_include_tag "https://maps.googleapis.com/maps/api/js?key=#{ENV['GOOGLE_API_KEY']}&callback=Function.prototype", 'data-turbolinks-track': 'false' %>
     <%= javascript_include_tag "https://cdn.jsdelivr.net/gh/mahnunchik/markerclustererplus@master/dist/markerclusterer.min.js", 'data-turbolinks-track': 'false' %>
     <%= javascript_include_tag "https://cdn.jsdelivr.net/gh/printercu/google-maps-utility-library-v3-read-only@master/infobox/src/infobox_packed.js", 'data-turbolinks-track': 'false' %>
-    <%= javascript_include_tag "https://cdn.jsdelivr.net/gh/googlemaps/js-rich-marker/gh-pages/src/richmarker-compiled.js", 'data-turbolinks-track': 'false' %>
+    <%= javascript_include_tag "https://cdn.jsdelivr.net/gh/googlemaps/js-rich-marker@gh-pages/src/richmarker-compiled.js", 'data-turbolinks-track': 'false' %>
     <%= javascript_include_tag 'application', 'data-turbolinks-track': 'false' %>
     <%= javascript_tag 'data-turbolinks-track': 'false' do %>
       <%= render partial: 'layouts/ahoy_event_tracking', formats: [:js] %>

--- a/app/views/maps/diffusion_map.html.erb
+++ b/app/views/maps/diffusion_map.html.erb
@@ -52,9 +52,6 @@
         <div id="map" style="width: 100%; height: 633px;"></div>
       </div>
     </div>
-    <div class="dm-loading-spinner text-center margin-y-8">
-      <i class="fas fa-circle-notch"></i>
-    </div>
   <% else %>
     <p>The map is not enabled for this site.</p>
   <% end %>

--- a/app/views/maps/diffusion_map.html.erb
+++ b/app/views/maps/diffusion_map.html.erb
@@ -17,7 +17,7 @@
     <p class="usa-prose-intro margin-bottom-4-important">
       Explore how innovations are being adopted across the country. There are currently <%= @successful_ct %> successful adoption<%= @successful_ct === 1 ? '' : 's' %>, <%= @in_progress_ct %> in-progress adoption<%= @in_progress_ct === 1 ? '' : 's' %>, and <%= @unsuccessful_ct %> unsuccessful adoption<%= @unsuccessful_ct === 1 ? '' : 's' %>.
     </p>
-    <div class="diffusion-map-container display-none">
+    <div class="diffusion-map-container">
       <div class="usa-accordion usa-accordion--bordered map-filters-accordion">
         <h4 class="usa-accordion__heading">
           <button

--- a/app/views/page/_page_map.html.erb
+++ b/app/views/page/_page_map.html.erb
@@ -6,11 +6,5 @@
     <%= javascript_include_tag 'page/page_map', 'data-turbolinks-track': 'reload' %>
   <% end %>
 
-  <div id="page_builder_map_<%= component_id %>" class="display-none grid-col-12 desktop:grid-col-9 page_builder_map"></div>
-  <%= render partial: 'shared/loading_spinner',
-             locals: {
-               display: true,
-               classes: 'flex-justify-center flex-align-self-center margin-y-8 desktop:margin-y-10 dm-facilities-show-map-loading-spinner text-center'
-             }
-  %>
+  <div id="page_builder_map_<%= component_id %>" class="grid-col-12 desktop:grid-col-9 page_builder_map"></div>
 <% end %>

--- a/app/views/va_facilities/map/_facility_map.html.erb
+++ b/app/views/va_facilities/map/_facility_map.html.erb
@@ -6,6 +6,6 @@
     <% end %>
     <%= javascript_include_tag 'va_facilities/map', 'data-turbolinks-track': 'reload' %>
   <% end %>
-  <div id="va_facility_map" class="display-none" style="width: 100%; height: 275px;"></div>
+  <div id="va_facility_map" style="width: 100%; height: 275px;"></div>
   <%= render partial: 'shared/loading_spinner', locals: { display: true, classes: 'flex-justify-center flex-align-self-center margin-y-8 desktop:margin-y-10 dm-facilities-show-map-loading-spinner text-center' } %>
 <% end %>

--- a/app/views/va_facilities/map/_facility_map.html.erb
+++ b/app/views/va_facilities/map/_facility_map.html.erb
@@ -7,5 +7,4 @@
     <%= javascript_include_tag 'va_facilities/map', 'data-turbolinks-track': 'reload' %>
   <% end %>
   <div id="va_facility_map" style="width: 100%; height: 275px;"></div>
-  <%= render partial: 'shared/loading_spinner', locals: { display: true, classes: 'flex-justify-center flex-align-self-center margin-y-8 desktop:margin-y-10 dm-facilities-show-map-loading-spinner text-center' } %>
 <% end %>

--- a/app/views/visns/maps/_index_map.html.erb
+++ b/app/views/visns/maps/_index_map.html.erb
@@ -11,7 +11,7 @@
   <section class="margin-bottom-0 padding-0">
     <div class="width-full position-relative grid-row margin-bottom-2">
       <%= render partial: 'shared/loading_spinner', locals: { display: true, classes: 'grid-col-full text-center margin-bottom-6 desktop:margin-bottom-10' } %>
-      <div id="visns-index-map" class="display-none" style="width: 100%; height: 462px"></div>
+      <div id="visns-index-map" style="width: 100%; height: 462px"></div>
     </div>
   </section>
 <% end %>

--- a/app/views/visns/maps/_index_map.html.erb
+++ b/app/views/visns/maps/_index_map.html.erb
@@ -10,7 +10,6 @@
   <% end %>
   <section class="margin-bottom-0 padding-0">
     <div class="width-full position-relative grid-row margin-bottom-2">
-      <%= render partial: 'shared/loading_spinner', locals: { display: true, classes: 'grid-col-full text-center margin-bottom-6 desktop:margin-bottom-10' } %>
       <div id="visns-index-map" style="width: 100%; height: 462px"></div>
     </div>
   </section>

--- a/app/views/visns/show.html.erb
+++ b/app/views/visns/show.html.erb
@@ -52,7 +52,7 @@
         </div>
       <% end %>
     </div>
-    <div class="dm-visn-show-map display-none margin-top-2">
+    <div class="dm-visn-show-map margin-top-2">
       <%
         visn_map_filters = [
           { label: 'vamc', value: 'VA Medical Center (VAMC)', checked: true },


### PR DESCRIPTION
Workaround for google maps not displaying in facilities, visn and diffusion map by removing display-none class on map containers.

### JIRA issue link
https://agile6.atlassian.net/browse/DM-3812

## Description - what does this code do?
Removes the "display-none' class on the Facility, VISN and Diffusion Map containers.

## Testing done - how did you test it/steps on how can another person can test it 
1.  Go to /visn - and ensure the map on the VISN Index page displays correctly.
2. Select any VISN and ensure that the VISN Map displays correctly on the VISN show page.
3. Go to /facilities and select select any facility to view.  i..,e /facilities/colorado-springs.  Ensure that the Facility Map displays correctly.  
![image](https://user-images.githubusercontent.com/60527788/223495391-680a584e-62a6-4e50-9460-4d5376efc8a7.png)

4.  If you have time.. go to /diffusion-map and ensure the large diffusion-map displays correctly.  I was able to test this successfully.
![image](https://user-images.githubusercontent.com/60527788/223499996-cca64755-ab0c-4f43-bf53-c7aa66b666b6.png)


## Link to mock-ups/mock ups (image file if you have it) (if applicable)
N/A

## Acceptance criteria

- Remove ‘display-none’ class for Facility, Visn, and Disffusion Map Containers
- Test on Dev and STG 
- Release to Prod

## Definition of done
- [ ] Unit tests written (if applicable)
- [ ] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating JIRA issue
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs