### PR TITLE
DM-3780: Add GitHub Actions workflow for running tests

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,0 +1,102 @@
+name: department-of-veterans-affairs/diffusion-marketplace/run-tests
+on:
+  push:
+    branches:
+    - master
+jobs:
+  hold:
+    environment:
+      name: approval
+    runs-on: ubuntu-latest
+    steps:
+    - run: echo 'approved'
+  test:
+    defaults:
+      run:
+        working-directory: "~/repo"
+    runs-on: ubuntu-latest
+    container:
+      image: circleci/ruby:2.7.5-node-browsers
+      env:
+        RAILS_ENV: test
+        MAX_THREADS: 2
+        WEB_CONCURRENCY: 1
+        POSTGRES_PASSWORD: mysecretlocalpassword
+        POSTGRES_USER: postgres
+        POSTGRES_DB: web_app
+        POSTGRES_HOST: 127.0.0.1
+        POSTGRES_PORT: 5432
+        REDIS_HOST: redis_test
+        REDIS_PORT: 6379
+        REDIS_DB_ID: 0
+        BUNDLE_JOBS: 3
+        BUNDLE_RETRY: 3
+        BUNDLE_PATH: vendor/bundle
+    services:
+      postgres:
+        image: cimg/postgres:12.10
+        env:
+          POSTGRES_PASSWORD: mysecretlocalpassword
+          POSTGRES_USER: postgres
+          POSTGRES_DB: web_app
+      redis:
+        image: redis
+    needs:
+    - hold
+    steps:
+    - uses: actions/checkout@v3.3.0
+    - name: restore_cache
+      uses: actions/cache@v3.3.1
+      with:
+        key: v1-dependencies-{{ checksum "Gemfile.lock" }}
+        restore-keys: |-
+          v1-dependencies-{{ checksum "Gemfile.lock" }}
+          v1-dependencies-
+        path: "./vendor/bundle"
+    - name: install dependencies
+      run: |-
+        wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
+        sudo apt-get update --allow-releaseinfo-change
+        sudo apt-get install libqt5webkit5-dev gstreamer1.0-plugins-base gstreamer1.0-tools gstreamer1.0-x
+        gem install bundler -v 2.1.4
+        bundle install --jobs=4 --retry=3 --path vendor/bundle
+    - run: bundle exec rails db:create
+    - run: bundle exec rails db:schema:load
+    - name: run bundler-audit
+      run: bundle exec bundle-audit check --update | tee /tmp/bundler-audit-report.txt
+    - name: run bundler-leak
+      run: bundle exec bundle leak check --update | tee /tmp/bundler-leak-report.txt
+    - name: run security scanner
+      run: |-
+        mkdir /tmp/security-report
+        bundle exec brakeman --exit-on-warn -o /tmp/security-report/report.json
+    - name: run tests
+      run: |-
+        mkdir /tmp/test-results
+        TEST_FILES="$(circleci tests glob "spec/**/*_spec.rb" | circleci tests split --split-by=timings)"
+        bundle exec rspec --format progress \
+                        --format RspecJunitFormatter \
+                        --out /tmp/test-results/rspec.xml \
+                        --format progress \
+                        $TEST_FILES
+    - uses: actions/upload-artifact@v3.1.1
+      with:
+        path: "/tmp/test-results"
+    - uses: actions/upload-artifact@v3.1.1
+      with:
+        path: "/tmp/security-report"
+    - uses: actions/upload-artifact@v3.1.1
+      with:
+        path: "/tmp/test-results"
+    - uses: actions/upload-artifact@v3.1.1
+      with:
+        path: "/tmp/security-report"
+    - uses: actions/upload-artifact@v3.1.1
+      with:
+        path: coverage
+    - uses: actions/upload-artifact@v3.1.1
+      with:
+        path: "/tmp/bundler-leak-report.txt"
+    - uses: actions/upload-artifact@v3.1.1
+      with:
+        path: "/tmp/bundler-audit-report.txt"


### PR DESCRIPTION
### JIRA issue link
Part 1  of [DM-3780](https://agile6.atlassian.net/browse/DM-3780?atlOrigin=eyJpIjoiZDM5NTA1MGNkZGVjNDI4ZTljMGVkMTI5ZTRjZTlmYWMiLCJwIjoiaiJ9)

## Description - what does this code do?
- Adds a GitHub Workflow for running tests 

## Testing done - how did you test it/steps on how can another person can test it 
- After merging PR, info about this workflow should appear in the [Actions tab for this repo](https://github.com/department-of-veterans-affairs/diffusion-marketplace/actions) (similar to our CodeQL workflow)

## Screenshots, Gifs, Videos from application (if applicable)


## Link to mock-ups/mock ups (image file if you have it) (if applicable)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Unit tests written (if applicable)
- [ ] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating JIRA issue
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs