### PR TITLE
Dm 3851

### DIFF
--- a/app/assets/javascripts/_page_show.es6
+++ b/app/assets/javascripts/_page_show.es6
@@ -100,6 +100,23 @@ const COMPONENT_CLASSES = [
         }
     }
 
+    function fetchDownloadableFileResources() {
+        const downloadableFileComponents = document.querySelectorAll('.page-downloadable-file-component');
+        // Replace each 'PageDownloadableFileComponent's 'href' with a new signed URL
+        downloadableFileComponents.forEach(function (element) {
+            const filePath = element.getAttribute('data-resource-path');
+            const fileUrl = element.href;
+            const fileId = element.getAttribute('data-resource-id');
+
+            fetchSignedResource(
+                filePath,
+                fileUrl,
+                `a[data-resource-id="${fileId}"]`,
+                'file'
+            );
+        });
+    }
+
 
 
     function execPageBuilderFunctions() {
@@ -108,6 +125,7 @@ const COMPONENT_CLASSES = [
         remediateInternalLinksTarget();
         identifyExternalLinks();
         chromeWorkaroundForAnchorTags();
+        fetchDownloadableFileResources();
     }
 
     $document.on('turbolinks:load', execPageBuilderFunctions);

--- a/app/assets/javascripts/_page_show.es6
+++ b/app/assets/javascripts/_page_show.es6
@@ -103,7 +103,7 @@ const COMPONENT_CLASSES = [
     function fetchDownloadableFileResources() {
         const downloadableFileComponents = document.querySelectorAll('.page-downloadable-file-component');
         // Replace each 'PageDownloadableFileComponent's 'href' with a new signed URL
-        downloadableFileComponents.forEach(function (element) {
+        downloadableFileComponents.forEach(element => {
             const filePath = element.getAttribute('data-resource-path');
             const fileUrl = element.href;
             const fileId = element.getAttribute('data-resource-id');

--- a/app/assets/javascripts/shared/_signed_resource.es6
+++ b/app/assets/javascripts/shared/_signed_resource.es6
@@ -17,6 +17,9 @@ function fetchSignedResource(
                     case 'image':
                         resourceElement.src = signedUrl;
                         break;
+                    case 'file':
+                        resourceElement.href = signedUrl;
+                        break;
                 }
             }
         });

--- a/app/views/page/show.html.erb
+++ b/app/views/page/show.html.erb
@@ -3,6 +3,7 @@
     var chromeWarning = <%= @page.has_chrome_warning_banner %>;
   <% end %>
   <%= javascript_include_tag 'ie', 'data-turbolinks-track': 'reload' %>
+  <%= javascript_include_tag 'shared/_signed_resource', 'data-turbolinks-track': 'reload' %>
   <%= javascript_include_tag '_page_show', 'data-turbolinks-track': 'reload' %>
 <% end %>
 <% accordion_ctr = 0 %>
@@ -210,7 +211,12 @@
           %>
           <div class="grid-row <%= page_narrow_classes %> <%= next_component != nil && next_component.component_type == pc.component_type ? 'margin-bottom-1' : 'margin-bottom-3 ' %> font-sans-sm line-height-162<%= ' margin-bottom-0' if last_component === index %>">
             <%= content_tag(:span, description, class: 'margin-right-1') if description != '' %>
-            <%= link_to component.attachment_s3_presigned_url, class: 'usa-link usa-link--external', target: '_blank', download: display_name != '' ? display_name : component.attachment_file_name do %>
+            <%= link_to component.attachment_s3_presigned_url,
+                        class: 'usa-link usa-link--external page-downloadable-file-component',
+                        target: '_blank',
+                        download: display_name != '' ? display_name : component.attachment_file_name,
+                        'data-resource-id': pc.component_id,
+                        'data-resource-path': pc.component.attachment.path do %>
               <i class="far fa-file margin-right-1"></i><%= display_name != '' ? display_name : component.attachment_file_name %>
             <% end %>
           </div>


### PR DESCRIPTION
### JIRA issue link
https://agile6.atlassian.net/browse/DM-3851

## Description - what does this code do?
Adjusts `PageDownloadableFileComponent`s on the page-builder `Page` show page to fetch signed URLs on load, in order to prevent URL expiration.

## Testing done - how did you test it/steps on how can another person can test it 
1. Log in as an admin.
2. Create/update a page-builder page, add at least two `PageDownloadableFileComponents`, and then save the page.
3. Visit the show page for the Page you just edited and open up the browser developer tools.
4. Inspect the first downloadable file and notice the `href` attribute. Refresh the page. Before the page is fully loaded, you should be able to see the current presigned URL. After the page loads, the `href` should get swapped out with the newly fetched presigned URL.
5. Repeat step `4` with the second downloadable file.

## Screenshots, Gifs, Videos from application (if applicable)
![](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExYjEwOWQyMDg0ZTQ3MzI1NzdkZGFlNmE2MzE1ZjQwMTNkZWY5ZTEzNiZjdD1n/OnYbRkqmj6uhaMmkka/giphy.gif)

## Link to mock-ups/mock ups (image file if you have it) (if applicable)


## Acceptance criteria
- Determine what caused this issue
- Determine why it has been fixed by re-uploading the document
- Come up with fix
- Release (if applicable)

## Definition of done
- [ ] Unit tests written (if applicable)
- [ ] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [X] A link has been provided to the originating JIRA issue
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs