### PR TITLE
Remove temporary shark tank redirect from DEV to PROD

### DIFF
--- a/app/controllers/page_controller.rb
+++ b/app/controllers/page_controller.rb
@@ -18,11 +18,6 @@ class PageController < ApplicationController
     @news_items_ids = []
     collect_paginated_components(@page_components)
 
-    # temporary Shark Tank competition redirect
-    if request.url.match?(/dev\.marketplace\.va\.gov\/competitions\/shark-tank/)
-      redirect_to "https://marketplace.va.gov/competitions/shark-tank"
-    end
-
     if page_group.is_community? && !request.url.include?('/communities')
       is_landing_page = @page_slug == 'home'
       host_name = ENV["HOSTNAME"]

--- a/app/views/about/index.html.erb
+++ b/app/views/about/index.html.erb
@@ -13,8 +13,8 @@
         <h1 class="usa-prose-h1 margin-bottom-4 margin-top-0">About us</h1>
         <p class="usa-prose-body">
           The Diffusion Marketplace is a discovery and collaboration tool that curates promising clinical, operational, and strategic innovations from VA. We are managed by the
-          <a href="https://www.va.gov/INNOVATIONECOSYSTEM/views/who-we-are/diffusion-of-excellence.html" class="usa-link usa-link--external" target="_blank">Diffusion of Excellence</a>, an organization within
-          the <a href="https://www.va.gov/INNOVATIONECOSYSTEM/home.html" class="usa-link usa-link--external" target="_blank">VHA Innovation Ecosystem</a>. Our goal is to
+          <a href="https://www.innovation.va.gov/ecosystem/views/about/mission.html" class="usa-link usa-link--external" target="_blank">Diffusion of Excellence</a>, an organization within
+          the <a href="https://www.innovation.va.gov/ecosystem/views/diffusion-excellence/doe.html" class="usa-link usa-link--external" target="_blank">VHA Innovation Ecosystem</a>. Our goal is to
           represent the best of VA and to reflect the spirit of service and collaboration for Veterans and the communities we serve.
         </p>
       </div>


### PR DESCRIPTION
### JIRA issue link


## Description - what does this code do?
- Reverts #590
- Updates links to VHA Innovation Ecosystem (flagged by [failing test](https://app.circleci.com/pipelines/github/department-of-veterans-affairs/diffusion-marketplace/5794/workflows/fe5854df-1e6e-4709-9188-2e012f2fa129/jobs/7359/parallel-runs/45/steps/45-109))

## Testing done - how did you test it/steps on how can another person can test it 
Remove redirect
- visit https://dev.marketplace.va.gov/competitions/shark-tank
- page should display a logo and a link to the 2023 competition info page

Update VHA Innovation Ecosystem
- Go to About page and click on links for `Diffusion of Excellence` and `VHA Innovation Ecosystem`. You should see the redesigned innovation ecosystem site instead of a redirect warning. 

### Before
![Screenshot 2023-04-28 at 11 06 01 AM](https://user-images.githubusercontent.com/5402927/235222675-c13be13f-86bf-43e5-b0f4-046c893981cd.png)

### After
![Screenshot 2023-04-28 at 11 13 39 AM](https://user-images.githubusercontent.com/5402927/235222762-837ca999-261c-4306-adb8-fe30ca30471d.png)

## Screenshots, Gifs, Videos from application (if applicable)


## Link to mock-ups/mock ups (image file if you have it) (if applicable)


## Acceptance criteria

## Definition of done
- [ ] Unit tests written (if applicable)
- [ ] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating JIRA issue
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs