### PR TITLE
Add VA Immersive to Communities list

### DIFF
--- a/app/models/page_group.rb
+++ b/app/models/page_group.rb
@@ -7,7 +7,8 @@ class PageGroup < ApplicationRecord
   validates :description, presence: true
 
   COMMUNITY_SLUGS = [
-    'xr-network'
+    'xr-network',
+    'va-immersive'
   ]
 
   def is_community?


### PR DESCRIPTION
### JIRA issue link


## Description - what does this code do?
- Adds VA immersive to community slugs. This makes pages available under `/communities/va-immersive` for the content team.

## Testing done - how did you test it/steps on how can another person can test it 
In local dev:
1. Create a page group named `va-immersive`
2. Create a new page. Set URL suffix to `home`. Add required title and description. Set page group to va-immersive.
3. Visit `/communities/va-immersive`. Your new page should load. 
4. Visit `/va-immersive`. The browser should redirect to `/communities/va-immersive`.
5. Create a second page. Set URL suffix to `events`. Add required title and description. Set page group to va-immersive.
6. Visit `/communities/va-immersive/events`. Your events page should load.
7. Visit `/va-immersive/events`. The page should redirect to `/communities/va-immersive/events`

## Screenshots, Gifs, Videos from application (if applicable)


## Link to mock-ups/mock ups (image file if you have it) (if applicable)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Unit tests written (if applicable)
- [ ] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating JIRA issue
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs