### PR TITLE
Allow emails with apostrophes

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -93,7 +93,7 @@ class User < ApplicationRecord
 
   def valid_email
     return true unless email_changed?
-    return true if /\A[\w+\-.]+@[a-z\d\-]+(\.[a-z\d\-]+)*\.[a-z]+\z/i.match?(email)
+    return true if /\A[\w+'\-.]+@[a-z\d\-]+(\.[a-z\d\-]+)*\.[a-z]+\z/i.match?(email)
 
     errors.add :email, 'invalid'
   end


### PR DESCRIPTION
### JIRA issue link
[DM-3931](https://agile6.atlassian.net/browse/DM-3931?atlOrigin=eyJpIjoiNmMwNGMyMzYyODUwNDA4YmIyYTM5YmM4Y2M1NWY1MmYiLCJwIjoiaiJ9)

## Description - what does this code do?
This PR allows us to create users for the rare VA user with an apostrophe in their email! 

## Testing done - how did you test it/steps on how can another person can test it 
In local development: 
1. Sign in > Register
2. Register a user with an apostrophe in their email name. (e.g. o'shea@va.gov). Add a valid password. 
3. You should get a new tab that simulates a confirmation email.

## Screenshots, Gifs, Videos from application (if applicable)
Example of successful user creation:
<img width="412" alt="Screenshot 2023-05-12 at 6 54 37 PM" src="https://github.com/department-of-veterans-affairs/diffusion-marketplace/assets/5402927/1f03dd7f-c51b-42dc-ad40-1c54cd43916e">


## Link to mock-ups/mock ups (image file if you have it) (if applicable)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Unit tests written (if applicable)
- [ ] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating JIRA issue
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs