### PR TITLE
DM-3942: Support links in Heading2 and Heading3 PageBuilder components

### DIFF
--- a/app/models/page_header2_component.rb
+++ b/app/models/page_header2_component.rb
@@ -1,3 +1,6 @@
 class PageHeader2Component < ApplicationRecord
   has_one :page_component, as: :component, autosave: true
+
+  validates_with InternalUrlValidator, on: [:create, :update], if: Proc.new { |page_component| page_component.url.present? && page_component.url.chars.first === '/' }
+  validates_with ExternalUrlValidator, on: [:create, :update], if: Proc.new { |page_component| page_component.url.present? && page_component.url.chars.first != '/' }
 end

--- a/app/models/page_header3_component.rb
+++ b/app/models/page_header3_component.rb
@@ -1,3 +1,6 @@
 class PageHeader3Component < ApplicationRecord
   has_one :page_component, as: :component, autosave: true
+
+  validates_with InternalUrlValidator, on: [:create, :update], if: Proc.new { |page_component| page_component.url.present? && page_component.url.chars.first === '/' }
+  validates_with ExternalUrlValidator, on: [:create, :update], if: Proc.new { |page_component| page_component.url.present? && page_component.url.chars.first != '/' }
 end

--- a/app/views/active_admin/resource/_page_header2_component_form.html.arb
+++ b/app/views/active_admin/resource/_page_header2_component_form.html.arb
@@ -24,6 +24,14 @@ html = Arbre::Context.new do
                   id: "page_page_components_attributes_#{placeholder}_component_attributes_subtopic_description",
                   name: "page[page_components_attributes][#{placeholder}][component_attributes][subtopic_description]"
           end
+
+          li class: 'string input optional stringish', id: "page_page_components_attributes_#{placeholder}_component_attributes_url_input" do
+          label 'URL', for: "page_page_components_attributes_#{placeholder}_component_attributes_text", class: 'label'
+          input value: component&.url || nil, type: 'text', required: 'required',
+                id: "page_page_components_attributes_#{placeholder}_component_attributes_url",
+                name: "page[page_components_attributes][#{placeholder}][component_attributes][url]"
+          para 'Optional. Enter a URL suffix to any internal page of the marketplace (Ex: "/innovations/vione" or a complete external URL (Ex.  https://www.va.gov/) that you would like the heading to link to', class: 'inline-hints'
+          end
         end
       end
     end

--- a/app/views/active_admin/resource/_page_header3_component_form.html.arb
+++ b/app/views/active_admin/resource/_page_header3_component_form.html.arb
@@ -36,6 +36,14 @@ html = Arbre::Context.new do
             end
             para 'Choose an alignment for this H3 component: Left, Center, or Right.', class: 'inline-hints'
           end
+
+          li class: 'string input optional stringish', id: "page_page_components_attributes_#{placeholder}_component_attributes_url_input" do
+          label 'URL', for: "page_page_components_attributes_#{placeholder}_component_attributes_text", class: 'label'
+          input value: component&.url || nil, type: 'text', required: 'required',
+                id: "page_page_components_attributes_#{placeholder}_component_attributes_url",
+                name: "page[page_components_attributes][#{placeholder}][component_attributes][url]"
+          para 'Optional. Enter a URL suffix to any internal page of the marketplace (Ex: "/innovations/vione" or a complete external URL (Ex.  https://www.va.gov/) that you would like the heading to link to', class: 'inline-hints'
+          end
         end
       end
     end

--- a/app/views/page/show.html.erb
+++ b/app/views/page/show.html.erb
@@ -41,7 +41,7 @@
         <% when 'PageHeader3Component' %>
           <div class="<%= page_narrow_classes %> margin-bottom-3<%= ' margin-bottom-0' if last_component === index %>">
             <h3 class="font-sans-lg text-<%= component.alignment.downcase %>">
-              <%= component.title %>
+              <%= link_to_unless component.url.blank?, component.title, component.url %>
             </h3>
             <% if component.description.present? %>
               <div class="grid-col-12 <%= 'desktop:grid-col-8' unless @page.narrow? %> margin-top-2 line-height-26">

--- a/app/views/page/show.html.erb
+++ b/app/views/page/show.html.erb
@@ -28,7 +28,7 @@
         <% case pc.component_type when 'PageHeader2Component' %>
           <div class="grid-row margin-bottom-3<%= ' margin-bottom-0' if last_component === index %>">
             <h2 class="grid-col-12 desktop:grid-col-8 font-sans-xl <%= 'margin-x-auto' if @page.narrow? %>">
-              <%= component.subtopic_title %>
+              <%= link_to_unless component.url.blank?, component.subtopic_title, component.url %>
             </h2>
             <% if component.subtopic_description.present? %>
               <div class="grid-col-12 desktop:grid-col-8 line-height-26 <%= 'margin-x-auto' if @page.narrow? %> margin-top-2">

--- a/app/views/page/show.html.erb
+++ b/app/views/page/show.html.erb
@@ -28,7 +28,7 @@
         <% case pc.component_type when 'PageHeader2Component' %>
           <div class="grid-row margin-bottom-3<%= ' margin-bottom-0' if last_component === index %>">
             <h2 class="grid-col-12 desktop:grid-col-8 font-sans-xl <%= 'margin-x-auto' if @page.narrow? %>">
-              <%= link_to_unless component.url.blank?, component.subtopic_title, component.url %>
+              <%= link_to_unless component.url.blank?, component.subtopic_title, component.url, target: get_link_target_attribute(component.url), class: set_link_classes(component.url) %>
             </h2>
             <% if component.subtopic_description.present? %>
               <div class="grid-col-12 desktop:grid-col-8 line-height-26 <%= 'margin-x-auto' if @page.narrow? %> margin-top-2">
@@ -41,7 +41,7 @@
         <% when 'PageHeader3Component' %>
           <div class="<%= page_narrow_classes %> margin-bottom-3<%= ' margin-bottom-0' if last_component === index %>">
             <h3 class="font-sans-lg text-<%= component.alignment.downcase %>">
-              <%= link_to_unless component.url.blank?, component.title, component.url %>
+              <%= link_to_unless component.url.blank?, component.title, component.url, target: get_link_target_attribute(component.url), class: set_link_classes(component.url) %>
             </h3>
             <% if component.description.present? %>
               <div class="grid-col-12 <%= 'desktop:grid-col-8' unless @page.narrow? %> margin-top-2 line-height-26">

--- a/db/migrate/20230515234423_add_url_to_page_header2_component.rb
+++ b/db/migrate/20230515234423_add_url_to_page_header2_component.rb
@@ -1,0 +1,5 @@
+class AddUrlToPageHeader2Component < ActiveRecord::Migration[6.0]
+  def change
+    add_column :page_header2_components, :url, :string
+  end
+end

--- a/db/migrate/20230516000120_add_url_to_page_header3_component.rb
+++ b/db/migrate/20230516000120_add_url_to_page_header3_component.rb
@@ -1,0 +1,5 @@
+class AddUrlToPageHeader3Component < ActiveRecord::Migration[6.0]
+  def change
+    add_column :page_header3_components, :url, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_11_07_181813) do
+ActiveRecord::Schema.define(version: 2023_05_15_234423) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -605,6 +605,7 @@ ActiveRecord::Schema.define(version: 2022_11_07_181813) do
     t.string "subtopic_description"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "url"
     t.index ["page_component_id"], name: "index_page_header2_components_on_page_component_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_05_15_234423) do
+ActiveRecord::Schema.define(version: 2023_05_16_000120) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -616,6 +616,7 @@ ActiveRecord::Schema.define(version: 2023_05_15_234423) do
     t.string "description"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "url"
     t.index ["page_component_id"], name: "index_page_header3_components_on_page_component_id"
   end
 

--- a/spec/features/pages/headings_spec.rb
+++ b/spec/features/pages/headings_spec.rb
@@ -1,0 +1,66 @@
+require 'rails_helper'
+describe 'Page Builder - Show - Paginated Components', type: :feature do
+  before do
+    page_group = PageGroup.create(name: 'programming', slug: 'programming', description: 'Pages about programming go in this group.')
+    @page = Page.create(page_group: page_group, title: 'ruby', description: 'what a gem', slug: 'ruby-rocks', has_chrome_warning_banner: true, created_at: Time.now, published: Time.now)
+
+
+    # must be logged in to view pages
+    login_as(@user, scope: :user, run_callbacks: false)
+  end
+
+  # add tests here!
+  context 'h2' do
+    it 'styles and sets target for external URLs' do
+      h2_internal = PageHeader2Component.create(url: '/about', subtopic_title: 'About Our Mission', subtopic_description: 'an internal link')
+      h2_external = PageHeader2Component.create(url: 'https://www.google.com', subtopic_title: 'External search', subtopic_description: 'an external link')
+      PageComponent.create(page: @page, component: h2_internal, created_at: Time.now)
+      PageComponent.create(page: @page, component: h2_external, created_at: Time.now)
+      visit '/programming/ruby-rocks'
+
+      internal_link = page.find_link('About Our Mission')
+      external_link = page.find_link('External search')
+
+      expect(external_link[:class]).to eq('usa-link usa-link--external')
+      expect(external_link[:target]).to eq('_blank')
+      expect(internal_link[:class]).not_to eq('usa-link usa-link--external')
+      expect(internal_link[:target]).not_to eq('_blank')
+    end
+
+    it 'does not apply link styling if a URL is not supplied' do
+      h2_plain = PageHeader2Component.create(url: '', subtopic_title: 'Just a Title', subtopic_description: 'no link provided')
+      PageComponent.create(page: @page, component: h2_plain, created_at: Time.now)
+      visit '/programming/ruby-rocks'
+
+      heading = page.find('h2', text: 'Just a Title')
+      expect(heading).not_to have_css('.usa-link')
+    end
+  end
+
+  context 'h3' do
+    it 'styles and sets target for external URLs' do
+      h3_internal = PageHeader3Component.create(url: '/about', title: 'About Our Mission', description: 'an internal link', alignment: 'Left')
+      h3_external = PageHeader3Component.create(url: 'https://www.google.com', title: 'External search', description: 'an external link', alignment: 'Left')
+      PageComponent.create(page: @page, component: h3_internal, created_at: Time.now)
+      PageComponent.create(page: @page, component: h3_external, created_at: Time.now)
+      visit '/programming/ruby-rocks'
+
+      internal_link = page.find_link('About Our Mission')
+      external_link = page.find_link('External search')
+
+      expect(external_link[:class]).to eq('usa-link usa-link--external')
+      expect(external_link[:target]).to eq('_blank')
+      expect(internal_link[:class]).not_to eq('usa-link usa-link--external')
+      expect(internal_link[:target]).not_to eq('_blank')
+    end
+
+    it 'does not apply link styling if a URL is not supplied' do
+      h3_plain = PageHeader3Component.create(url: '', title: 'Just a Title', description: 'no link provided', alignment: 'Left')
+      PageComponent.create(page: @page, component: h3_plain, created_at: Time.now)
+      visit '/programming/ruby-rocks'
+
+      heading = page.find('h3', text: 'Just a Title')
+      expect(heading).not_to have_css('.usa-link')
+    end
+  end
+end


### PR DESCRIPTION
### JIRA issue link
[DM-3942](https://agile6.atlassian.net/browse/DM-3942?atlOrigin=eyJpIjoiMjBlZTI1MzM4ODc1NDgxY2JiZjZjMmYxOWVmMTgwZTgiLCJwIjoiaiJ9)

## Description - what does this code do?
This PR updates the Heading2 and Heading3 components so that an editor can supply a link for each heading.

## Testing done - how did you test it/steps on how can another person can test it 
In local dev: 
1. run `rails db:migrate`
1. Log in as an admin
2. Create a new page group and page. Go to page editing UI

Heading 2
1. Create a Heading2 component with an internal URL 
1. Create a Heading2 component with an external URL 
1. Create a Heading2 component with no URL 
1. Confirm that links get appropriate styling (e.g. external URL should open in a new tab and get an icon)

Repeat for Heading3 component.

## Screenshots, Gifs, Videos from application (if applicable)
![Screenshot 2023-05-16 at 10 40 38 AM](https://github.com/department-of-veterans-affairs/diffusion-marketplace/assets/5402927/2297794c-45b4-4996-b3a4-2367d8f0e28b)


## Link to mock-ups/mock ups (image file if you have it) (if applicable)

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Unit tests written (if applicable)
- [ ] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating JIRA issue
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs