### PR TITLE
DM-3939: Adjust styling for Events and News PageBuilder components

### DIFF
--- a/app/assets/stylesheets/dm/components/page_component.scss
+++ b/app/assets/stylesheets/dm/components/page_component.scss
@@ -173,9 +173,16 @@
 
   .page-event-component {
     @include u-margin-bottom(2);
+    .usa-card__container {
+      border: 0;
+    }
   }
 
   .page-news-component {
     @include u-margin-bottom(2);
+
+    .usa-card__container {
+        border: 0;
+      }
   }
 

--- a/app/assets/stylesheets/dm/components/page_component.scss
+++ b/app/assets/stylesheets/dm/components/page_component.scss
@@ -172,7 +172,7 @@
 }
 
   .page-event-component {
-    border-top: 1px solid black;
+    @include u-margin-bottom(2);
   }
 
   .page-news-component {

--- a/app/views/page/_events_list.html.erb
+++ b/app/views/page/_events_list.html.erb
@@ -1,10 +1,14 @@
 <% events.each do |event|%>
-    <div class="page-event-component">
-        <h3 class="event-title margin-bottom-3">
-            <%= link_to_if(event.title.present? && event.url.present?, event.title, event.url, class: set_link_classes(event.url), target: get_link_target_attribute(event.url)) %>
-        </h3>
-        <div id="<%= event.id %>" class="event-description usa-prose padding-bottom-5">
-            <%= event&.text.html_safe %>
+    <li class="page-event-component usa-card tablet:grid-col-6">
+        <div class="usa-card__container">
+            <div class="usa-card__header">
+                <h3 class="margin-bottom-2 event-title">
+                    <%= link_to_if(event.title.present? && event.url.present?, event.title, event.url, class: set_link_classes(event.url), target: get_link_target_attribute(event.url)) %>
+                </h3>
+            </div>
+            <div id="<%= event.id %>" class="event-item-description usa-prose usa-card__body">
+                <%= event&.text.html_safe %>
+            </div>
         </div>
-    </div>
+    </li>
 <% end %>

--- a/app/views/page/_news_items_list.html.erb
+++ b/app/views/page/_news_items_list.html.erb
@@ -7,10 +7,10 @@
                 </h3>
             </div>
             <div id="<%= news_item.id %>" class="news-item-description usa-prose usa-card__body">
-                <%= news_item&.text.html_safe %>
-            </div>
-            <div class="usa-card__footer">
-                <span class="news-published-date"><%= news_item&.published_date&.strftime("%B %e, %Y") %></span>
+                <% if news_item.published_date.present? %>
+                    Published on <p class="news-published-date"><%= news_item&.published_date&.strftime("%B %e, %Y") %></p>
+                    <%= news_item&.text.html_safe %>
+                <% end %>
             </div>
         </div>
     </li>

--- a/app/views/page/show.html.erb
+++ b/app/views/page/show.html.erb
@@ -96,9 +96,9 @@
               elc = @event_list_components[component_index]
               @event_list_component_index = component_index + 1
             %>
-            <div class="event-component-list dm-paginated-<%= component_index %>-events margin-bottom-4 <%= page_narrow_classes %><%= ' margin-bottom-0' if last_component === index %>">
+            <ul class="event-component-list usa-card-group dm-paginated-<%= component_index %>-events margin-bottom-4 <%= page_narrow_classes %><%= ' margin-bottom-0' if last_component === index %>">
               <%= render(partial: 'events_list', locals: {events: elc[:events]}) %>
-            </div>
+            </ul>
             <% if elc[:pagy].count > 3  %>
               <div class="text-center dm-load-more-events-<%= component_index %>-btn-container">
                 <% link = pagy_link_proc(elc[:pagy]) %>


### PR DESCRIPTION
### JIRA issue link
[DM-3939](https://agile6.atlassian.net/browse/DM-3939?atlOrigin=eyJpIjoiYWQ1OWI5OTBhODNiNDAxYmFkZmY0NWEzOGViN2Y2MGQiLCJwIjoiaiJ9)

## Description - what does this code do?
- Converts PageBuilder Event components to use card styling
- Removes borders from both Event and News component cards
- Moves published date location and adds it to a string "Published on {DATE}"

## Testing done - how did you test it/steps on how can another person can test it 
1. Log in as an admin
2. Create a page group and page
3. Create 2 Event components
4. Create 2 News components
5. Confirm that Events are styled as cards
6. Confirm that News "published date" now appears underneath the news item title in a string "Published on {DATE}"


## Screenshots, Gifs, Videos from application (if applicable)
### Before
![Screenshot 2023-05-16 at 12 45 16 PM](https://github.com/department-of-veterans-affairs/diffusion-marketplace/assets/5402927/b3d4a59b-92a2-46e8-bc52-05e8aad5c10e)

### After
![Screenshot 2023-05-16 at 12 43 16 PM](https://github.com/department-of-veterans-affairs/diffusion-marketplace/assets/5402927/f6d391c3-bb19-4b3e-8a09-fa13721a4322)

### Before

![Screenshot 2023-05-16 at 12 45 04 PM](https://github.com/department-of-veterans-affairs/diffusion-marketplace/assets/5402927/be5919b4-c210-467f-a3e4-6df5d6647a46)

### After
![Screenshot 2023-05-16 at 12 43 31 PM](https://github.com/department-of-veterans-affairs/diffusion-marketplace/assets/5402927/d7ef6edf-d887-4506-b2c3-f1964e4c6f54)

## Link to mock-ups/mock ups (image file if you have it) (if applicable)
https://www.figma.com/file/ccwLbt94U9QGfnuFCwOXzY/Core-Designs---VA-DM?type=design&node-id=6181%3A38873&t=LK8vVcQKrISsIvPD-1

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Unit tests written (if applicable)
- [ ] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating JIRA issue
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs