### PR TITLE
Move rails-assets gems to a source block

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,4 @@
 source 'https://rubygems.org'
-source 'https://rails-assets.org'
-git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 ruby '2.7.8'
 
@@ -124,9 +122,11 @@ gem 'friendly_id', '~> 5.2.4'
 
 gem 'jquery-cropper'
 
-gem 'rails-assets-jquery', source: 'https://rails-assets.org'
-gem 'rails-assets-sticky', source: 'https://rails-assets.org'
-gem 'rails-assets-jquery.scrollTo', source: 'https://rails-assets.org'
+source 'https://rails-assets.org' do
+  gem 'rails-assets-jquery'
+  gem 'rails-assets-sticky'
+  gem 'rails-assets-jquery.scrollTo'
+end
 gem "nested_form"
 gem 'colorize'
 gem 'humanize'

--- a/Gemfile
+++ b/Gemfile
@@ -109,7 +109,7 @@ gem 'acts_as_list'
 gem 'aws-sdk-s3'
 gem 'aws-sdk-rds'
 gem 'wt_s3_signer'
-gem 'paperclip', github: 'agilesix/paperclip', ref: 'ruby-2.7.x-deprecation-fix'
+gem 'paperclip', github: 'agilesix/paperclip', branch: 'ruby-2.7.x-deprecation-fix'
 gem 'font-awesome-sass', '~> 5.13.0'
 gem 'sidekiq'
 
@@ -149,12 +149,12 @@ gem 'groupdate'
 
 gem 'ahoy_matey'
 
-gem 'ntlm-sso', github: 'agilesix/ntlm-sso', ref: 'master'
+gem 'ntlm-sso', github: 'agilesix/ntlm-sso', branch: 'master'
 gem 'net-ldap'
 
 gem 'wdm', '>= 0.1.0' if Gem.win_platform?
 
-gem 'gmaps4rails', github: 'agilesix/Google-Maps-for-Rails', ref: 'master'
+gem 'gmaps4rails', github: 'agilesix/Google-Maps-for-Rails', branch: 'master'
 gem 'lodash-rails'
 
 gem 'route_downcaser'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -53,7 +53,6 @@ GEM
 
 GEM
   remote: https://rubygems.org/
-  remote: https://rails-assets.org/
   specs:
     actioncable (6.0.5.1)
       actionpack (= 6.0.5.1)
@@ -596,12 +595,7 @@ GEM
       bundler (>= 1.3.0)
       railties (= 6.0.5.1)
       sprockets-rails (>= 2.0.0)
-    rails-assets-jquery (3.6.0)
-    rails-assets-jquery.scrollTo (2.1.2)
-      rails-assets-jquery (>= 1.8)
     rails-assets-normalize-css (3.0.3)
-    rails-assets-sticky (1.0.4)
-      rails-assets-jquery
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,14 +1,14 @@
 GIT
   remote: https://github.com/agilesix/Google-Maps-for-Rails.git
   revision: b75a989aa3fb187cfd945a40b139d22d6ac672bf
-  ref: master
+  branch: master
   specs:
     gmaps4rails (2.1.2)
 
 GIT
   remote: https://github.com/agilesix/ntlm-sso.git
   revision: 32807d619a8cd930b0f1ae549f2eeb32e6154f87
-  ref: master
+  branch: master
   specs:
     ntlm-sso (0.0.1)
       ruby-ntlm
@@ -16,7 +16,7 @@ GIT
 GIT
   remote: https://github.com/agilesix/paperclip.git
   revision: e1df9f4d9ebb0f59220e726df5453b75c5b77641
-  ref: ruby-2.7.x-deprecation-fix
+  branch: ruby-2.7.x-deprecation-fix
   specs:
     paperclip (6.1.0)
       activemodel (>= 4.2.0)


### PR DESCRIPTION
### JIRA issue link


## Description - what does this code do?
Address deprecation warning: 
```
[DEPRECATED] Your Gemfile contains multiple primary sources. Using `source` more than once without a block is a security risk, and may result in installing unexpected gems. To resolve this warning, use a block to indicate which gems should come from the secondary source.
```

## Testing done - how did you test it/steps on how can another person can test it 


## Screenshots, Gifs, Videos from application (if applicable)


## Link to mock-ups/mock ups (image file if you have it) (if applicable)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Unit tests written (if applicable)
- [ ] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating JIRA issue
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs