### PR TITLE
Add authors field to News PageBuilder component

### DIFF
--- a/app/admin/pages.rb
+++ b/app/admin/pages.rb
@@ -21,6 +21,7 @@ ActiveAdmin.register Page do
                   :position,
                   :_destroy,
                   component_attributes: [
+                    :authors,
                     :url,
                     :description,
                     :title,

--- a/app/views/active_admin/resource/_page_news_component_form.html.arb
+++ b/app/views/active_admin/resource/_page_news_component_form.html.arb
@@ -44,6 +44,14 @@ html = Arbre::Context.new do
           para 'Original publication date', class: 'inline-hints'
         end
 
+        li class: 'string input optional stringish', id: "page_page_components_attributes_#{placeholder}_component_attributes_authors_input" do
+          label 'Author(s)', for: "page_page_components_attributes_news_#{placeholder}_component_attributes_text", class: 'label'
+          input value: component&.authors || nil, type: 'text', required: 'required',
+                id: "page_page_components_attributes_#{placeholder}_component_attributes_authors",
+                name: "page[page_components_attributes][#{placeholder}][component_attributes][authors]"
+          para 'Enter with appropriate punctuation. e.g. "John, Joan, and Jill', class: 'inline-hints'
+        end
+
         li class: 'string input optional stringish', id: "page_page_components_attributes_news_#{placeholder}_component_attributes_text_input" do
           if component
             input type: 'hidden', value: component.id, name: "page[page_components_attributes][#{placeholder}][component_attributes][id]"

--- a/app/views/page/_news_items_list.html.erb
+++ b/app/views/page/_news_items_list.html.erb
@@ -7,10 +7,14 @@
                 </h3>
             </div>
             <div id="<%= news_item.id %>" class="news-item-description usa-prose usa-card__body">
-                <% if news_item.published_date.present? %>
-                    Published on <p class="news-published-date"><%= news_item&.published_date&.strftime("%B %e, %Y") %></p>
-                    <%= news_item&.text.html_safe %>
+                <% if news_item.published_date.present? && news_item.authors.present? %>
+                    <p>Published on <%= news_item&.published_date&.strftime("%B %e, %Y") %> by <%= news_item&.authors %></p>
+                <% elsif news_item.published_date.present? %>
+                    <p>Published on <%= news_item&.published_date&.strftime("%B %e, %Y") %></p>
+                <% elsif news_item.authors.present? %>
+                    <p>Published by <%= news_item&.authors %></p>
                 <% end %>
+                <p><%= news_item&.text&.html_safe %></p>
             </div>
         </div>
     </li>

--- a/db/migrate/20230525214628_add_authors_to_page_news_component.rb
+++ b/db/migrate/20230525214628_add_authors_to_page_news_component.rb
@@ -1,0 +1,5 @@
+class AddAuthorsToPageNewsComponent < ActiveRecord::Migration[6.0]
+  def change
+    add_column :page_news_components, :authors, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_05_16_203145) do
+ActiveRecord::Schema.define(version: 2023_05_25_214628) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -674,6 +674,7 @@ ActiveRecord::Schema.define(version: 2023_05_16_203145) do
     t.string "url"
     t.string "text"
     t.date "published_date"
+    t.string "authors"
     t.index ["page_component_id"], name: "index_page_news_components_on_page_component_id"
   end
 

--- a/spec/features/pages/news_component_spec.rb
+++ b/spec/features/pages/news_component_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+describe 'Page Builder - Show - Paginated Components', type: :feature do
+  before do
+    page_group = PageGroup.create(name: 'programming', slug: 'programming', description: 'Pages about programming go in this group.')
+    @page = Page.create(page_group: page_group, title: 'ruby', description: 'what a gem', slug: 'ruby-rocks', has_chrome_warning_banner: true, created_at: Time.now, published: Time.now)
+
+    # must be logged in to view pages
+    login_as(@user, scope: :user, run_callbacks: false)
+  end
+
+  context 'Publication info' do
+    it 'date only' do
+      news_component = PageNewsComponent.create(title: 'Date only', published_date: Date.new(2023,05,16) )
+      PageComponent.create(page: @page, component: news_component, created_at: Time.now)
+      visit 'programming/ruby-rocks'
+
+      expect(page).to have_content "Published on May 16, 2023"
+    end
+
+    it 'author only' do
+      news_component = PageNewsComponent.create(title: 'Author', authors: "Bubbles, Blossom, and Buttercup" )
+      PageComponent.create(page: @page, component: news_component, created_at: Time.now,)
+      visit 'programming/ruby-rocks'
+      expect(page).to have_content "Published by Bubbles, Blossom, and Buttercup"
+    end
+
+    it 'date and author' do
+      news_component = PageNewsComponent.create(title: 'Date and author', published_date: Date.new(2023,05,16), authors: "Bubbles, Blossom, and Buttercup" )
+      PageComponent.create(page: @page, component: news_component, created_at: Time.now,)
+      visit 'programming/ruby-rocks'
+      expect(page).to have_content "Published on May 16, 2023 by Bubbles, Blossom, and Buttercup"
+    end
+  end
+end


### PR DESCRIPTION
### JIRA issue link
[DM-3994](https://agile6.atlassian.net/browse/DM-3994?atlOrigin=eyJpIjoiNmUyZWI0NjhlNTE3NDc3YTgzMjFmYjg1NDIxNWFlNjciLCJwIjoiaiJ9)

## Description - what does this code do?
- Adds an Authors field to the News PageBuilder component so that each news story can have a "Published on {DATE} by {AUTHORS}" text appear under the title
![Screenshot 2023-05-25 at 3 22 12 PM](https://github.com/department-of-veterans-affairs/diffusion-marketplace/assets/5402927/39833dc5-8a86-4d27-a2b4-60d75ac3dc3a)

## Testing done - how did you test it/steps on how can another person can test it 
1. Log in as an admin
2. Create a test page group and page
3. Add a news component with a title and a date
4. Add a news component with a title and authors
5. Add a news component with a title, date, and authors
6. Confirm that the "Published" field is rendering correctly for each case.

## Screenshots, Gifs, Videos from application (if applicable)
![Screenshot 2023-05-25 at 3 00 30 PM](https://github.com/department-of-veterans-affairs/diffusion-marketplace/assets/5402927/b111bc6d-7b7e-427e-8be6-6429f9019006)


## Link to mock-ups/mock ups (image file if you have it) (if applicable)
https://www.figma.com/file/ccwLbt94U9QGfnuFCwOXzY/Core-Designs---VA-DM?type=design&node-id=6181%3A38873&t=tzJ5zLb1itlQkVHL-1

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Unit tests written (if applicable)
- [x] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating JIRA issue
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs