### PR TITLE
Add different column layout options to PB Map Component

### DIFF
--- a/app/admin/pages.rb
+++ b/app/admin/pages.rb
@@ -43,6 +43,7 @@ ActiveAdmin.register Page do
                     :display_in_progress_adoptions,
                     :display_unsuccessful_adoptions,
                     :map_info_window_text,
+                    :description_text_alignment,
                     :body,
                     :title_header,
                     :text_alignment,

--- a/app/assets/javascripts/_page_show.es6
+++ b/app/assets/javascripts/_page_show.es6
@@ -3,7 +3,8 @@ const COMPONENT_CLASSES = [
     '.page-accordion-component',
     '.page-compound-body-component',
     '.page-event-component p',
-    '.page-news-component p'
+    '.page-news-component p',
+    '.page-map-component p'
 ].join(', ');
 
 (($) => {

--- a/app/views/active_admin/resource/_page_map_component_form.html.arb
+++ b/app/views/active_admin/resource/_page_map_component_form.html.arb
@@ -28,6 +28,21 @@ html = Arbre::Context.new do
           para 'Enter text or acronym to display in the maps info window.', class: 'inline-hints'
         end
 
+        # Description text alignment
+        li class: 'select input description-text-alignment-container',
+           id: "page_page_components_attributes_#{placeholder}_component_attributes_description_text_alignment_input" do
+          label 'Text alignment', for: "page_page_components_attributes_#{placeholder}_component_attributes_description_text_alignment", class: 'label'
+          select value: component&.description_text_alignment || nil,
+                 id: "page_page_components_attributes_#{placeholder}_component_attributes_description_text_alignment",
+                 name: "page[page_components_attributes][#{placeholder}][component_attributes][description_text_alignment]" do
+            option 'Bottom', selected: component&.description_text_alignment === 'Bottom' || component&.description_text_alignment.blank?
+            option 'Left', selected: component&.description_text_alignment === 'Left'
+            option 'Right', selected: component&.description_text_alignment === 'Right'
+          end
+          para "Text alignment for map description (bottom, left or right). Defaults to below the map.",
+               class: 'inline-hints'
+        end
+
         li class: 'url input required stringish', id: "page_page_components_attributes_#{placeholder}_component_attributes_description_input" do
           label 'Description', for: "page_page_components_attributes_#{placeholder}_component_attributes_description", class: 'label'
           input value: component&.description || nil, type: 'text', required: 'required',

--- a/app/views/active_admin/resource/_page_map_component_form.html.arb
+++ b/app/views/active_admin/resource/_page_map_component_form.html.arb
@@ -43,11 +43,13 @@ html = Arbre::Context.new do
                class: 'inline-hints'
         end
 
+        # Map description
         li class: 'url input required stringish', id: "page_page_components_attributes_#{placeholder}_component_attributes_description_input" do
           label 'Description', for: "page_page_components_attributes_#{placeholder}_component_attributes_description", class: 'label'
-          input value: component&.description || nil, type: 'text', required: 'required',
-                id: "page_page_components_attributes_#{placeholder}_component_attributes_description",
-                name: "page[page_components_attributes][#{placeholder}][component_attributes][description]"
+
+          textarea component&.description, id: "page_page_components_attributes_#{placeholder}_component_attributes_description", name: "page[page_components_attributes][#{placeholder}][component_attributes][description]", class: 'tinymce', rows:'18' do
+            component&.send(:description).try :html_safe
+          end
           para 'Enter a brief description of the map.', class: 'inline-hints'
         end
 

--- a/app/views/page/_page_map.html.erb
+++ b/app/views/page/_page_map.html.erb
@@ -6,5 +6,5 @@
     <%= javascript_include_tag 'page/page_map', 'data-turbolinks-track': 'reload' %>
   <% end %>
 
-  <div id="page_builder_map_<%= component_id %>" class="grid-col-12 desktop:grid-col-9 page_builder_map"></div>
+  <div id="page_builder_map_<%= component_id %>" class="page_builder_map"></div>
 <% end %>

--- a/app/views/page/show.html.erb
+++ b/app/views/page/show.html.erb
@@ -229,43 +229,45 @@
             map_component_markers = @map_components_with_markers.find { |key, value| value[:component] == component }&.last[:markers]
             text_alignment = component.description_text_alignment
           %>
-          <% if title.present? %>
-            <div class="margin-bottom-2 font-sans-lg text-bold margin-top-9 <%= page_narrow_classes %>">
-              <%= content_tag(:span, title, class: 'margin-right-1') %>
-            </div>
-          <% end %>
-
-          <div class="grid-row <%= page_narrow_classes %>">
-            <% map_cols = if description&.blank?
-                            'grid-col-12'
-                          elsif text_alignment == 'Left'
-                            'grid-col-12 desktop:grid-col-9 order-2 padding-left-2'
-                          elsif text_alignment == 'Right'
-                            'grid-col-12 desktop:grid-col-9 padding-right-2'
-                          else
-                            'grid-col-12'
-                          end
-            %>
-            <div class="margin-bottom-1 page-map-component <%= map_cols %>">
-              <%= render partial: "page/page_map",
-                        locals: {
-                          facility_markers: map_component_markers,
-                          component: component,
-                          component_id: component.page_component.id }
-              %>
-            </div>
-
-            <% if description&.present? %>
-            <% description_cols = if text_alignment == 'Left' || text_alignment == 'Right'
-                                    'grid-col-12 desktop:grid-col-3'
-                                  else
-                                    'grid-col-12'
-                                  end
-            %>
-              <div class="margin-top-2 <%= description_cols %> font-sans-sm line-height-162<%= ' margin-bottom-9' if last_component === index %>">
-                <%= content_tag(:span, description, class: 'margin-right-1') %>
+          <div class="page-map-component">
+            <% if title.present? %>
+              <div class="margin-bottom-2 font-sans-lg text-bold margin-top-9 <%= page_narrow_classes %>">
+                <%= content_tag(:span, title, class: 'margin-right-1') %>
               </div>
             <% end %>
+
+            <div class="grid-row <%= page_narrow_classes %>">
+              <% map_cols = if description&.blank?
+                              'grid-col-12'
+                            elsif text_alignment == 'Left'
+                              'grid-col-12 desktop:grid-col-9 order-2 padding-left-2'
+                            elsif text_alignment == 'Right'
+                              'grid-col-12 desktop:grid-col-9 padding-right-2'
+                            else
+                              'grid-col-12'
+                            end
+              %>
+              <div class="margin-bottom-1 page-map-component <%= map_cols %>">
+                <%= render partial: "page/page_map",
+                          locals: {
+                            facility_markers: map_component_markers,
+                            component: component,
+                            component_id: component.page_component.id }
+                %>
+              </div>
+
+              <% if description&.present? %>
+              <% description_cols = if text_alignment == 'Left' || text_alignment == 'Right'
+                                      'grid-col-12 desktop:grid-col-3'
+                                    else
+                                      'grid-col-12'
+                                    end
+              %>
+                <div class="margin-top-2 <%= description_cols %> font-sans-sm line-height-162<%= ' margin-bottom-9' if last_component === index %>">
+                  <p class="margin-right-1"><%= description.html_safe %></p>
+                </div>
+              <% end %>
+            </div>
           </div>
 
         <%# Text and Images %>

--- a/app/views/page/show.html.erb
+++ b/app/views/page/show.html.erb
@@ -224,19 +224,19 @@
         <%# Map Component %>
         <% when 'PageMapComponent' %>
           <%
-            description = component.description
-            title = component.title
+            description = component&.description
+            title = component&.title
             map_component_markers = @map_components_with_markers.find { |key, value| value[:component] == component }&.last[:markers]
-            text_alignment = component.description_text_alignment
+            text_alignment = component&.description_text_alignment
           %>
-          <div class="page-map-component">
+          <div class="page-map-component <%= page_narrow_classes %>">
             <% if title.present? %>
-              <div class="margin-bottom-2 font-sans-lg text-bold margin-top-9 <%= page_narrow_classes %>">
+              <div class="font-sans-lg text-bold margin-top-9">
                 <%= content_tag(:span, title, class: 'margin-right-1') %>
               </div>
             <% end %>
 
-            <div class="grid-row <%= page_narrow_classes %>">
+            <div class="grid-row margin-top-2">
               <% map_cols = if description&.blank?
                               'grid-col-12'
                             elsif text_alignment == 'Left'
@@ -247,7 +247,7 @@
                               'grid-col-12'
                             end
               %>
-              <div class="margin-bottom-1 page-map-component <%= map_cols %>">
+              <div class="margin-bottom-1 <%= map_cols %>">
                 <%= render partial: "page/page_map",
                           locals: {
                             facility_markers: map_component_markers,
@@ -263,7 +263,7 @@
                                       'grid-col-12'
                                     end
               %>
-                <div class="margin-top-2 <%= description_cols %> font-sans-sm line-height-162<%= ' margin-bottom-9' if last_component === index %>">
+                <div class="<%= description_cols %> font-sans-sm line-height-162<%= ' margin-bottom-9' if last_component === index %>">
                   <p class="margin-right-1"><%= description.html_safe %></p>
                 </div>
               <% end %>

--- a/app/views/page/show.html.erb
+++ b/app/views/page/show.html.erb
@@ -230,12 +230,12 @@
             text_alignment = component.description_text_alignment
           %>
           <% if title.present? %>
-            <div class="margin-bottom-2 font-sans-lg text-bold margin-top-9">
+            <div class="margin-bottom-2 font-sans-lg text-bold margin-top-9 <%= page_narrow_classes %>">
               <%= content_tag(:span, title, class: 'margin-right-1') %>
             </div>
           <% end %>
 
-          <div class="grid-row">
+          <div class="grid-row <%= page_narrow_classes %>">
             <% map_cols = if description&.blank?
                             'grid-col-12'
                           elsif text_alignment == 'Left'
@@ -262,11 +262,11 @@
                                     'grid-col-12'
                                   end
             %>
-              <div class="margin-top-2 <%= description_cols %> <%= page_narrow_classes %> font-sans-sm line-height-162<%= ' margin-bottom-9' if last_component === index %>">
+              <div class="margin-top-2 <%= description_cols %> font-sans-sm line-height-162<%= ' margin-bottom-9' if last_component === index %>">
                 <%= content_tag(:span, description, class: 'margin-right-1') %>
               </div>
             <% end %>
-          <div>
+          </div>
 
         <%# Text and Images %>
         <% when 'PageCompoundBodyComponent' %>

--- a/app/views/page/show.html.erb
+++ b/app/views/page/show.html.erb
@@ -226,8 +226,8 @@
           <%
             description = component.description
             title = component.title
-            next_component = @page.page_components.find_by(position: pc.position + 1)
             map_component_markers = @map_components_with_markers.find { |key, value| value[:component] == component }&.last[:markers]
+            text_alignment = component.description_text_alignment
           %>
           <% if title.present? %>
             <div class="margin-bottom-2 font-sans-lg text-bold margin-top-9">
@@ -235,20 +235,39 @@
             </div>
           <% end %>
 
-          <div class="margin-bottom-1 page-map-component">
-            <%= render partial: "page/page_map",
-                       locals: {
-                         facility_markers: map_component_markers,
-                         component: component,
-                         component_id: component.page_component.id }
+          <div class="grid-row">
+            <% map_cols = if description&.blank?
+                            'grid-col-12'
+                          elsif text_alignment == 'Left'
+                            'grid-col-12 desktop:grid-col-9 order-2 padding-left-2'
+                          elsif text_alignment == 'Right'
+                            'grid-col-12 desktop:grid-col-9 padding-right-2'
+                          else
+                            'grid-col-12'
+                          end
             %>
-          </div>
-
-          <% if description.present? %>
-            <div class="margin-top-2 grid-row <%= page_narrow_classes %> <%= next_component != nil && next_component.component_type == 'margin-bottom-9 ' %> font-sans-sm line-height-162<%= ' margin-bottom-9' if last_component === index %>">
-              <%= content_tag(:span, description, class: 'margin-right-1') %>
+            <div class="margin-bottom-1 page-map-component <%= map_cols %>">
+              <%= render partial: "page/page_map",
+                        locals: {
+                          facility_markers: map_component_markers,
+                          component: component,
+                          component_id: component.page_component.id }
+              %>
             </div>
-          <% end %>
+
+            <% if description&.present? %>
+            <% description_cols = if text_alignment == 'Left' || text_alignment == 'Right'
+                                    'grid-col-12 desktop:grid-col-3'
+                                  else
+                                    'grid-col-12'
+                                  end
+            %>
+              <div class="margin-top-2 <%= description_cols %> <%= page_narrow_classes %> font-sans-sm line-height-162<%= ' margin-bottom-9' if last_component === index %>">
+                <%= content_tag(:span, description, class: 'margin-right-1') %>
+              </div>
+            <% end %>
+          <div>
+
         <%# Text and Images %>
         <% when 'PageCompoundBodyComponent' %>
           <div

--- a/db/migrate/20230609232224_add_text_alignment_to_page_map_component.rb
+++ b/db/migrate/20230609232224_add_text_alignment_to_page_map_component.rb
@@ -1,0 +1,5 @@
+class AddTextAlignmentToPageMapComponent < ActiveRecord::Migration[6.0]
+  def change
+    add_column :page_map_components, :description_text_alignment, :string
+  end
+end

--- a/db/migrate/20230612222945_change_page_map_component_description.rb
+++ b/db/migrate/20230612222945_change_page_map_component_description.rb
@@ -1,0 +1,5 @@
+class ChangePageMapComponentDescription < ActiveRecord::Migration[6.0]
+  def change
+    change_column :page_map_components, :description, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_05_25_214628) do
+ActiveRecord::Schema.define(version: 2023_06_09_232224) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -665,6 +665,7 @@ ActiveRecord::Schema.define(version: 2023_05_25_214628) do
     t.boolean "display_unsuccessful_adoptions", default: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "description_text_alignment"
     t.index ["page_component_id"], name: "index_page_map_components_on_page_component_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_06_09_232224) do
+ActiveRecord::Schema.define(version: 2023_06_12_222945) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -658,7 +658,7 @@ ActiveRecord::Schema.define(version: 2023_06_09_232224) do
     t.bigint "page_component_id"
     t.string "title"
     t.string "map_info_window_text"
-    t.string "description"
+    t.text "description"
     t.string "practices", default: [], array: true
     t.boolean "display_successful_adoptions", default: false
     t.boolean "display_in_progress_adoptions", default: false


### PR DESCRIPTION
### JIRA issue link
[DM-3937](https://agile6.atlassian.net/browse/DM-3937?atlOrigin=eyJpIjoiMTRiNTBlNjVjMmY2NDA0ZDg0YmU3ZjJiYzFmNGI2MWIiLCJwIjoiaiJ9)

## Description - what does this code do?
- Adds a text alignment field to PageBuilder Map Component
-  Converts description field to a WYSIWYG textarea so editors can add a link

## Testing done - how did you test it/steps on how can another person can test it 
1. Sign in as an admin user
2. Create a page group and test page
3. Add three Map components. 
4. Add titles and descriptions to each component.
5. Add a link to an external site to the description of one component. 
6. Add a link to an internal site (i.e. `/about`) to the description of one component
7. Select a different text alignment for each component description 
8. Save the page and confirm styling 

## Screenshots, Gifs, Videos from application (if applicable)
![Screenshot 2023-06-09 at 5 38 59 PM](https://github.com/department-of-veterans-affairs/diffusion-marketplace/assets/5402927/f1508c91-cccf-4f6e-8dfe-cfb2f7bd4b85)


## Link to mock-ups/mock ups (image file if you have it) (if applicable)
https://www.figma.com/file/ccwLbt94U9QGfnuFCwOXzY/Core-Designs---VA-DM?type=design&node-id=6181%3A38719&t=482uC53bBlMy2B7F-1

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Unit tests written (if applicable)
- [ ] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating JIRA issue
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs