### PR TITLE
DM-4006: Move news component body above publish date / authors

### DIFF
--- a/app/views/page/_news_items_list.html.erb
+++ b/app/views/page/_news_items_list.html.erb
@@ -2,11 +2,12 @@
     <li class="page-news-component usa-card tablet:grid-col-6">
         <div class="usa-card__container">
             <div class="usa-card__header">
-                <h3 class="margin-bottom-2 news-item-title">
+                <h3 class="news-item-title">
                     <%= link_to_if(news_item.title.present? && news_item.url.present?, news_item.title, news_item.url, class: set_link_classes(news_item.url), target: get_link_target_attribute(news_item.url)) %>
                 </h3>
             </div>
             <div id="<%= news_item.id %>" class="news-item-description usa-prose usa-card__body">
+                <p><%= news_item&.text&.html_safe %></p>
                 <% if news_item.published_date.present? && news_item.authors.present? %>
                     <p>Published on <%= news_item&.published_date&.strftime("%B %e, %Y") %> by <%= news_item&.authors %></p>
                 <% elsif news_item.published_date.present? %>
@@ -14,7 +15,6 @@
                 <% elsif news_item.authors.present? %>
                     <p>Published by <%= news_item&.authors %></p>
                 <% end %>
-                <p><%= news_item&.text&.html_safe %></p>
             </div>
         </div>
     </li>


### PR DESCRIPTION
### JIRA issue link

https://agile6.atlassian.net/browse/DM-4006

## Description - what does this code do?

Moves news component's body to above published date / authored by

## Testing done - how did you test it/steps on how can another person can test it 

1. Create page with news component
2. add body and published date
3. view the page and verify body is above published date

## Screenshots, Gifs, Videos from application (if applicable)

<img width="1422" alt="Screenshot 2023-06-13 at 3 06 09 PM" src="https://github.com/department-of-veterans-affairs/diffusion-marketplace/assets/65036872/13e21a3b-3ae1-4789-8e1c-79fd16eb2209">

## Link to mock-ups/mock ups (image file if you have it) (if applicable)

https://www.figma.com/file/ccwLbt94U9QGfnuFCwOXzY/Core-Designs---VA-DM?type=design&node-id=6181-38873&t=odXdjQxK4fxa7YeN-0

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Unit tests written (if applicable)
- [ ] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating JIRA issue
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs