### PR TITLE
Force rails-assets-normalize-css to load from railsassets.org

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -126,6 +126,7 @@ source 'https://rails-assets.org' do
   gem 'rails-assets-jquery'
   gem 'rails-assets-sticky'
   gem 'rails-assets-jquery.scrollTo'
+  gem 'rails-assets-normalize-css' # force dependency for uswds-rails to load from rails-assets
 end
 gem "nested_form"
 gem 'colorize'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -48,6 +48,7 @@ GEM
     rails-assets-jquery (3.6.0)
     rails-assets-jquery.scrollTo (2.1.2)
       rails-assets-jquery (>= 1.8)
+    rails-assets-normalize-css (3.0.3)
     rails-assets-sticky (1.0.4)
       rails-assets-jquery
 
@@ -595,7 +596,6 @@ GEM
       bundler (>= 1.3.0)
       railties (= 6.0.5.1)
       sprockets-rails (>= 2.0.0)
-    rails-assets-normalize-css (3.0.3)
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
@@ -842,6 +842,7 @@ DEPENDENCIES
   rails (~> 6.0.5)
   rails-assets-jquery!
   rails-assets-jquery.scrollTo!
+  rails-assets-normalize-css!
   rails-assets-sticky!
   rails-erd
   rails-timeago


### PR DESCRIPTION
## Description - what does this code do?
- Continues work from #602, where we addressed a deprecation warning in the Gemfile. We are now explicitly declaring any dependencies that are not loaded from rubygems.org. Previously, the application would look for dependencies in rails-assets.org if they were not found on rubygems. 
- addresses error from deployment:
```
Your bundle is locked to rails-assets-normalize-css (3.0.3) from rubygems
repository https://rubygems.org/ or installed locally, but that version can no
longer be found in that source. That means the author of
rails-assets-normalize-css (3.0.3) has removed it. You'll need to update your
bundle to a version other than rails-assets-normalize-css (3.0.3) that hasn't
been removed in order to install.
```
- `rails-assets-normalize-css` is an dependency of a dependency (`uswds-rails`) that was implicitly being loaded from rails-assets.org. In the Gemfile we are explicitly telling bundler to rails-assets.org. We could also fix this in the upstream gem fork [agilesix/uswds-rails](https://github.com/agilesix/uswds-rails), but we'll be moving away from this fork soon anyway.

## Testing done - how did you test it/steps on how can another person can test it 
- deployed this branch to STG and the app built successfully. Styling and JS interactions are as expected.