### PR TITLE
Component alignment cleanup

### DIFF
--- a/app/views/active_admin/resource/_page_header3_component_form.html.arb
+++ b/app/views/active_admin/resource/_page_header3_component_form.html.arb
@@ -30,11 +30,9 @@ html = Arbre::Context.new do
                    id: "page_page_components_attributes_#{placeholder}_component_attributes_alignment",
                    name: "page[page_components_attributes][#{placeholder}][component_attributes][alignment]" do
               option 'Left'
-              %w(Center Right).each do |h|
-                option h, value: h, selected: component&.alignment == h
-              end
+              option 'Center', value: 'Center', selected: component&.alignment == 'Center'
             end
-            para 'Choose an alignment for this H3 component: Left, Center, or Right.', class: 'inline-hints'
+            para 'Choose an alignment for this H3 component: Left or Center', class: 'inline-hints'
           end
 
           li class: 'string input optional stringish', id: "page_page_components_attributes_#{placeholder}_component_attributes_url_input" do

--- a/app/views/page/show.html.erb
+++ b/app/views/page/show.html.erb
@@ -50,7 +50,7 @@
               </h3>
               <% if component.description.present? %>
                 <div class="grid-col-12 <%= 'desktop:grid-col-8' unless @page.narrow? %> margin-top-2 line-height-26">
-                  <%= component.description %>
+                  <%= component.description.html_safe %>
                 </div>
               <% end %>
             </div>

--- a/app/views/page/show.html.erb
+++ b/app/views/page/show.html.erb
@@ -49,7 +49,7 @@
                 <%= link_to_unless component.url.blank?, component.title, component.url, target: get_link_target_attribute(component.url), class: set_link_classes(component.url) %>
               </h3>
               <% if component.description.present? %>
-                <div class="grid-col-12 <%= 'desktop:grid-col-8' unless @page.narrow? %> margin-top-2 line-height-26">
+                <div class="grid-col-12 margin-top-2 line-height-26 text-<%= component.alignment.downcase unless @page.narrow? %>">
                   <%= component.description.html_safe %>
                 </div>
               <% end %>

--- a/app/views/page/show.html.erb
+++ b/app/views/page/show.html.erb
@@ -316,10 +316,12 @@
 
         <%# Text and Images %>
         <% when 'PageCompoundBodyComponent' %>
+        <div class="grid-container">
           <div
             class="page-compound-body-component <%= last_component === index ? 'margin-bottom-0 padding-bottom-0' : "padding-bottom-#{component.padding_bottom}" %> <%= "padding-top-#{component.padding_top}" %><%= page_narrow_classes %>">
             <%= render partial: 'compound_body_component', locals: { component: component } %>
           </div>
+        </div>
         <% end %>
       <% end %>
     </div>


### PR DESCRIPTION
### JIRA issue link


## Description - what does this code do?
- Removes the 'Right' text alignment option for Header 3 components, per designer request
  - aligns the Header 3 description to the component
-  adds the Text and Images component to a `grid-containers`

## Testing done - how did you test it/steps on how can another person can test it 
1. Log in as an admin
1. create a new page group and page.
1. Add a Heading 3 component  with text alignment: center
1. Add a Text and Images component
1. Confirm that:
  - heading 3 description is aligned with title
  - all text and images component content has appropriate whitespace

## Screenshots, Gifs, Videos from application (if applicable)

### Before
![Screenshot 2023-06-30 at 3 18 03 PM](https://github.com/department-of-veterans-affairs/diffusion-marketplace/assets/5402927/d8881858-0a23-4f9e-a238-044994fec19b)

### After
![Screenshot 2023-06-30 at 3 17 50 PM](https://github.com/department-of-veterans-affairs/diffusion-marketplace/assets/5402927/1118184b-3544-4f8f-9fd0-714d98834567)


## Link to mock-ups/mock ups (image file if you have it) (if applicable)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Unit tests written (if applicable)
- [ ] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating JIRA issue
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs