### PR TITLE
moves news component titlte under pic

### DIFF
--- a/app/views/page/_news_items_list.html.erb
+++ b/app/views/page/_news_items_list.html.erb
@@ -1,11 +1,6 @@
 <% news_items.each do |news_item| %>
     <li class="page-news-component usa-card tablet:grid-col-6">
         <div class="usa-card__container">
-            <div class="usa-card__header">
-                <h3 class="news-item-title">
-                    <%= link_to_if(news_item.title.present? && news_item.url.present?, news_item.title, news_item.url, class: set_link_classes(news_item.url), target: get_link_target_attribute(news_item.url)) %>
-                </h3>
-            </div>
             <% if news_item.image.present? %>
                 <div class="usa-card__media--inset">
                     <div class="dm-news-img-container">
@@ -16,6 +11,11 @@
                     </div>
                 </div>
             <% end %>
+            <div class="usa-card__header">
+                <h3 class="news-item-title">
+                    <%= link_to_if(news_item.title.present? && news_item.url.present?, news_item.title, news_item.url, class: set_link_classes(news_item.url), target: get_link_target_attribute(news_item.url)) %>
+                </h3>
+            </div>
             <div id="<%= news_item.id %>" class="news-item-description usa-prose usa-card__body">
                 <% if news_item.published_date.present? && news_item.authors.present? %>
                     <p>Published on <%= news_item&.published_date&.strftime("%B %e, %Y") %> by <%= news_item&.authors %></p>


### PR DESCRIPTION
### JIRA issue link
https://agile6.atlassian.net/browse/DM-3941

## Description - what does this code do?
swaps position of news pb component's title with it's image

## Testing done - how did you test it/steps on how can another person can test it 
1. create page w/ news component w/ image and title
2. verify the component renders with the title below the image

## Screenshots, Gifs, Videos 
![Screenshot 2023-07-13 at 5 20 14 PM](https://github.com/department-of-veterans-affairs/diffusion-marketplace/assets/65036872/e052b5a5-1ed1-4f7f-a23c-e94ec7bd1748)
from application (if applicable)


## Link to mock-ups/mock ups (image file if you have it) (if applicable)
https://www.figma.com/file/ccwLbt94U9QGfnuFCwOXzY/Core-Designs---VA-DM?type=design&node-id=6181-38719&mode=design&t=gDybDrtTPEizDN3C-0

## Acceptance criteria
- [ ]

## Definition of done
- [x] Unit tests written (if applicable)
- [ ] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating JIRA issue
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs