### PR TITLE
DM-3948: Bold and decrease margin on PageBuilder 2:1 component

### DIFF
--- a/app/views/page/_two_to_one_image_component.html.erb
+++ b/app/views/page/_two_to_one_image_component.html.erb
@@ -9,7 +9,7 @@
       <a href="<%= component.url %>"
           target="<%= get_link_target_attribute(component.url) %>"
           title="Go to <%= component.url %>"
-          class="<%= set_link_classes(component.url) %> display-inline-block margin-top-3">
+          class="<%= set_link_classes(component.url) %> display-inline-block text-bold">
         <%= component.url_link_text %>
       </a>
     <% end %>

--- a/app/views/page/_two_to_one_image_component.html.erb
+++ b/app/views/page/_two_to_one_image_component.html.erb
@@ -18,6 +18,6 @@
     <% end %>
   </div>
   <div class="grid-item-image <%= component.flipped_ratio? ? 'tablet:grid-col-4' : 'tablet:grid-col-8' %> display-flex flex-align-center">
-    <img class="usa-img width-full height-auto margin-y-auto maxh-mobile-lg"" src="<%= component.image_s3_presigned_url %>" alt="<%= component.image_alt_text %>"/>
+    <img class="usa-img width-full height-auto margin-y-auto maxh-mobile-lg" src="<%= component.image_s3_presigned_url %>" alt="<%= component.image_alt_text %>"/>
   </div>
 </div>


### PR DESCRIPTION
### JIRA issue link
Small follow up to #629 
[DM-3948](https://agile6.atlassian.net/browse/DM-3948)

## Description - what does this code do?
- Bolds URL text and adds bottom margin to bring it closer to Figma design

## Screenshots, Gifs, Videos from application (if applicable)
### Before
<img width="994" alt="Screenshot 2023-07-19 at 5 18 57 PM" src="https://github.com/department-of-veterans-affairs/diffusion-marketplace/assets/5402927/7a53f880-e821-4e44-abb3-30c7c0e6a4a5">

### After
<img width="992" alt="Screenshot 2023-07-19 at 5 18 37 PM" src="https://github.com/department-of-veterans-affairs/diffusion-marketplace/assets/5402927/48613bf0-0656-4ee7-8b7b-a340a0e3b271">


## Link to mock-ups/mock ups (image file if you have it) (if applicable)
https://www.figma.com/file/ccwLbt94U9QGfnuFCwOXzY/Core-Designs---VA-DM?type=design&node-id=6181%3A38719&mode=design&t=ukbYyhEVY0aVzsHN-1
