### PR TITLE
Align PageBuilder 2:1 Image to Text component towards top of container

### DIFF
--- a/app/views/page/_two_to_one_image_component.html.erb
+++ b/app/views/page/_two_to_one_image_component.html.erb
@@ -18,6 +18,6 @@
     <% end %>
   </div>
   <div class="grid-item-image <%= component.flipped_ratio? ? 'tablet:grid-col-4' : 'tablet:grid-col-8' %> display-flex flex-align-center">
-    <img class="usa-img width-full height-auto margin-y-auto maxh-mobile-lg"" src="<%= component.image_s3_presigned_url %>" alt="<%= component.image_alt_text %>"/>
+    <img class="usa-img width-full height-auto maxh-mobile-lg flex-align-self-start"" src="<%= component.image_s3_presigned_url %>" alt="<%= component.image_alt_text %>"/>
   </div>
 </div>


### PR DESCRIPTION
### JIRA issue link
Small follow up to #629 
[DM-3948](https://agile6.atlassian.net/browse/DM-3948)

## Description - what does this code do?
- Updates 2:1 Image to Text component to align images with the top of the component container

## Screenshots, Gifs, Videos from application (if applicable)
### Before
<img width="360" alt="Screenshot 2023-07-19 at 7 32 11 PM" src="https://github.com/department-of-veterans-affairs/diffusion-marketplace/assets/5402927/cbed9fee-80b9-4afb-9f71-e0e646e7e7b3">

### After
<img width="399" alt="Screenshot 2023-07-19 at 7 32 16 PM" src="https://github.com/department-of-veterans-affairs/diffusion-marketplace/assets/5402927/c5cba43d-7a93-443e-9ddd-8b4be52a1c7e">

## Link to mock-ups/mock ups (image file if you have it) (if applicable)
https://www.figma.com/file/ccwLbt94U9QGfnuFCwOXzY/Core-Designs---VA-DM?type=design&node-id=6181%3A39179&mode=design&t=HjmE44OB3I9RHEoM-1