### PR TITLE
Dm 4056 create one to one pb component

### DIFF
--- a/app/admin/pages.rb
+++ b/app/admin/pages.rb
@@ -144,7 +144,8 @@ ActiveAdmin.register Page do
                 pc.component_type == 'PageMapComponent' ||
                 pc.component_type == 'PagePublicationComponent' ||
                 pc.component_type == 'PageCompoundBodyComponent' ||
-                pc.component_type == 'PageTwoToOneImageComponent') && component&.title.present?
+                pc.component_type == 'PageTwoToOneImageComponent' ||
+                pc.component_type == 'PageOneToOneImageComponent') && component&.title.present?
               para "Title: #{component.title}"
             end
             # Large title
@@ -161,7 +162,8 @@ ActiveAdmin.register Page do
                 pc.component_type == 'PageParagraphComponent' ||
                 pc.component_type == 'PageCompoundBodyComponent' ||
                 pc.component_type == 'PageBlockQuoteComponent' ||
-                pc.component_type == 'PageTwoToOneImageComponent') && component&.text.present?
+                pc.component_type == 'PageTwoToOneImageComponent' ||
+                pc.component_type == 'PageOneToOneImageComponent') && component&.text.present?
               para component.text.html_safe
             end
 
@@ -185,7 +187,8 @@ ActiveAdmin.register Page do
             end
             # Text alignment
             if (pc.component_type == 'PageCompoundBodyComponent' || 
-                pc.component_type == 'PageTwoToOneImageComponent')
+                pc.component_type == 'PageTwoToOneImageComponent' ||
+                pc.component_type == 'PageOneToOneImageComponent')
               para "Text alignment: #{component&.text_alignment}"
             end
             # Practice list count
@@ -198,7 +201,8 @@ ActiveAdmin.register Page do
                 pc.component_type == 'PageYouTubePlayerComponent' ||
                 pc.component_type == 'PageSimpleButtonComponent' ||
                 pc.component_type == 'PageCompoundBodyComponent' ||
-                pc.component_type == 'PageTwoToOneImageComponent') && component&.url.present?
+                pc.component_type == 'PageTwoToOneImageComponent' ||
+                pc.component_type == 'PageOneToOneImageComponent') && component&.url.present?
               para "URL: #{component.url}"
             end
             # URL link text
@@ -208,7 +212,8 @@ ActiveAdmin.register Page do
             # Alt text
             if pc.component_type == 'PageImageComponent'
               para "Image Alt Text: #{component&.alt_text}"
-            elsif pc.component_type == 'PageTwoToOneImageComponent'
+            elsif (pc.component_type == 'PageTwoToOneImageComponent' ||
+                   pc.component_type == 'PageOneToOneImageComponent')
               para "Image Alt Text: #{component&.image_alt_text}"
             end
             # Attachment file name

--- a/app/admin/pages.rb
+++ b/app/admin/pages.rb
@@ -206,7 +206,11 @@ ActiveAdmin.register Page do
               para "URL: #{component.url}"
             end
             # URL link text
-            para "URL link text: #{component&.url_link_text}" if pc.component_type == 'PageCompoundBodyComponent' && component&.url_link_text.present?
+            if (pc.component_type == 'PageCompoundBodyComponent' ||
+                pc.component_type == 'PageTwoToOneImageComponent' ||
+                pc.component_type == 'PageOneToOneImageComponent') && component&.url_link_text.present?
+              para "URL link text: #{component&.url_link_text}"
+            end
             # Caption
             para component&.caption if pc.component_type == 'PageYouTubePlayerComponent'
             # Alt text

--- a/app/assets/javascripts/active_admin.js
+++ b/app/assets/javascripts/active_admin.js
@@ -22,6 +22,7 @@ const pageComponentNames = [
     'PageImageComponent',
     'PageMapComponent',
     'PageNewsComponent',
+    'PageOneToOneImageComponent',
     'PageParagraphComponent',
     'PagePublicationComponent',
     'PagePracticeListComponent',
@@ -186,7 +187,8 @@ const pageComponentNames = [
                 componentType === 'PageParagraphComponent' || 
                 componentType === 'PageTripleParagraphComponent' || 
                 componentType === 'PageBlockQuoteComponent' || 
-                componentType === 'PageTwoToOneImageComponent'
+                componentType === 'PageTwoToOneImageComponent' ||
+                componentType === 'PageOneToOneImageComponent'
             ) {
                 _initTinyMCE(componentTextareaId);
             }
@@ -200,7 +202,8 @@ const pageComponentNames = [
                                        'PageParagraphComponent', 
                                        'PageTripleParagraphComponent', 
                                        'PageBlockQuoteComponent',
-                                       'PageTwoToOneImageComponent'];
+                                       'PageTwoToOneImageComponent',
+                                       'PageOneToOneImageComponent'];
             var componentType = $(e.target).closest('ol').find('.polyselect').val();
 
             if (wysiwygComponents.includes(componentType)) {

--- a/app/models/concerns/text_and_image_component.rb
+++ b/app/models/concerns/text_and_image_component.rb
@@ -1,0 +1,27 @@
+module TextAndImageComponent
+  extend ActiveSupport::Concern
+
+  included do
+    has_attached_file :image
+
+    validates :text_alignment, allow_blank: true, inclusion: {
+      in: %w[Left Right],
+      message: "%{value} is not a valid text alignment"
+    }
+
+    validates_with InternalUrlValidator,
+                   on: [:create, :update],
+                   if: Proc.new { |component| component.url.present? && component.url.chars.first === '/' }
+    validates_with ExternalUrlValidator,
+                   on: [:create, :update],
+                   if: Proc.new { |component| component.url.present? && component.url.chars.first != '/' }
+
+    validates :image, presence: true
+    validates :image_alt_text, presence: true, if: -> { image.present? }
+    validates_attachment_content_type :image, :content_type => ["image/jpg", "image/jpeg", "image/png"], if: -> { image.present? }
+
+    def image_s3_presigned_url(style = nil)
+      object_presigned_url(image, style)
+    end
+  end
+end

--- a/app/models/page_component.rb
+++ b/app/models/page_component.rb
@@ -37,6 +37,7 @@ class PageComponent < ApplicationRecord
       'Text and Images': 'PageCompoundBodyComponent',
       'Triple Body Text': 'PageTripleParagraphComponent',
       'Block Quote': 'PageBlockQuoteComponent',
+      '1:1 Image to Text': 'PageOneToOneImageComponent',
       '2:1 Image to Text': 'PageTwoToOneImageComponent'
   }
 

--- a/app/models/page_one_to_one_image_component.rb
+++ b/app/models/page_one_to_one_image_component.rb
@@ -1,0 +1,3 @@
+class PageOneToOneImageComponent < ApplicationRecord
+  include TextAndImageComponent
+end

--- a/app/models/page_two_to_one_image_component.rb
+++ b/app/models/page_two_to_one_image_component.rb
@@ -1,23 +1,3 @@
 class PageTwoToOneImageComponent < ApplicationRecord
-  has_attached_file :image
-
-  validates :text_alignment, allow_blank: true, inclusion: {
-    in: %w[Left Right],
-    message: "%{value} is not a valid text alignment"
-  }
-
-  validates_with InternalUrlValidator,
-                 on: [:create, :update],
-                 if: Proc.new { |component| component.url.present? && component.url.chars.first === '/' }
-  validates_with ExternalUrlValidator,
-                 on: [:create, :update],
-                 if: Proc.new { |component| component.url.present? && component.url.chars.first != '/' }
-
-  validates :image, presence: true
-  validates :image_alt_text, presence: true, if: -> { image.present? }
-  validates_attachment_content_type :image, :content_type => ["image/jpg", "image/jpeg", "image/png"], if: -> { image.present? }
-
-  def image_s3_presigned_url(style = nil)
-    object_presigned_url(image, style)
-  end
+  include TextAndImageComponent
 end

--- a/app/views/active_admin/resource/_page_components_form.html.arb
+++ b/app/views/active_admin/resource/_page_components_form.html.arb
@@ -21,7 +21,7 @@ f.has_many page_components, heading: nil, sortable: :position, sortable_start: 1
   pc.template.concat(render partial: 'page_cta_component_form', locals: {component: component.class == PageCtaComponent ? component : nil, placeholder: placeholder})
   pc.template.concat(render partial: 'page_map_component_form', locals: {component: component.class == PageMapComponent ? component : nil, placeholder: placeholder})
   pc.template.concat(render partial: 'page_block_quote_component_form', locals: {component: component.class == PageBlockQuoteComponent ? component : nil, placeholder: placeholder})
-  pc.template.concat(render partial: 'page_one_to_one_image_component_form', locals: {component: component.class == PageTwoToOneImageComponent ? component : nil, placeholder: placeholder})
+  pc.template.concat(render partial: 'page_one_to_one_image_component_form', locals: {component: component.class == PageOneToOneImageComponent ? component : nil, placeholder: placeholder})
   pc.template.concat(render partial: 'page_two_to_one_image_component_form', locals: {component: component.class == PageTwoToOneImageComponent ? component : nil, placeholder: placeholder})
   pc.template.concat(
     render partial: 'page_compound_body_component_form',

--- a/app/views/active_admin/resource/_page_components_form.html.arb
+++ b/app/views/active_admin/resource/_page_components_form.html.arb
@@ -21,6 +21,7 @@ f.has_many page_components, heading: nil, sortable: :position, sortable_start: 1
   pc.template.concat(render partial: 'page_cta_component_form', locals: {component: component.class == PageCtaComponent ? component : nil, placeholder: placeholder})
   pc.template.concat(render partial: 'page_map_component_form', locals: {component: component.class == PageMapComponent ? component : nil, placeholder: placeholder})
   pc.template.concat(render partial: 'page_block_quote_component_form', locals: {component: component.class == PageBlockQuoteComponent ? component : nil, placeholder: placeholder})
+  pc.template.concat(render partial: 'page_one_to_one_image_component_form', locals: {component: component.class == PageTwoToOneImageComponent ? component : nil, placeholder: placeholder})
   pc.template.concat(render partial: 'page_two_to_one_image_component_form', locals: {component: component.class == PageTwoToOneImageComponent ? component : nil, placeholder: placeholder})
   pc.template.concat(
     render partial: 'page_compound_body_component_form',

--- a/app/views/active_admin/resource/_page_one_to_one_image_component_form.html.arb
+++ b/app/views/active_admin/resource/_page_one_to_one_image_component_form.html.arb
@@ -1,0 +1,104 @@
+# TODO: get the placeholder how active admin does "NEW_#{association_human_name.upcase.split(' ').join('_')}_RECORD"
+placeholder ||= 'NEW_PAGE_COMPONENT_RECORD'
+component ||= nil
+
+html = Arbre::Context.new do
+  li "", id: "PageOneToOneImageComponent_poly_#{placeholder}", class: "input polyform component-#{placeholder}" do
+    fieldset class: "inputs" do
+      legend do
+        span '1:1 Image to Text'
+      end
+
+      if component
+        input type: 'hidden', value: component.id, name: "page[page_components_attributes][#{placeholder}][component_attributes][id]"
+      end
+
+      ol do
+        li class: 'string input optional stringish title-container', id: "page_page_components_attributes_#{placeholder}_component_attributes_title_input" do
+          label 'Title', for: "page_page_components_attributes_#{placeholder}_component_attributes_title", class: 'label'
+
+          input value: component&.title || nil,
+            id: "page_page_components_attributes_#{placeholder}_component_attributes_title",
+            name: "page[page_components_attributes][#{placeholder}][component_attributes][title]",
+            type: 'text'
+          para 'Title', class: 'inline-hints'
+        end
+
+        li class: 'string input optional stringish url-container', id: "page_page_components_attributes_#{placeholder}_component_attributes_url_input" do
+          label 'URL', for: "page_page_components_attributes_#{placeholder}_component_attributes_url", class: 'label'
+          input value: component&.url || nil, type: 'text',
+            id: "page_page_components_attributes_#{placeholder}_component_attributes_url",
+            name: "page[page_components_attributes][#{placeholder}][component_attributes][url]"
+          para class: 'inline-hints' do
+            span 'For external URLs, enter a complete URL (Ex: "https://www.va.gov", "https://google.com").'
+            span 'For internal URLs, simply enter a suffix to any internal page of the marketplace (Ex: "/innovations/vione", "/partners", "/covid-19/telehealth").'
+          end
+        end
+
+        li class: 'string input optional stringish url-link-text-container',
+          id: "page_page_components_attributes_#{placeholder}_component_attributes_url_link_text_input" do
+          label 'URL link text', for: "page_page_components_attributes_#{placeholder}_component_attributes_url_link_text", class: 'label'
+          input value: component&.url_link_text || nil, type: 'text',
+            id: "page_page_components_attributes_#{placeholder}_component_attributes_url_link_text",
+            name: "page[page_components_attributes][#{placeholder}][component_attributes][url_link_text]"
+          para 'Enter the text that will displayed for the link to the URL above', class: 'inline-hints'
+        end
+
+        li class: 'string input optional stringish text-container', id: "page_page_components_attributes_#{placeholder}_component_attributes_text_input" do
+          label 'Text', for: "page_page_components_attributes_one_to_one_image_#{placeholder}_component_attributes_text", class: 'label'
+
+          textarea component&.text || nil,
+            id: "page_page_components_attributes_one_to_one_image_#{placeholder}_component_attributes_text",
+            name: "page[page_components_attributes][#{placeholder}][component_attributes][text]",
+            class: 'tinymce two-to-one-image-component-text',
+            rows:'18' do
+              component&.send(:text).try :html_safe
+            end
+          para 'Text Body', class: 'inline-hints'
+        end
+
+        li class: 'select input required text-alignment-container', id: "page_page_components_attributes_#{placeholder}_component_attributes_text_alignment_input" do
+          label 'Text alignment', for: "page_page_components_attributes_#{placeholder}_component_attributes_text_alignment", class: 'label'
+          select value: component&.text_alignment || nil,
+            id: "page_page_components_attributes_#{placeholder}_component_attributes_text_alignment",
+            name: "page[page_components_attributes][#{placeholder}][component_attributes][text_alignment]" do
+            option 'Left', selected: component&.text_alignment === 'Left' || component&.text_alignment.blank?
+            option 'Right', selected: component&.text_alignment === 'Right'
+          end
+          para "Choose the text alignment for this '1:1 Image to Text' component (left or right). Defaults to left.",
+            class: 'inline-hints'
+        end
+
+        li class: 'file input required', id: "page_page_components_attributes_#{placeholder}_component_attributes_image_input" do
+          label 'Image', for: "page_page_components_attributes_#{placeholder}_component_attributes_image", class: 'label'
+          input value: component&.image_file_name || nil, type: 'file', required: 'required', accept: '.jpg, .jpeg, .png',
+            id: "page_page_components_attributes_#{placeholder}_component_attributes_image",
+            name: "page[page_components_attributes][#{placeholder}][component_attributes][image]"
+          para 'File types allowed: jpg, png. Max file size: 25MB', class: 'inline-hints'
+        end
+
+        if component&.image.present?
+          li do
+            div class: 'page-image-preview-container no-padding' do
+              div class: 'placeholder'
+              div class: 'page-image-container' do
+                img class: 'page-image', src: component.image_s3_presigned_url, alt: component.image_alt_text
+                para "Current image name: #{component.image_file_name}"
+              end
+            end
+          end
+        end
+
+        li class: 'string input required stringish', id: "page_page_components_attributes_#{placeholder}_component_attributes_image_alt_text_input" do
+          label 'Alternative Text', for: "page_page_components_attributes_#{placeholder}_component_attributes_image_alt_text", class: 'label'
+          input value: component&.image_alt_text || nil, type: 'text', required: 'required',
+            id: "page_page_components_attributes_#{placeholder}_component_attributes_image_alt_text",
+            name: "page[page_components_attributes][#{placeholder}][component_attributes][image_alt_text]"
+          para 'Alternate text that gets rendered in case the image cannot load.', class: 'inline-hints'
+        end
+      end
+    end
+  end
+end
+
+return html.to_s

--- a/app/views/page/_one_to_one_image_component.html.erb
+++ b/app/views/page/_one_to_one_image_component.html.erb
@@ -18,6 +18,6 @@
     <% end %>
   </div>
   <div class="grid-item-image tablet:grid-col-6 display-flex flex-align-center">
-    <img class="usa-img width-full height-auto margin-y-auto maxh-mobile-lg" src="<%= component.image_s3_presigned_url %>" alt="<%= component.image_alt_text %>"/>
+    <img class="usa-img width-full height-auto maxh-mobile-lg flex-align-self-start" src="<%= component.image_s3_presigned_url %>" alt="<%= component.image_alt_text %>"/>
   </div>
 </div>

--- a/app/views/page/_one_to_one_image_component.html.erb
+++ b/app/views/page/_one_to_one_image_component.html.erb
@@ -1,0 +1,23 @@
+<div class="grid-row grid-gap display-flex flex-column flex-row-tablet">
+  <div class="grid-item-text <%= component.text_alignment === "Left" ? 'order-first' : 'order-last' %> tablet:grid-col-6">
+    <% if component.title.present? %>
+      <h3 class="margin-top-0">
+        <%= component.title %>
+      </h3>
+    <% end %>
+    <% if component.url.present? && component.url_link_text.present? %>
+      <a href="<%= component.url %>"
+          target="<%= get_link_target_attribute(component.url) %>"
+          title="Go to <%= component.url %>"
+          class="<%= set_link_classes(component.url) %> display-inline-block text-bold">
+        <%= component.url_link_text %>
+      </a>
+    <% end %>
+    <% if component.text.present? %>
+      <p><%= component.text.html_safe %></p>
+    <% end %>
+  </div>
+  <div class="grid-item-image tablet:grid-col-6 display-flex flex-align-center">
+    <img class="usa-img width-full height-auto margin-y-auto maxh-mobile-lg" src="<%= component.image_s3_presigned_url %>" alt="<%= component.image_alt_text %>"/>
+  </div>
+</div>

--- a/app/views/page/show.html.erb
+++ b/app/views/page/show.html.erb
@@ -401,6 +401,12 @@
           <div class="grid-container margin-bottom-5 <%= ' margin-bottom-0' if last_component === index %>">
             <%= render partial: 'two_to_one_image_component', locals: { component: component } %>
           </div>
+
+        <%# 1:1 Image to Text %>
+        <% when 'PageOneToOneImageComponent' %>
+          <div class="grid-container margin-bottom-5 <%= ' margin-bottom-0' if last_component === index %>">
+            <%= render partial: 'one_to_one_image_component', locals: { component: component } %>
+          </div>
         <% end %>
       <% end %>
     </div>

--- a/db/migrate/20230720184846_create_page_one_to_one_image_component.rb
+++ b/db/migrate/20230720184846_create_page_one_to_one_image_component.rb
@@ -1,0 +1,17 @@
+class CreatePageOneToOneImageComponent < ActiveRecord::Migration[6.0]
+  def change
+    create_table :page_one_to_one_image_components, id: :uuid do |t|
+      t.belongs_to :page_component, foreign_key: true
+      t.string :title
+      t.text :text
+      t.string :url
+      t.string :url_link_text
+      t.string :text_alignment
+      t.text :image_alt_text
+      t.boolean :flipped_ratio, default: false
+      t.timestamps
+    end
+
+    add_attachment :page_one_to_one_image_components, :image
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_07_11_205117) do
+ActiveRecord::Schema.define(version: 2023_07_20_184846) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -692,6 +692,24 @@ ActiveRecord::Schema.define(version: 2023_07_11_205117) do
     t.bigint "image_file_size"
     t.datetime "image_updated_at"
     t.index ["page_component_id"], name: "index_page_news_components_on_page_component_id"
+  end
+
+  create_table "page_one_to_one_image_components", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.bigint "page_component_id"
+    t.string "title"
+    t.text "text"
+    t.string "url"
+    t.string "url_link_text"
+    t.string "text_alignment"
+    t.text "image_alt_text"
+    t.boolean "flipped_ratio", default: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.string "image_file_name"
+    t.string "image_content_type"
+    t.bigint "image_file_size"
+    t.datetime "image_updated_at"
+    t.index ["page_component_id"], name: "index_page_one_to_one_image_components_on_page_component_id"
   end
 
   create_table "page_paragraph_components", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/spec/features/pages/one_to_one_image_spec.rb
+++ b/spec/features/pages/one_to_one_image_spec.rb
@@ -1,0 +1,64 @@
+require 'rails_helper'
+
+describe 'Page Builder - Show - 1:1 Image to Text', type: :feature do
+  before do
+    page_group = PageGroup.create(
+      name: 'programming', 
+      slug: 'programming', 
+      description: 'Pages about programming go in this group.',
+    )
+    page = Page.create(
+      page_group: page_group, 
+      title: 'ruby', description: 'what a gem', 
+      slug: 'ruby-rocks', 
+      has_chrome_warning_banner: true, 
+      created_at: Time.now, 
+      published: Time.now,
+    )
+    image_path = File.join(Rails.root, '/spec/assets/charmander.png')
+    image_file = File.new(image_path)
+    @one_to_one_image_component = PageOneToOneImageComponent.new(
+      text: "THIS IS A CAT",
+      text_alignment: 'Left',
+      title: 'Image and alt text',
+      image: image_file,
+      image_alt_text: "Test Image",
+      url: "https://example.com",
+      url_link_text: "Link Text",
+    )
+    @one_to_one_image_component.save!
+
+    PageComponent.create(page: page, component: @one_to_one_image_component, created_at: Time.now)
+    # must be logged in to view pages
+    login_as(@user, scope: :user, run_callbacks: false)
+  end
+
+  context 'Image and alt text' do
+    it 'image and alt text present' do
+      visit 'programming/ruby-rocks'
+
+      expect(page).to have_css("img[src*='#{@one_to_one_image_component.image_s3_presigned_url}']")
+      expect(page).to have_css("img[alt='Test Image']")
+    end
+  end
+
+  context 'Text alignment' do
+    it 'aligns the text to the left of the image when text_alignment is "Left"' do
+      visit '/programming/ruby-rocks'
+      expect(page).to have_css('.grid-item-text.order-first')
+    end
+
+    it 'aligns the text to the right of the image when text_alignment is "Right"' do
+      @one_to_one_image_component.update!(text_alignment: "Right")
+      visit '/programming/ruby-rocks'
+      expect(page).to have_css('.grid-item-text.order-last')
+    end
+  end
+
+  context 'URL' do
+    it 'displays the component URL' do
+      visit '/programming/ruby-rocks'
+      expect(page).to have_link('Link Text', href: 'https://example.com')
+    end
+  end
+end

--- a/spec/models/page_one_to_one_image_spec.rb
+++ b/spec/models/page_one_to_one_image_spec.rb
@@ -1,0 +1,45 @@
+require 'rails_helper'
+
+RSpec.describe PageOneToOneImageComponent, type: :model do
+  describe 'validations' do
+    subject do
+      image_path = File.join(Rails.root, '/spec/assets/charmander.png')
+      image_file = File.new(image_path)
+      described_class.new(
+        text_alignment: 'Left',
+        image: image_file,
+        image_alt_text: 'Test Image'
+      )
+    end
+
+    it 'validates text alignment' do
+      subject.text_alignment = 'Middle'
+      expect(subject).not_to be_valid
+      expect(subject.errors[:text_alignment]).to include('Middle is not a valid text alignment')
+    end
+
+    it 'validates internal urls' do
+      subject.url = '/internal_url'
+      expect(subject).to be_valid(InternalUrlValidator)
+    end
+
+    it 'validates external urls' do
+      subject.url = 'http://external_url.com'
+      expect(subject).to be_valid(ExternalUrlValidator)
+    end
+
+    it { should validate_presence_of(:image) }
+
+    it 'validates presence of image_alt_text if image is present' do
+      expect(subject).to validate_presence_of(:image_alt_text)
+    end
+
+    it 'validates content type of image' do
+      file_path = File.join(Rails.root, 'spec/assets/SpongeBob.txt')
+      subject.image = File.new(file_path)
+
+      expect(subject).not_to be_valid
+      expect(subject.errors[:image]).to include('is invalid')
+    end
+  end
+end


### PR DESCRIPTION
### JIRA issue link
https://agile6.atlassian.net/browse/DM-4056

## Description - what does this code do?
Adds new 1:1 Image To Text page-builder component

## Testing done - how did you test it/steps on how can another person can test it 
1. Create a group, create a page, add the group to the page
2. Add the new component, include a few sentences worth of text and a url
3. View the page and verify the component renders as seen in the screenshots below
4. Edit the component and set the text alignment to be on the right
5. View the page and verify the component renders with the text to the right of the image.
6. Using dev tools reduce the resolution to mobile view, verify the text changes position to be below the image, above if the text alignment is set to "Right".

## Screenshots, Gifs, Videos from application (if applicable)
![Screenshot 2023-07-20 at 2 58 29 PM](https://github.com/department-of-veterans-affairs/diffusion-marketplace/assets/65036872/ad1f988d-3c0e-4a21-a36a-89d078d45469)

## Link to mock-ups/mock ups (image file if you have it) (if applicable)
https://www.figma.com/file/ccwLbt94U9QGfnuFCwOXzY/Core-Designs---VA-DM?type=design&node-id=6181-38719&mode=design&t=nCtYqPdvAf6SU5cQ-0

## Acceptance criteria
- [ ]

## Definition of done
- [x] Unit tests written (if applicable)
- [ ] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating JIRA issue
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs