### PR TITLE
Move link below body text for 1:1 Image and Text component

### DIFF
--- a/app/views/page/_one_to_one_image_component.html.erb
+++ b/app/views/page/_one_to_one_image_component.html.erb
@@ -5,6 +5,9 @@
         <%= component.title %>
       </h3>
     <% end %>
+    <% if component.text.present? %>
+      <p><%= component.text.html_safe %></p>
+    <% end %>
     <% if component.url.present? && component.url_link_text.present? %>
       <a href="<%= component.url %>"
           target="<%= get_link_target_attribute(component.url) %>"
@@ -12,9 +15,6 @@
           class="<%= set_link_classes(component.url) %> display-inline-block text-bold">
         <%= component.url_link_text %>
       </a>
-    <% end %>
-    <% if component.text.present? %>
-      <p><%= component.text.html_safe %></p>
     <% end %>
   </div>
   <div class="grid-item-image tablet:grid-col-6 display-flex flex-align-center">


### PR DESCRIPTION
### JIRA issue link
Small addition to #635 

## Description - what does this code do?
This moves the link in the 1:1 Image to Text component below the body text

## Screenshots, Gifs, Videos from application (if applicable)
### Before
![Screenshot 2023-07-25 at 12 44 00 PM](https://github.com/department-of-veterans-affairs/diffusion-marketplace/assets/5402927/dbe12382-894d-490b-9ae8-94aefb94eb48)

### After
![Screenshot 2023-07-25 at 12 44 04 PM](https://github.com/department-of-veterans-affairs/diffusion-marketplace/assets/5402927/b7a50af9-b49b-465c-9c30-08034a23c35c)


## Link to mock-ups/mock ups (image file if you have it) (if applicable)
https://www.figma.com/file/ccwLbt94U9QGfnuFCwOXzY/Core-Designs---VA-DM?type=design&node-id=6181%3A38719&mode=design&t=e7q0GZMOMgO0OVnq-1
