### PR TITLE
DM-4044 Swap out XR Network navbar URLs for VA Immersive

### DIFF
--- a/app/assets/javascripts/_header_utilities.es6
+++ b/app/assets/javascripts/_header_utilities.es6
@@ -17,7 +17,7 @@
   function loadHeaderUtilitiesFn() {
     _preventCrisisLineModalFlickerOnPageLoad();
     _preventHeaderElementFlickerOnPageLoad('#browse-by-locations-dropdown')
-    _preventHeaderElementFlickerOnPageLoad('#xr-network-dropdown')
+    _preventHeaderElementFlickerOnPageLoad('#va-immersive-dropdown')
   }
 
   $document.on('turbolinks:load', loadHeaderUtilitiesFn);

--- a/app/assets/stylesheets/dm/pages/_partials/_header.scss
+++ b/app/assets/stylesheets/dm/pages/_partials/_header.scss
@@ -149,7 +149,7 @@
           width: 133px !important;
         }
 
-        &[aria-controls="xr-network-dropdown"] {
+        &[aria-controls="va-immersive-dropdown"] {
           width: 84px !important;
         }
 
@@ -216,7 +216,7 @@
           background-position: right 13% top 50%;
         }
 
-        &[aria-controls="dm-user-profile-options"], &[aria-controls="xr-network-dropdown"] {
+        &[aria-controls="dm-user-profile-options"], &[aria-controls="va-immersive-dropdown"] {
           background-position: right 18% top 50%;
         }
       }
@@ -241,7 +241,7 @@
         right: 1rem;
       }
 
-      &#xr-network-dropdown {
+      &#va-immersive-dropdown {
         left: 38.45rem;
       }
 

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,11 +1,11 @@
 <%= render 'shared/usa_banner' %>
 <%= render 'shared/veterans_crisis_line_modal' %>
 <%
-  xr_home_url = '/communities/xr-network'
-  xr_about_url = '/communities/xr-network/about'
-  xr_events_url = '/communities/xr-network/events'
-  xr_news_url = '/communities/xr-network/news'
-  xr_innovations_url = '/communities/xr-network/innovations'
+  va_immersive_home_url = '/communities/va-immersive'
+  va_immersive_about_url = '/communities/va-immersive/about'
+  va_immersive_events_and_news_url = '/communities/va-immersive/events-and-news'
+  va_immersive_innovations_url = '/communities/va-immersive/innovations'
+  va_immersive_getting_started_url = '/communities/va-immersive/getting-started'
 %>
 <!-- source: https://designsystem.digital.gov/components/header/#extended -->
 <a class="usa-skipnav" href="#main-content">Skip to main content</a>
@@ -80,36 +80,36 @@
         </li>
         <li class="usa-nav__primary-item border-base-light desktop:border-bottom-0">
           <button
-            class="margin-y-2px dm-text-no-underline desktop:margin-y-0 usa-accordion__button usa-nav__link border-base-light <%= 'usa-current' if request.fullpath === xr_home_url || request.fullpath === xr_about_url || request.fullpath === xr_events_url || request.fullpath === xr_news_url || request.fullpath === xr_innovations_url %>"
+            class="margin-y-2px dm-text-no-underline desktop:margin-y-0 usa-accordion__button usa-nav__link border-base-light <%= 'usa-current' if request.fullpath === va_immersive_home_url || request.fullpath === va_immersive_about_url || request.fullpath === va_immersive_events_and_news_url || request.fullpath === va_immersive_innovations_url || request.fullpath === va_immersive_getting_started_url %>"
             aria-expanded="false"
-            aria-controls="xr-network-dropdown"
+            aria-controls="va-immersive-dropdown"
           >
-            <span class="text-normal desktop:text-semibold padding-right-0">XR Network</span>
+            <span class="text-normal desktop:text-semibold padding-right-0">VA Immersive</span>
           </button>
-          <ul id="xr-network-dropdown" class="display-none usa-nav__submenu">
+          <ul id="va-immersive-dropdown" class="display-none usa-nav__submenu">
             <li class="usa-nav__submenu-item border-base-light">
-              <a class="font-sans-sm desktop:font-sans-2xs margin-y-2px desktop:margin-y-0 <%= 'usa-current' if request.fullpath === xr_home_url %>" href="<%= xr_home_url %>">
+              <a class="font-sans-sm desktop:font-sans-2xs margin-y-2px desktop:margin-y-0 <%= 'usa-current' if request.fullpath === va_immersive_home_url %>" href="<%= va_immersive_home_url %>">
                 Community
               </a>
             </li>
             <li class="usa-nav__submenu-item border-base-light">
-              <a class="font-sans-sm desktop:font-sans-2xs margin-y-2px desktop:margin-y-0 <%= 'usa-current' if request.fullpath === xr_about_url %>" href="<%= xr_about_url %>">
+              <a class="font-sans-sm desktop:font-sans-2xs margin-y-2px desktop:margin-y-0 <%= 'usa-current' if request.fullpath === va_immersive_about_url %>" href="<%= va_immersive_about_url %>">
                 About
               </a>
             </li>
             <li class="usa-nav__submenu-item border-base-light">
-              <a class="font-sans-sm desktop:font-sans-2xs margin-y-2px desktop:margin-y-0 <%= 'usa-current' if request.fullpath === xr_events_url %>" href="<%= xr_events_url %>">
-                Events
+              <a class="font-sans-sm desktop:font-sans-2xs margin-y-2px desktop:margin-y-0 <%= 'usa-current' if request.fullpath === va_immersive_events_and_news_url %>" href="<%= va_immersive_events_and_news_url %>">
+                Events and News
               </a>
             </li>
             <li class="usa-nav__submenu-item border-base-light">
-              <a class="font-sans-sm desktop:font-sans-2xs margin-y-2px desktop:margin-y-0 <%= 'usa-current' if request.fullpath === xr_news_url %>" href="<%= xr_news_url %>">
-                News
-              </a>
-            </li>
-            <li class="usa-nav__submenu-item border-base-light">
-              <a class="font-sans-sm desktop:font-sans-2xs margin-y-2px desktop:margin-y-0 <%= 'usa-current' if request.fullpath === xr_innovations_url %>" href="<%= xr_innovations_url %>">
+              <a class="font-sans-sm desktop:font-sans-2xs margin-y-2px desktop:margin-y-0 <%= 'usa-current' if request.fullpath === va_immersive_innovations_url %>" href="<%= va_immersive_innovations_url %>">
                 Innovations
+              </a>
+            </li>
+            <li class="usa-nav__submenu-item border-base-light">
+              <a class="font-sans-sm desktop:font-sans-2xs margin-y-2px desktop:margin-y-0 <%= 'usa-current' if request.fullpath === va_immersive_getting_started_url %>" href="<%= va_immersive_getting_started_url %>">
+                Getting Started
               </a>
             </li>
           </ul>

--- a/spec/features/shared/header_spec.rb
+++ b/spec/features/shared/header_spec.rb
@@ -11,12 +11,12 @@ describe 'Diffusion Marketplace header', type: :feature, js: true do
     page_group = PageGroup.create(name: 'competitions', slug: 'competitions', description: 'competitions page')
     Page.create(page_group: page_group, title: 'Shark Tank', description: 'Shark Tank page', slug: 'shark-tank', has_chrome_warning_banner: true, created_at: Time.now, published: Time.now)
     page_group_2 = PageGroup.create(name: 'covid-19', slug: 'covid-19', description: 'covid-19 page')
-    page_group_3 = PageGroup.create(name: 'xr-network', slug: 'xr-network', description: 'xr-network page')
-    Page.create(page_group: page_group_3, title: 'XR Network', description: 'XR Network page', slug: 'home', has_chrome_warning_banner: true, created_at: Time.now, published: Time.now)
-    Page.create(page_group: page_group_3, title: 'XR Network About', description: 'XR Network about page', slug: 'about', has_chrome_warning_banner: true, created_at: Time.now, published: Time.now)
-    Page.create(page_group: page_group_3, title: 'XR Network Events', description: 'XR Network evetns page', slug: 'events', has_chrome_warning_banner: true, created_at: Time.now, published: Time.now)
-    Page.create(page_group: page_group_3, title: 'XR Network News', description: 'XR Network News page', slug: 'news', has_chrome_warning_banner: true, created_at: Time.now, published: Time.now)
-    Page.create(page_group: page_group_3, title: 'XR Network Innovations', description: 'XR Network innovations page', slug: 'innovations', has_chrome_warning_banner: true, created_at: Time.now, published: Time.now)
+    page_group_3 = PageGroup.create(name: 'va-immersive', slug: 'va-immersive', description: 'va-immersive page')
+    Page.create(page_group: page_group_3, title: 'VA Immersive', description: 'VA Immersive page', slug: 'home', has_chrome_warning_banner: true, created_at: Time.now, published: Time.now)
+    Page.create(page_group: page_group_3, title: 'VA Immersive About', description: 'VA Immersive about page', slug: 'about', has_chrome_warning_banner: true, created_at: Time.now, published: Time.now)
+    Page.create(page_group: page_group_3, title: 'VA Immersive Events and News', description: 'VA Immersive events and news page', slug: 'events-and-news', has_chrome_warning_banner: true, created_at: Time.now, published: Time.now)
+    Page.create(page_group: page_group_3, title: 'VA Immersive Innovations', description: 'VA Immersive innovations page', slug: 'innovations', has_chrome_warning_banner: true, created_at: Time.now, published: Time.now)
+    Page.create(page_group: page_group_3, title: 'VA Immersive Getting Started', description: 'VA Immersive getting started page', slug: 'getting-started', has_chrome_warning_banner: true, created_at: Time.now, published: Time.now)
 
     visit practice_path(@practice)
     # ensure header desktop view
@@ -48,7 +48,7 @@ describe 'Diffusion Marketplace header', type: :feature, js: true do
         expect(page).to have_link(href: '/competitions/shark-tank')
         expect(page).to have_content('Your profile')
         expect(page).to have_content('Browse by locations')
-        expect(page).to have_content('XR Network')
+        expect(page).to have_content('VA Immersive')
       end
     end
 
@@ -67,7 +67,7 @@ describe 'Diffusion Marketplace header', type: :feature, js: true do
         expect(page).to have_content('Shark Tank')
         expect(page).to have_link(href: '/competitions/shark-tank')
         expect(page).to have_content('Browse by locations')
-        expect(page).to have_content('XR Network')
+        expect(page).to have_content('VA Immersive')
         expect(page).to_not have_content('Sign in')
       end
 
@@ -104,42 +104,42 @@ describe 'Diffusion Marketplace header', type: :feature, js: true do
     end
 
     context 'clicking on the Community link' do
-      it 'should redirect to XR-Network index page' do
-        click_on 'XR Network'
+      it 'should redirect to VA Immersive index page' do
+        click_on 'VA Immersive'
         click_on 'Community'
-        expect(page).to have_current_path('/communities/xr-network')
+        expect(page).to have_current_path('/communities/va-immersive')
       end
     end
 
     context 'clicking on the About  link' do
-      it 'should redirect to XR-Network about page' do
-        click_on 'XR Network'
+      it 'should redirect to VA Immersive about page' do
+        click_on 'VA Immersive'
         click_on 'About'
-        expect(page).to have_current_path('/communities/xr-network/about')
+        expect(page).to have_current_path('/communities/va-immersive/about')
       end
     end
 
-    context 'clicking on the Events link' do
-      it 'should redirect to XR-Network events page' do
-        click_on 'XR Network'
+    context 'clicking on the Events and News link' do
+      it 'should redirect to VA Immersive events page' do
+        click_on 'VA Immersive'
         click_on 'Events'
-        expect(page).to have_current_path('/communities/xr-network/events')
-      end
-    end
-
-    context 'clicking on the News link' do
-      it 'should redirect to XR-Network news page' do
-        click_on 'XR Network'
-        click_on 'News'
-        expect(page).to have_current_path('/communities/xr-network/news')
+        expect(page).to have_current_path('/communities/va-immersive/events')
       end
     end
 
     context 'clicking on the Innovations link' do
-      it 'should redirect to XR-Network innovations  page' do
-        click_on 'XR Network'
+      it 'should redirect to VA Immersive innovations  page' do
+        click_on 'VA Immersive'
         click_on 'Innovations'
-        expect(page).to have_current_path('/communities/xr-network/innovations')
+        expect(page).to have_current_path('/communities/va-immersive/innovations')
+      end
+    end
+
+    context 'clicking on the Getting Started link' do
+      it 'should redirect to VA Immersive innovations  page' do
+        click_on 'VA Immersive'
+        click_on 'Getting Started'
+        expect(page).to have_current_path('/communities/va-immersive/getting-started')
       end
     end
 

--- a/spec/features/shared/header_spec.rb
+++ b/spec/features/shared/header_spec.rb
@@ -123,7 +123,7 @@ describe 'Diffusion Marketplace header', type: :feature, js: true do
       it 'should redirect to VA Immersive events page' do
         click_on 'VA Immersive'
         click_on 'Events'
-        expect(page).to have_current_path('/communities/va-immersive/events')
+        expect(page).to have_current_path('/communities/va-immersive/events-and-news')
       end
     end
 

--- a/spec/requests/page_controller_spec.rb
+++ b/spec/requests/page_controller_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe PageController, type: :request do
       # To circumvent this issue, we can just check to make sure that the response header 'Location' includes '/communities'
       expect(response.header['Location']).to include('/communities/va-immersive')
 
-      get '/va-immersive/events'
+      get '/va-immersive/events-and-news'
       expect(response.header['Location']).to include('/communities/va-immersive/events-and-news')
     end
   end

--- a/spec/requests/page_controller_spec.rb
+++ b/spec/requests/page_controller_spec.rb
@@ -3,20 +3,20 @@ require 'rails_helper'
 RSpec.describe PageController, type: :request do
   before do
     page_group = PageGroup.create!(
-      name: 'xr-network',
+      name: 'va-immersive',
       description: 'Pages about programming go in this group.'
     )
     Page.create!(
-      title: 'XR Network Home',
+      title: 'VA Immersive Home',
       description: 'This is a homepage',
       slug: 'home',
       page_group: page_group,
       published: Time.now
     )
     Page.create!(
-      title: 'XR Network Events',
+      title: 'VA Immersive Events nad News',
       description: 'This is an events page',
-      slug: 'events',
+      slug: 'events-and-news',
       page_group: page_group,
       published: Time.now
     )
@@ -25,13 +25,13 @@ RSpec.describe PageController, type: :request do
   context 'show' do
     it "should redirect the user with a prepended '/communities' to the URL if the Page is a community page "\
       "and the URL doesn't include '/communities'" do
-      get '/xr-network'
-      # For some reason on CI, an ID gets appended to the sample domain (e.g. 'http://www.example.com482c087b40dc/communities/xr-network').
+      get '/va-immersive'
+      # For some reason on CI, an ID gets appended to the sample domain (e.g. 'http://www.example.com482c087b40dc/communities/va-immersive').
       # To circumvent this issue, we can just check to make sure that the response header 'Location' includes '/communities'
-      expect(response.header['Location']).to include('/communities/xr-network')
+      expect(response.header['Location']).to include('/communities/va-immersive')
 
-      get '/xr-network/events'
-      expect(response.header['Location']).to include('/communities/xr-network/events')
+      get '/va-immersive/events'
+      expect(response.header['Location']).to include('/communities/va-immersive/events-and-news')
     end
   end
 end


### PR DESCRIPTION
### JIRA issue link
[DM-4044](https://agile6.atlassian.net/browse/DM-4044?atlOrigin=eyJpIjoiN2MwYWE4OTdkMjU0NDNkMDlhNzQzNDA3MjBkMDhjZGUiLCJwIjoiaiJ9)

## Description - what does this code do?
- Swaps "XR Network" for "VA Immersive" pages in navbar dropdown
- Removes "News" and renames "Events" to "Events and News"
- Adds "Getting Started" page to navbar

## Testing done - how did you test it/steps on how can another person can test it 


## Screenshots, Gifs, Videos from application (if applicable)
### Before
<img width="293" alt="Screenshot 2023-07-26 at 4 47 28 PM" src="https://github.com/department-of-veterans-affairs/diffusion-marketplace/assets/5402927/86ac54ad-fc2b-4519-bf79-0706a3ce21d5">

### After
<img width="373" alt="Screenshot 2023-07-26 at 4 47 20 PM" src="https://github.com/department-of-veterans-affairs/diffusion-marketplace/assets/5402927/8de47a99-be8c-4051-aa67-8ab73a132852">

## Definition of done
- [ ] Unit tests written (if applicable)
- [x] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating JIRA issue
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs