### PR TITLE
Remove letter spacing from PageBuilder BlockQuote component

### DIFF
--- a/app/views/page/show.html.erb
+++ b/app/views/page/show.html.erb
@@ -79,10 +79,11 @@
             </div>
           </div>
 
+        <%# Block Quote %>
         <% when 'PageBlockQuoteComponent' %>
           <div class="grid-container">
             <div class="page-block-quote-component margin-bottom-4-important <%= page_narrow_classes %><%= ' margin-bottom-0' if last_component === index %>">
-              <p class="font-body-xl text-medium text-ls-1">
+              <p class="font-body-xl text-medium">
                 "<%= component.text.html_safe %>"
               </p>
               <p class="text-italic font-body-lg">


### PR DESCRIPTION
### JIRA issue link
[DM-4063](https://agile6.atlassian.net/browse/DM-4063?atlOrigin=eyJpIjoiYjQ2OWQ0MjE5ZTc4NDkyOWJlNDE4Y2Q3NDJlY2U5NjAiLCJwIjoiaiJ9)

## Description - what does this code do?
Small visual design tweak. Removes letter spacing from block quote component

## Screenshots, Gifs, Videos from application (if applicable)
### Before
<img width="1018" alt="Screenshot 2023-07-26 at 4 58 23 PM" src="https://github.com/department-of-veterans-affairs/diffusion-marketplace/assets/5402927/f0927efb-aa81-4358-8817-112cb7cd312a">

### After
<img width="1061" alt="Screenshot 2023-07-26 at 4 58 17 PM" src="https://github.com/department-of-veterans-affairs/diffusion-marketplace/assets/5402927/b1b3f2f2-d91d-49fd-b936-a46b2c6e8dab">


## Link to mock-ups/mock ups (image file if you have it) (if applicable)
https://www.figma.com/file/ccwLbt94U9QGfnuFCwOXzY/Core-Designs---VA-DM?type=design&node-id=6181%3A38719&mode=design&t=XAZpl8b9jfdjTvmU-1
