### PR TITLE
DM-4065: Adds SCSS to unset whitespace from USWDS card styling for PageBuilder News and Events

### DIFF
--- a/app/assets/stylesheets/dm/components/page_component.scss
+++ b/app/assets/stylesheets/dm/components/page_component.scss
@@ -2,10 +2,10 @@
   p, li {
     margin-top: 1rem;
     margin-bottom: 1rem;
-    line-height: 1.53;
+    line-height: 1.62;
 
     &.usa-prose-body {
-      line-height: 1.6;
+      line-height: 1.62;
     }
 
     &.ql-align-justify {

--- a/app/assets/stylesheets/dm/components/page_component.scss
+++ b/app/assets/stylesheets/dm/components/page_component.scss
@@ -232,6 +232,11 @@
       &:last-child {
         padding-bottom: 0;
       }
+
+      .event-metadata p {
+        margin-bottom: 0.5rem;
+        margin-top: 0;
+      }
     }
   }
 

--- a/app/assets/stylesheets/dm/components/page_component.scss
+++ b/app/assets/stylesheets/dm/components/page_component.scss
@@ -202,20 +202,39 @@
     }
   }
 
-  .page-event-component {
-    @include u-margin-bottom(2);
+  // disable USWDS USA card styles the affect whitespace
+  .page-event-component, .page-news-component {
+    margin-top: 0;
+    margin-bottom: 0;
+    padding-bottom: 0;
+
     .usa-card__container {
       border: 0;
+      max-width: 395px; // Match card widths in Figma
+    }
+
+    .usa-card__container > div {
+      padding-left: 0;
+      padding-right: 0;
+    }
+
+    .usa-card__media--inset {
+      padding-top: 0;
+      padding-bottom: 1.5rem;
+    }
+
+    .usa-card__header {
+      padding-top: 0;
+    }
+
+    .usa-card__body {
+      padding-bottom: 0;
+      &:last-child {
+        padding-bottom: 0;
+      }
     }
   }
 
-  .page-news-component {
-    @include u-margin-bottom(2);
-
-    .usa-card__container {
-        border: 0;
-      }
-  }
   .publication-component-list {
     .page-publication-component:not(:last-child) {
       @include u-padding-bottom(4);

--- a/app/views/page/_events_list.html.erb
+++ b/app/views/page/_events_list.html.erb
@@ -2,7 +2,7 @@
     <li class="page-event-component usa-card tablet:grid-col-6">
         <div class="usa-card__container">
             <div class="usa-card__header">
-                <h3 class="margin-bottom-2 event-title">
+                <h3 class="event-title">
                     <%= link_to_if(event.title.present? && event.url.present?, event.title, event.url, class: set_link_classes(event.url), target: get_link_target_attribute(event.url)) %>
                 </h3>
             </div>

--- a/app/views/page/_events_list.html.erb
+++ b/app/views/page/_events_list.html.erb
@@ -7,13 +7,15 @@
                 </h3>
             </div>
             <div id="<%= event.id %>" class="event-item-description usa-prose usa-card__body">
-              <% if event&.start_date.present? %>
-                <p><i class="fas fa-calendar-alt"></i><span class='sr-only'>Date: </span> <%= event.rendered_date %></p>
-              <% end %>
-              <% if event&.location.present? %>
-                <p><i class="fas fa-map-marker-alt"></i><span class='sr-only'>Location: </span> <%= event&.location %></p>
-              <% end %>
-              <p><%= event&.text&.html_safe %></p>
+                <div class="event-metadata">
+                  <% if event&.start_date.present? %>
+                    <p><span><i class="fas fa-calendar-alt"></i><span class='sr-only'>Date: </span> <%= event.rendered_date %></span></p>
+                  <% end %>
+                  <% if event&.location.present? %>
+                    <p><span><i class="fas fa-map-marker-alt"></i><span class='sr-only'>Location: </span> <%= event&.location %></span></p>
+                  <% end %>
+                </div>
+                <p><%= event&.text&.html_safe %></p>
             </div>
         </div>
     </li>


### PR DESCRIPTION
### JIRA issue link
[DM-4065](https://agile6.atlassian.net/browse/DM-4065?atlOrigin=eyJpIjoiMThjZjU2ZWNmOGFlNDYzYTk1ODU4MTdiNjZkZjYxMDkiLCJwIjoiaiJ9)

## Description - what does this code do?
- Most of this is SCSS to undo whitespace styling from the USWDS Card component. Because these styles are shared by two not-exactly-similar components, I opted to do it in the stylesheet.
  - aligns Event / News cards with the grid container's left margin
  - updates markup and styling for Event date and location info
  - generally reduces padding and margins within the card component to match the Figma design
- Sets line-height to `1.62px` across PageBuilder components ([DM-4066](https://agile6.atlassian.net/browse/DM-4066?atlOrigin=eyJpIjoiZWE4MTkzZGMyYzIxNDU5MzlkYjRhMmEyYTI0ZmI0ZTMiLCJwIjoiaiJ9)

## Screenshots, Gifs, Videos from application (if applicable)
### Before
![Screenshot 2023-07-27 at 12 28 30 PM](https://github.com/department-of-veterans-affairs/diffusion-marketplace/assets/5402927/48a7bd98-71aa-4cee-ad7b-0c9b12356f53)

### After
![Screenshot 2023-07-27 at 12 28 05 PM](https://github.com/department-of-veterans-affairs/diffusion-marketplace/assets/5402927/44efeb07-a2ca-4816-a6dd-7ee6d207424a)


## Link to mock-ups/mock ups (image file if you have it) (if applicable)
https://www.figma.com/file/ccwLbt94U9QGfnuFCwOXzY/Core-Designs---VA-DM?type=design&node-id=6181%3A38873&mode=design&t=d3BI6dvrqLJpLQ8n-1