### PR TITLE
DM-4065: Apply card whitespacing rules to PageBuilder publication lists of <2

### DIFF
--- a/app/assets/stylesheets/dm/components/page_component.scss
+++ b/app/assets/stylesheets/dm/components/page_component.scss
@@ -203,7 +203,9 @@
   }
 
   // disable USWDS USA card styles the affect whitespace
-  .page-event-component, .page-news-component {
+  .page-event-component, 
+  .page-news-component, 
+  .publication-component-list-cards .page-publication-component { // Publication lists with <2 components
     margin-top: 0;
     margin-bottom: 0;
     padding-bottom: 0;

--- a/app/views/page/_publications_list_cards.html.erb
+++ b/app/views/page/_publications_list_cards.html.erb
@@ -2,7 +2,7 @@
   <li class="page-publication-component usa-card tablet:grid-col-6">
     <div class="usa-card__container border-0">
         <div class="usa-card__header">
-            <h3 class="margin-bottom-2 publication-title">
+            <h3 class="publication-title">
                 <% if publication.attachment? %>
                   <%= link_to publication.attachment_s3_presigned_url,
                   class: 'usa-link',


### PR DESCRIPTION
### JIRA issue link
Add on to DM-4065 / #646 

## Description - what does this code do?
- Adds visual design updates for USWDS card component styling to PageBuilder Publication component lists of <2. 

## Screenshots, Gifs, Videos from application (if applicable)
### Before
<img width="700" alt="Screenshot 2023-07-27 at 5 44 21 PM" src="https://github.com/department-of-veterans-affairs/diffusion-marketplace/assets/5402927/80a187c8-3c44-4d7c-b1b8-b1cb99c1b594">

### After
<img width="706" alt="Screenshot 2023-07-27 at 5 44 37 PM" src="https://github.com/department-of-veterans-affairs/diffusion-marketplace/assets/5402927/52159a10-6a24-4686-ade9-c4d320b2261d">

## Link to mock-ups/mock ups (image file if you have it) (if applicable)
https://www.figma.com/file/ccwLbt94U9QGfnuFCwOXzY/Core-Designs---VA-DM?type=design&node-id=6181%3A38719&mode=design&t=BQ1YuZbZrRo0lRUx-1
