### PR TITLE
DM-4072: Set blue banner line heights to 1.53

### DIFF
--- a/app/assets/stylesheets/dm/components/_gradient_banner.scss
+++ b/app/assets/stylesheets/dm/components/_gradient_banner.scss
@@ -39,6 +39,10 @@
       // bottom of description text (should mimic homepage gradient banner image) - per design 10/6/2022).
       padding-bottom: 87px;
     }
+
+    .dm-heading-description {
+      line-height: 1.53;
+    }
   }
 
   .page-image-column {

--- a/app/views/shared/_breadcrumbs.html.erb
+++ b/app/views/shared/_breadcrumbs.html.erb
@@ -55,7 +55,7 @@
             <%= heading %>
           </h1>
           <% if description.present? %>
-            <p class="font-sans-lg <%= page_image.present? ? ' grid-col-12' : ' grid-col-10' %> text-white dm-word-break-break-word hyphens-auto">
+            <p class="dm-heading-description font-sans-lg <%= page_image.present? ? ' grid-col-12' : ' grid-col-10' %> text-white dm-word-break-break-word hyphens-auto">
               <%= description %>
             </p>
           <% end %>


### PR DESCRIPTION
### JIRA issue link
[DM-4072](https://agile6.atlassian.net/jira/software/c/projects/DM/boards/22?modal=detail&selectedIssue=DM-4072)	

## Description - what does this code do?
- Sets the line height for blue banners to `1.53` across the app. (Note this is a little different from what USWDS offers for [line height utilities](https://designsystem.digital.gov/design-tokens/typesetting/line-height/#line-height-tokens). I'm making the exception here because it's a component defined by the [Diffusion Marketplace internal design system](https://www.figma.com/file/dkvSpADVqwN5KKByF1TVIa/Design-System---VA-DM?type=design&node-id=1305-3&mode=design&t=ln1GK4CrmlhnIYXB-0))

## Screenshots, Gifs, Videos from application (if applicable)
### Before
<img width="1148" alt="Screenshot 2023-07-28 at 2 28 21 PM" src="https://github.com/department-of-veterans-affairs/diffusion-marketplace/assets/5402927/8ddb97bc-64b1-4e96-8071-2a24c7c4cf8e">

### After
<img width="1149" alt="Screenshot 2023-07-28 at 2 28 12 PM" src="https://github.com/department-of-veterans-affairs/diffusion-marketplace/assets/5402927/ecf5f76f-118f-4151-815e-e631a1cfc98e">
