### PR TITLE
DM-4073: Add 'Presented by' field to PageBuilder Event components

### DIFF
--- a/app/admin/pages.rb
+++ b/app/admin/pages.rb
@@ -264,17 +264,10 @@ ActiveAdmin.register Page do
             end
             # Event
             if pc.component_type == 'PageEventComponent'
-              fields = {
-                title: 'Title',
-                url: 'URL',
-                presented_by: 'Presented by',
-                start_date: 'Start date',
-                end_date: 'End date',
-                location: 'Location',
-                text: 'Description'
-              }
-              fields.each do | key, value|
-                para "#{value}: #{component.send(key)}" if component.send(key).present?
+              ul do
+                component.class::FIELDS.each do | key, value|
+                  li "#{value}: #{component.send(key)}" if component.send(key).present?
+                end
               end
             end
           end

--- a/app/admin/pages.rb
+++ b/app/admin/pages.rb
@@ -265,7 +265,7 @@ ActiveAdmin.register Page do
             # Event
             if pc.component_type == 'PageEventComponent'
               ul do
-                component.class::FIELDS.each do | key, value|
+                component.class::FORM_FIELDS.each do | key, value|
                   li "#{value}: #{component.send(key)}" if component.send(key).present?
                 end
               end

--- a/app/admin/pages.rb
+++ b/app/admin/pages.rb
@@ -61,6 +61,7 @@ ActiveAdmin.register Page do
                     :large_title,
                     :padding_bottom,
                     :padding_top,
+                    :presented_by,
                     :published_date,
                     :published_in,
                     :published_on_day,

--- a/app/admin/pages.rb
+++ b/app/admin/pages.rb
@@ -262,7 +262,21 @@ ActiveAdmin.register Page do
               para "Year: #{component&.published_on_year}" if component&.published_on_year.present?
               para "Authors: #{component&.authors}" if component&.authors.present?
             end
-
+            # Event
+            if pc.component_type == 'PageEventComponent'
+              fields = {
+                title: 'Title',
+                url: 'URL',
+                presented_by: 'Presented by',
+                start_date: 'Start date',
+                end_date: 'End date',
+                location: 'Location',
+                text: 'Description'
+              }
+              fields.each do | key, value|
+                para "#{value}: #{component.send(key)}" if component.send(key).present?
+              end
+            end
           end
         }.join('').html_safe
       end

--- a/app/assets/stylesheets/dm/components/page_component.scss
+++ b/app/assets/stylesheets/dm/components/page_component.scss
@@ -230,6 +230,7 @@
     }
 
     .usa-card__body {
+      padding-top: 0;
       padding-bottom: 0;
       &:last-child {
         padding-bottom: 0;

--- a/app/models/page_event_component.rb
+++ b/app/models/page_event_component.rb
@@ -1,7 +1,7 @@
 class PageEventComponent < ApplicationRecord
   has_one :page_component, as: :component, autosave: true
 
-  FIELDS = { # Fields and labels in .arb form
+  FORM_FIELDS = { # Fields and labels in .arb form
     title: 'Title',
     url: 'URL',
     presented_by: 'Presented by',

--- a/app/models/page_event_component.rb
+++ b/app/models/page_event_component.rb
@@ -1,5 +1,6 @@
 class PageEventComponent < ApplicationRecord
   has_one :page_component, as: :component, autosave: true
+  validates :start_date, presence: { message: 'Must provide a start date' } if :end_date?
 
   validates_with InternalUrlValidator,
                  on: [:create, :update],

--- a/app/models/page_event_component.rb
+++ b/app/models/page_event_component.rb
@@ -1,5 +1,16 @@
 class PageEventComponent < ApplicationRecord
   has_one :page_component, as: :component, autosave: true
+
+  FIELDS = { # Fields and labels in .arb form
+    title: 'Title',
+    url: 'URL',
+    presented_by: 'Presented by',
+    start_date: 'Start date',
+    end_date: 'End date',
+    location: 'Location',
+    text: 'Description'
+  }.freeze
+
   validates :start_date, presence: { message: 'Must provide a start date' } if :end_date?
 
   validates_with InternalUrlValidator,

--- a/app/views/active_admin/resource/_page_event_component_form.html.arb
+++ b/app/views/active_admin/resource/_page_event_component_form.html.arb
@@ -36,6 +36,14 @@ html = Arbre::Context.new do
           para 'URL used for event title link, e.g. https://va.gov', class: 'inline-hints'
         end
 
+        li class: 'string input optional stringish', id: "page_page_components_attributes_#{placeholder}_component_attributes_presented_by_input" do
+          label 'Presented by', for: "page_page_components_attributes_event_#{placeholder}_component_attributes_text", class: 'label'
+          input value: component&.presented_by || nil, type: 'text', required: 'required',
+                id: "page_page_components_attributes_#{placeholder}_component_attributes_presented_by",
+                name: "page[page_components_attributes][#{placeholder}][component_attributes][presented_by]"
+          para 'Sponsoring organization, e.g. VHA Innovation Network', class: 'inline-hints'
+        end
+
         li class: 'date input optional', id: "page_page_components_attributes_#{placeholder}_component_attributes_start_date_input" do
           label 'Start date', for: "page_page_components_attributes_event_#{placeholder}_component_attributes_start_date", class: 'label'
           input value: component&.start_date || nil, type: 'date', required: 'required',

--- a/app/views/active_admin/resource/_page_event_component_form.html.arb
+++ b/app/views/active_admin/resource/_page_event_component_form.html.arb
@@ -21,7 +21,7 @@ html = Arbre::Context.new do
       end
       ol do
         li class: 'string input optional stringish', id: "page_page_components_attributes_#{placeholder}_component_attributes_title_input" do
-          label 'Title', for: "page_page_components_attributes_event_#{placeholder}_component_attributes_text", class: 'label'
+          label 'Title', for: "page_page_components_attributes_event_#{placeholder}_component_attributes_title", class: 'label'
           input value: component&.title || nil, type: 'text', required: 'required',
                 id: "page_page_components_attributes_#{placeholder}_component_attributes_title",
                 name: "page[page_components_attributes][#{placeholder}][component_attributes][title]"
@@ -37,7 +37,7 @@ html = Arbre::Context.new do
         end
 
         li class: 'string input optional stringish', id: "page_page_components_attributes_#{placeholder}_component_attributes_presented_by_input" do
-          label 'Presented by', for: "page_page_components_attributes_event_#{placeholder}_component_attributes_text", class: 'label'
+          label 'Presented by', for: "page_page_components_attributes_event_#{placeholder}_component_attributes_presented_by", class: 'label'
           input value: component&.presented_by || nil, type: 'text', required: 'required',
                 id: "page_page_components_attributes_#{placeholder}_component_attributes_presented_by",
                 name: "page[page_components_attributes][#{placeholder}][component_attributes][presented_by]"
@@ -61,7 +61,7 @@ html = Arbre::Context.new do
         end
 
         li class: 'string input optional stringish', id: "page_page_components_attributes_#{placeholder}_component_attributes_location_input" do
-          label 'Location', for: "page_page_components_attributes_event_#{placeholder}_component_attributes_text", class: 'label'
+          label 'Location', for: "page_page_components_attributes_event_#{placeholder}_component_attributes_location", class: 'label'
           input value: component&.location || nil, type: 'text', required: 'required',
                 id: "page_page_components_attributes_#{placeholder}_component_attributes_location",
                 name: "page[page_components_attributes][#{placeholder}][component_attributes][location]"

--- a/app/views/page/_events_list.html.erb
+++ b/app/views/page/_events_list.html.erb
@@ -8,11 +8,14 @@
             </div>
             <div id="<%= event.id %>" class="event-item-description usa-prose usa-card__body">
                 <div class="event-metadata">
+                  <% if event.presented_by? %>
+                    <p>Presented by: <%= event.presented_by%></p>
+                  <% end %>
                   <% if event&.start_date.present? %>
-                    <p><span><i class="fas fa-calendar-alt"></i><span class='sr-only'>Date: </span> <%= event.rendered_date %></span></p>
+                    <p><i class="fas fa-calendar-alt"></i><span class='sr-only'>Date: </span> <%= event.rendered_date %></span></p>
                   <% end %>
                   <% if event&.location.present? %>
-                    <p><span><i class="fas fa-map-marker-alt"></i><span class='sr-only'>Location: </span> <%= event&.location %></span></p>
+                    <p><i class="fas fa-map-marker-alt"></i><span class='sr-only'>Location: </span> <%= event&.location %></span></p>
                   <% end %>
                 </div>
                 <p><%= event&.text&.html_safe %></p>

--- a/db/migrate/20230728213402_add_presented_by_to_page_event_components.rb
+++ b/db/migrate/20230728213402_add_presented_by_to_page_event_components.rb
@@ -1,0 +1,5 @@
+class AddPresentedByToPageEventComponents < ActiveRecord::Migration[6.0]
+  def change
+    add_column :page_event_components, :presented_by, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_07_20_184846) do
+ActiveRecord::Schema.define(version: 2023_07_28_213402) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -600,6 +600,7 @@ ActiveRecord::Schema.define(version: 2023_07_20_184846) do
     t.date "start_date"
     t.date "end_date"
     t.string "location"
+    t.string "presented_by"
     t.index ["page_component_id"], name: "index_page_event_components_on_page_component_id"
   end
 

--- a/spec/models/page_event_component_spec.rb
+++ b/spec/models/page_event_component_spec.rb
@@ -3,12 +3,19 @@ require 'rails_helper'
 
 RSpec.describe PageEventComponent, type: :model do
   let(:event) { described_class.new }
+
   describe 'associations' do
     it { should have_one(:page_component) }
   end
 
-  describe '#rendered_date' do
+  describe 'validations' do
+    it 'rejects end dates without start date' do
+      event.end_date = Date.new(2023,07,28)
+      expect(event).to be_invalid
+    end
+  end
 
+  describe '#rendered_date' do
     it 'renders events with only a start date' do
       event.start_date = Date.new(2023,05,16)
       expect(event.rendered_date).to eq "May 16, 2023"


### PR DESCRIPTION
### JIRA issue link
[DM-4073](https://agile6.atlassian.net/browse/DM-4073?atlOrigin=eyJpIjoiOWI0NmU4NDZhMzVjNGEyOTgzZTg5M2IzYTY0NDVhNmEiLCJwIjoiaiJ9)


## Description - what does this code do?
- Adds a "Presented by" field to the PB Events component
- Adds a validation to reject events with an end date but no start date
- Adjusts whitespace between event title and metadata (and applies this to News and Publication cards too)
- Adds Event component info to the content preview in `/admin/pages/:id`

## Testing done - how did you test it/steps on how can another person can test it 
1. Log in as an admin and create a page group and page
2. Create a new event component with a Title and save. 
3. Add an end date to event component and save. 
4. Edit the component. Event component should not have persisted an end date. 
5. Fill out the rest of the info as expected and save. 
6. Check `/admin/pages/:id` to confirm all component info is available in the preview. 

## Screenshots, Gifs, Videos from application (if applicable)
### Before
<img width="443" alt="Screenshot 2023-07-28 at 3 33 27 PM" src="https://github.com/department-of-veterans-affairs/diffusion-marketplace/assets/5402927/e8e1017d-ed48-4584-84a7-6f0f292f65c4">

### After
<img width="518" alt="Screenshot 2023-07-28 at 3 33 19 PM" src="https://github.com/department-of-veterans-affairs/diffusion-marketplace/assets/5402927/9fd95a80-9c6c-4cde-86d4-a3eb4e217855">


## Link to mock-ups/mock ups (image file if you have it) (if applicable)
https://www.figma.com/file/ccwLbt94U9QGfnuFCwOXzY/Core-Designs---VA-DM?type=design&node-id=6181%3A38873&mode=design&t=7vahiMU1tvgcGRfR-1