### PR TITLE
Silence uswds-rails notifications until we upgrade to USWDS 3

### DIFF
--- a/app/assets/stylesheets/dm_uswds/theme/_uswds-theme-general.scss
+++ b/app/assets/stylesheets/dm_uswds/theme/_uswds-theme-general.scss
@@ -36,6 +36,7 @@ mixins use non-standard tokens.
 ----------------------------------------
 */
 
+$theme-show-notifications: false // disable version notifications until USWDS 3 upgrade
 $theme-show-compile-warnings: true;
 
 /*


### PR DESCRIPTION

## Description - what does this code do?
Silences the USWDS notifications that show up every time someone runs the tests. This reduces noise while running CI experiments since this information isn't useful to us until we can work on upgrading to USWDS 3. 

```
--------------------------------------------------------------------
✉ USWDS Notifications
--------------------------------------------------------------------
2.11.0:
- We updated some settings defaults:
... 
```