### PR TITLE
Set log levels to info

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -51,7 +51,7 @@ Rails.application.configure do
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.
-  config.log_level = :debug
+  config.log_level = :info
 
   # Prepend all log lines with the following tags.
   config.log_tags = [ :request_id ]


### PR DESCRIPTION
### JIRA issue link
[DM-4096](https://agile6.atlassian.net/browse/DM-4096?atlOrigin=eyJpIjoiNzI1ODc2NTE0YmYzNGY3MGExMTFmZjU2MTBjMjcyNGEiLCJwIjoiaiJ9)

## Description - what does this code do?
Set log levels to `info` to make logs less verbose. See [Debugging Rails Applications](https://guides.rubyonrails.org/debugging_rails_applications.html#log-levels) for more info.

## Testing done - how did you test it/steps on how can another person can test it 
1. In config/environments/development.rb, add `config.log_level = :info`.
1. Start your local rails server
1. Compare the output 
