### PR TITLE
DM-4109 Fix CodeQl security warning "unsafe-external-link"

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -126,10 +126,14 @@ module ApplicationHelper
   end
 
   def is_internal_link?(url)
-    return nil if url.blank?
-    url.include?(ENV.fetch('HOSTNAME')) ||
-    url.start_with?('/') ||
-    url.start_with?('.')
+    return false if url.blank?
+
+    uri = URI.parse(url)
+    host_name = URI.parse(ENV.fetch('HOSTNAME'))
+
+    uri.host == host_name.host && uri.port == host_name.port ||
+      url.start_with?('/') ||
+      url.start_with?('.')
   end
 
   def set_link_classes(url)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -132,6 +132,7 @@ module ApplicationHelper
     host_name = URI.parse(ENV.fetch('HOSTNAME'))
 
     uri.host == host_name.host && uri.port == host_name.port ||
+      url.start_with?(host_name.host) ||
       url.start_with?('/') ||
       url.start_with?('.')
   end

--- a/app/views/practices/form/editors.html.erb
+++ b/app/views/practices/form/editors.html.erb
@@ -23,7 +23,10 @@
           <div class="grid-row flex-align-center border-bottom-1px <%= 'border-top-1px' if practice_editors.first === pe %> practice-editor-entry">
             <div class="grid-col-11 padding-y-3 line-height-26">
               <p class="text-bold <%= 'display-none' unless is_full_name_present(user) %>"><%= user_full_name(user) %></p>
-              <a target="_blank" href="mailto:<%= email %>" class="usa-link usa-link--external line-height-26">
+              <a target="_blank" 
+                  href="mailto:<%= email %>" 
+                  class="usa-link usa-link--external line-height-26"
+                  rel="noopener noreferrer">
                 <%= email %>
               </a>
               <%

--- a/app/views/practices/show/implementation/_resource_link_attachment.html.erb
+++ b/app/views/practices/show/implementation/_resource_link_attachment.html.erb
@@ -8,7 +8,15 @@
         <% end %>
         <% la.name = la.link_url unless la.name.present? %>
         <div class="margin-top-1 width-full line-height-26">
-          <li class="small-disc"><%= la.description %> <a class="usa-link <%= la.link_url.downcase().include?('marketplace.gov') ? '' : 'usa-link--external' %>" href="<%= la.link_url %>" target="_blank"><%= la.name || la.link_url %></a></li>
+          <li class="small-disc">
+            <%= la.description %>
+            <a class="usa-link <%= la.link_url.downcase().include?('marketplace.gov') ? '' : 'usa-link--external' %>"
+                href="<%= la.link_url %>"
+                target="_blank"
+                rel="noopener noreferrer">
+              <%= la.name || la.link_url %>
+            </a>
+          </li>
         </div>
       <% end %>
     </div>

--- a/app/views/practices/show/implementation/_resource_link_attachment.html.erb
+++ b/app/views/practices/show/implementation/_resource_link_attachment.html.erb
@@ -10,7 +10,7 @@
         <div class="margin-top-1 width-full line-height-26">
           <li class="small-disc">
             <%= la.description %>
-            <a class="usa-link <%= la.link_url.downcase().include?('marketplace.gov') ? '' : 'usa-link--external' %>"
+            <a class="usa-link <%= set_link_classes(la.link_url.downcase()) %>"
                 href="<%= la.link_url %>"
                 target="_blank"
                 rel="noopener noreferrer">

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -239,7 +239,7 @@ RSpec.describe ApplicationHelper, type: :helper do
 
   describe 'is_internal_link?' do
     before do
-      ENV['HOSTNAME'] = 'marketplace.va.gov'
+      ENV['HOSTNAME'] = 'https://dev.marketplace.va.gov'
     end
 
     after do
@@ -250,6 +250,7 @@ RSpec.describe ApplicationHelper, type: :helper do
       expect(is_internal_link?('test')).to eq(false)
       expect(is_internal_link?('/search')).to eq(true)
       expect(is_internal_link?('.visns')).to eq(true)
+      expect(is_internal_link?('https://dev.marketplace.va.gov/partners')).to eq(true)
       expect(is_internal_link?('dev.marketplace.va.gov/partners')).to eq(true)
     end
   end


### PR DESCRIPTION
### JIRA issue link

https://agile6.atlassian.net/browse/DM-4109

## Description - what does this code do?

Edit external link tags as per codeql security warning "js/unsafe-external-link"

## Testing done - how did you test it/steps on how can another person can test it 

1. Edit a current practice
2. Go to "Editors" tab, click the email link, verify it opens mail client
3. Go to "Implementation" tab, add a resource link
4. View the practice's page, verify the added link opens a new tab to the correct url when clicked

## Screenshots, Gifs, Videos from application (if applicable)


## Link to mock-ups/mock ups (image file if you have it) (if applicable)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Unit tests written (if applicable)
- [ ] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating JIRA issue
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs