### PR TITLE
DM-4110: Remove legacy Google Analytics tag

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,28 +1,9 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <% if Rails.env.production? %>
-      <!-- Global site tag (gtag.js) - Google Analytics -->
-      <script async src="https://www.googletagmanager.com/gtag/js?id=UA-139930129-1"></script>
-      <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-        (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-        m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', '<%= ENV['GA_TRACKING_ID'] %>', 'auto');
-
-        document.addEventListener('turbolinks:load', function() {
-          if (typeof ga === 'function') {
-            ga('send', 'pageview');
-          }
-        });
-      </script>
-      <!-- DAP GA Analytics -->
-      <% unless private_path? %>
-        <!-- We participate in the US government's analytics program. See the data at analytics.usa.gov. -->
-        <script async type="text/javascript" src="https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=VA" id="_fed_an_ua_tag"></script>
-      <% end %>
+    <% if Rails.env.production? && private_path? == false %>
+      <!-- We participate in the US government's analytics program. See the data at analytics.usa.gov. -->
+      <script async type="text/javascript" src="https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=VA" id="_fed_an_ua_tag"></script>
     <% end %>
     <title>Diffusion Marketplace</title>
     <%= favicon_link_tag asset_path('favicon.ico') %>


### PR DESCRIPTION
### JIRA issue link
[DM-4110](https://agile6.atlassian.net/browse/DM-4110)

## Description - what does this code do?
- Removes extra Google Analytics tag that was slowing down page load times
- Simplifies logic for adding the DAP Analytics program snippet


## Testing done - how did you test it/steps on how can another person can test it 
1. Deploy the branch to DEV.
1.  Access a public page (e.g. the homepage) and inspect the markup. You should see ` <!-- We participate in the US government's analytics program. See the data at analytics.usa.gov. -->`. 
1. Go to a page requiring a user account e.g. `/innovations/vha-rapid-naloxone/edit/metrics`. Inspect the markup. You should NOT see ` <!-- We participate in the US government's analytics program. See the data at analytics.usa.gov. -->`.