### PR TITLE
DM-3214: Use asterisks for required field labels in Innovation Editor 

### DIFF
--- a/app/views/practices/form/about.html.erb
+++ b/app/views/practices/form/about.html.erb
@@ -108,8 +108,8 @@
           </fieldset>
           <fieldset class="usa-fieldset grid-col-11">
             <legend class="usa-sr-only">Innovation Contact</legend>
-            <div>
-              <h4 class="line-height-18px margin-top-3 font-sans-sm text-bold margin-bottom-2">Contact information <span class="text-gray-50">(required field)</span></h4>
+            <div class="margin-bottom-5">
+              <h4 class="line-height-18px margin-top-3 font-sans-sm text-bold margin-bottom-2">Contact information*</h4>
               <p class="line-height-26 margin-bottom-2">
                 Add at least one email address that will be dedicated to responding to messages about this innovation. People may reach out with questions, ask for support, or want to connect about this innovation.
               </p>

--- a/app/views/practices/form/introduction.html.erb
+++ b/app/views/practices/form/introduction.html.erb
@@ -51,7 +51,7 @@
             <div class="margin-bottom-5 margin-top-3">
               <div>
                 <%= f.label :name, class: 'usa-label text-bold display-block margin-top-0 margin-bottom-2' do %>
-                  Name <span class="text-gray-50">(required field)</span>
+                  Name*
                 <% end %>
                 <span>Type the official name of your innovation.</span>&nbsp;
               </div>
@@ -65,7 +65,7 @@
                 <div class="margin-bottom-5 margin-top-3">
                   <div>
                     <%= f.label :tagline, class: 'usa-label text-bold display-block margin-top-0 margin-bottom-2' do %>
-                      Tagline <span class="text-gray-50">(required field)</span>
+                      Tagline*
                     <% end %>
                     <span>Type a short sentence summarizing the key outcomes of your innovation.  This text will display on the innovation card.</span>&nbsp&nbsp;
                     <%= render partial: 'shared/textarea_counter', locals: { counter_class: "practice-editor-tagline-character-counter", textarea_class: "practice-editor-tagline-textarea", max_char_count: 72 } %>
@@ -91,7 +91,7 @@
 
             <div class="margin-top-3 margin-bottom-5">
               <%= f.label :summary, class: 'usa-label text-bold display-block margin-top-0 margin-bottom-2' do %>
-                Summary <span class="text-gray-50">(required field)</span>
+                Summary*
               <% end %>
               <span class="line-height-26">
                 Type a short 1-3 sentence summary of your innovation’s mission to engage the audience and provide initial context.
@@ -101,7 +101,7 @@
 
             <div class="margin-top-3 margin-bottom-5">
               <p class="margin-bottom-2 text-bold">
-                Date created <span class="text-gray-50">(required field)</span>
+                Date created*
               </p>
               Select the month and year this innovation was created.
               <div class="grid-row grid-gap-2">
@@ -129,7 +129,7 @@
 
             <div class="margin-top-3 margin-bottom-5">
               <p class="text-bold margin-bottom-2">
-                Innovation origin <span class="text-gray-50">(required field)</span>
+                Innovation origin*
               </p>
               <span>Select the location where this innovation originated</span>
               <div class="grid-row grid-gap grid-col-1 margin-bottom-3">

--- a/app/views/practices/form/overview.html.erb
+++ b/app/views/practices/form/overview.html.erb
@@ -32,7 +32,7 @@
             <!-- PROBLEM section -->
             <div id="problem_section" class="grid-col-12">
               <div class="margin-bottom-5 margin-top-3">
-                <%= label_tag 'practice_overview_problem', 'Problem statement', class: 'usa-label text-bold display-inline overview-problem-statement-label' %><span class="text-gray-50 text-bold line-height-18px"> (required field)</span>
+                <%= label_tag 'practice_overview_problem', 'Problem statement', class: 'usa-label text-bold display-inline overview-problem-statement-label' %>*
                 <p class="line-height-26 margin-top-2">Type the main problem your innovation attempted to address and include context and any initial goals.</p>
                 <%= f.text_area :overview_problem, class: "usa-input #{ @practice.errors[:name].any? ? 'usa-input--error' : '' } display-block practice-editor-overview-statement-input #{'dm-required-field' if @practice.published}", required: @practice.published %>
               </div>
@@ -123,7 +123,7 @@
             <!-- SOLUTION section -->
             <div id="solution_section" class="grid-col-12">
               <div class="margin-bottom-5 margin-top-3">
-                <%= label_tag 'practice_overview_solution', 'Solution statement', class: 'usa-label margin-0 text-bold display-inline overview-solution-statement-label' %><span class="text-gray-50 text-bold"> (required field)</span>
+                <%= label_tag 'practice_overview_solution', 'Solution statement', class: 'usa-label margin-0 text-bold display-inline overview-solution-statement-label' %>*
                 <p class="line-height-26 margin-top-2">Type the solution that was implemented to address the problem.</p>
                 <%= f.text_area :overview_solution, required: @practice.published, class: "usa-input #{ @practice.errors[:name].any? ? 'usa-input--error' : '' } display-block practice-editor-overview-statement-input" %>
               </div>
@@ -216,7 +216,7 @@
             <!-- RESULTS section -->
             <div id="results_section" class="grid-col-12">
               <div class="margin-bottom-5 margin-top-3">
-                <%= label_tag 'practice_overview_results', 'Results statement', class: 'usa-label margin-0 text-bold display-inline overview-results-statement-label' %><span class="text-gray-50 text-bold"> (required field)</span>
+                <%= label_tag 'practice_overview_results', 'Results statement', class: 'usa-label margin-0 text-bold display-inline overview-results-statement-label' %>*
                 <p class="line-height-26 margin-top-2">Type information about the impact of the innovation at the originating facility.</p>
                 <%= f.text_area :overview_results, required: @practice.published, class: "usa-input #{ @practice.errors[:name].any? ? 'usa-input--error' : '' } display-block practice-editor-overview-statement-input" %>
               </div>

--- a/spec/features/practice_editor/introduction/introduction_spec.rb
+++ b/spec/features/practice_editor/introduction/introduction_spec.rb
@@ -52,13 +52,13 @@ describe 'Practice editor - introduction', type: :feature, js: true do
       expect(page).to have_content('Introduction')
       expect(page).to have_content('Introduce your innovation and provide a brief summary to people who may be unfamiliar with it.')
       expect(page).to have_content('Do not enter PII or PHI for any individual, Veteran, or patient. See our Privacy policy.')
-      expect(page).to have_content('Name (required field)')
+      expect(page).to have_content('Name*')
       expect(page).to have_content('Type the official name of your innovation.')
-      expect(page).to have_content('Summary (required field)')
+      expect(page).to have_content('Summary*')
       expect(page).to have_content('Type a short 1-3 sentence summary of your innovation’s mission to engage the audience and provide initial context.')
-      expect(page).to have_content('Date created (required field)')
+      expect(page).to have_content('Date created*')
       expect(page).to have_content('Select the month and year this innovation was created.')
-      expect(page).to have_content('Innovation origin (required field)')
+      expect(page).to have_content('Innovation origin*')
       expect(page).to have_content('Select the location where this innovation originated')
       expect(page).to have_content('Awards and recognition')
       expect(page).to have_content('Partners')
@@ -110,7 +110,7 @@ describe 'Practice editor - introduction', type: :feature, js: true do
       expect(page).to have_field('Name', with: @practice.name)
       expect(page).to have_field('Summary', with: @practice.summary)
       # add whitespace to practice name
-      fill_in('Name (required field)', with: '   Edited practice ')
+      fill_in('Name*', with: '   Edited practice ')
       fill_in('Summary', with: 'Updated summary')
       click_save
       # make sure white space is trimmed from practice name

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -141,7 +141,7 @@ describe 'Search', type: :feature do
     select('Alabama', :from => 'editor_office_state_select')
     select('Montgomery Regional Office', :from => 'editor_office_select')
     fill_in('practice_summary', with: 'This is the most super practice ever made')
-    fill_in('Tagline (required field)', with: 'practice tagline')
+    fill_in('Tagline*', with: 'practice tagline')
     select('October', :from => 'editor_date_initiated_month')
     fill_in('Year', with: '1970')
     find("#maturity_level_replicate").sibling('label').click


### PR DESCRIPTION
### JIRA issue link
[DM-3214](https://agile6.atlassian.net/browse/DM-3214)

## Description - what does this code do?
- Updates required fields in the Innovation Editor to use asterisks to match the Editing guide

## Screenshots
### Before
![Screenshot 2023-08-17 at 12 22 09 PM](https://github.com/department-of-veterans-affairs/diffusion-marketplace/assets/5402927/76023c08-efce-4886-b7da-d61feb8ab4ef)

### After
![Screenshot 2023-08-17 at 12 21 58 PM](https://github.com/department-of-veterans-affairs/diffusion-marketplace/assets/5402927/26e80e4a-fb2a-4794-af2a-af447974b967)
