### PR TITLE
DM-4080: Consistently apply about 80px of bottom margin to PageBuilder components

### DIFF
--- a/app/views/page/show.html.erb
+++ b/app/views/page/show.html.erb
@@ -26,10 +26,11 @@
             </div>
           <% end %>
 
+        <%# Three Text Columns %>
         <% if pc.component_type == 'PageTripleParagraphComponent' && component.text1.present? %>
           <div class=<%='bg-primary-lighter' if component.has_background_color %>>
             <div class="grid-container">
-              <div class="page-triple-paragraph-component padding-top-7 padding-bottom-7 <%= page_narrow_classes %><%= ' margin-bottom-0' if last_component === index %>">
+              <div class="page-triple-paragraph-component padding-top-7 padding-bottom-7 margin-bottom-10 <%= page_narrow_classes %><%= ' margin-bottom-0' if last_component === index %>">
                 <div class="grid-row grid-gap">
                   <div class="grid-col-12 desktop:grid-col-4">
                     <h3><%= component.title1.html_safe %></h3>
@@ -346,9 +347,9 @@
             text_alignment = component&.description_text_alignment
           %>
           <div class="grid-container">
-            <div class="page-map-component <%= page_narrow_classes %>">
+            <div class="page-map-component margin-bottom-10 <%= page_narrow_classes %>">
               <% if title.present? %>
-                <div class="font-sans-lg text-bold margin-top-9">
+                <div class="font-sans-lg text-bold">
                   <%= content_tag(:span, title, class: 'margin-right-1') %>
                 </div>
               <% end %>
@@ -390,13 +391,13 @@
 
         <%# 2:1 Image to Text %>
         <% when 'PageTwoToOneImageComponent' %>
-          <div class="grid-container margin-bottom-5 <%= ' margin-bottom-0' if last_component === index %>">
+          <div class="grid-container margin-bottom-10 <%= ' margin-bottom-0' if last_component === index %>">
             <%= render partial: 'two_to_one_image_component', locals: { component: component } %>
           </div>
 
         <%# 1:1 Image to Text %>
         <% when 'PageOneToOneImageComponent' %>
-          <div class="grid-container margin-bottom-5 <%= ' margin-bottom-0' if last_component === index %>">
+          <div class="grid-container margin-bottom-10 <%= ' margin-bottom-0' if last_component === index %>">
             <%= render partial: 'one_to_one_image_component', locals: { component: component } %>
           </div>
         <% end %>


### PR DESCRIPTION
### JIRA issue link
[DM-4080](https://agile6.atlassian.net/browse/DM-4045?atlOrigin=eyJpIjoiYjE2MzBkY2I2OWQxNDBiNmJkZjlkZTU3MmQxN2IyMTQiLCJwIjoiaiJ9)

## Description - what does this code do?
Unifies the treatment of whitespace between PageBuilder components! We were getting weird whitespace around the Map, three column text, and call to action components because some also applied whitespace above the component.

## Testing done - how did you test it/steps on how can another person can test it 
See: VA Immersive clone page in DEV (`/communities/va-immersive`)

## Screenshots, Gifs, Videos from application (if applicable)

### Before
![Screenshot 2023-09-08 at 12 10 31 PM](https://github.com/department-of-veterans-affairs/diffusion-marketplace/assets/5402927/b69aa879-6a20-4d1d-b45b-458c1cd745cb)


### After
<img width="299" alt="va-immersive-whitespace" src="https://github.com/department-of-veterans-affairs/diffusion-marketplace/assets/5402927/c3cc069e-6f98-48e5-a9ed-c9076216936f">


## Link to mock-ups/mock ups (image file if you have it) (if applicable)
https://www.figma.com/file/ccwLbt94U9QGfnuFCwOXzY/Core-Designs---VA-DM?type=design&node-id=6181-38719&mode=design&t=fNia1FbnSMlNAlv3-0
