### PR TITLE
remove "Text and Images" option from components options in PB edit

### DIFF
--- a/app/models/page_component.rb
+++ b/app/models/page_component.rb
@@ -22,7 +22,6 @@ class PageComponent < ApplicationRecord
       'Three Text Columns': 'PageTripleParagraphComponent',
       'Block Quote': 'PageBlockQuoteComponent',
       'Subpage Hyperlink': 'PageSubpageHyperlinkComponent',
-      'Text and Images': 'PageCompoundBodyComponent',
       '1:1 Image to Text': 'PageOneToOneImageComponent',
       '2:1 Image to Text': 'PageTwoToOneImageComponent',
       'Accordion': 'PageAccordionComponent',


### PR DESCRIPTION
### JIRA issue link
https://agile6.atlassian.net/browse/DM-4043

## Description - what does this code do?

* remove "Text and Images" option from components options in PB edit

## Testing done - how did you test it/steps on how can another person can test it 

1. Go to the edit view for a PB page
2. Add new component, verify "Text and Images" is not an option in the dropdown

## Screenshots

![Screenshot 2023-08-17 at 4 07 28 PM](https://github.com/department-of-veterans-affairs/diffusion-marketplace/assets/65036872/4898e117-4572-4575-9d80-c79c0e549d98)
ifs, Videos from application (if applicable)


## Link to mock-ups/mock ups (image file if you have it) (if applicable)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Unit tests written (if applicable)
- [ ] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating JIRA issue
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specsIn application (if applicable)