### PR TITLE
DM-4060: Add section dividers to PageBuilder component selection

### DIFF
--- a/app/models/page_component.rb
+++ b/app/models/page_component.rb
@@ -16,20 +16,24 @@ class PageComponent < ApplicationRecord
   # used for the component selection on the page builder
   # 'Friendly Name': 'ClassName'
   COMPONENT_SELECTION = {
+      '---Text---': 'sectiondivider',
       'Heading 2': 'PageHeader2Component',
       'Heading 3': 'PageHeader3Component',
       'Body text': 'PageParagraphComponent',
       'Three Text Columns': 'PageTripleParagraphComponent',
       'Block Quote': 'PageBlockQuoteComponent',
       'Subpage Hyperlink': 'PageSubpageHyperlinkComponent',
+      '---Text and image blocks---': 'sectiondivider',
       '1:1 Image to Text': 'PageOneToOneImageComponent',
       '2:1 Image to Text': 'PageTwoToOneImageComponent',
+      '---Simple components---': 'sectiondivider',
       'Accordion': 'PageAccordionComponent',
       'Simple Button': 'PageSimpleButtonComponent',
       'Image': 'PageImageComponent',
       'Call to Action': 'PageCtaComponent',
       'Downloadable File': 'PageDownloadableFileComponent',
       'Horizontal Separator line ': 'PageHrComponent',
+      '---Complex components---': 'sectiondivider',
       'Event': 'PageEventComponent',
       'News': 'PageNewsComponent',
       'Innovations': 'PagePracticeListComponent',
@@ -49,6 +53,7 @@ class PageComponent < ApplicationRecord
         # Delete the component associated with this page component and make a new one.
         # There should only be one component associated with the page component
         COMPONENT_SELECTION.values.each do |c|
+          skip if c == 'sectiondivider'
           delete_component =  c.constantize.where({page_component: self}).first
           delete_component.destroy if delete_component
         end


### PR DESCRIPTION
### JIRA issue link
[DM-4060](https://agile6.atlassian.net/browse/DM-4060)

## Description - what does this code do?
- Adds section dividers to PageBuilder component selection per designer request

## Testing done - how did you test it/steps on how can another person can test it 
1. Log in as an admin. Create a page group and test page. 
2. Add a new component
3. Select a section divider (e.g. `---Text---`)
4. Save the page. The divider should not have persisted
5. Select a normal component (e.g. `Heading 2`) and add text.
6. Save the page. The component should have persisted.

## Screenshots, Gifs, Videos from application (if applicable)
<img width="479" alt="Screenshot 2023-08-18 at 4 29 32 PM" src="https://github.com/department-of-veterans-affairs/diffusion-marketplace/assets/5402927/32448d5c-4823-4034-a4b3-2b39c94833e2">

## Definition of done
- [ ] Unit tests written (if applicable)
- [ ] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating JIRA issue
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs