### PR TITLE
add instance variable to allow requests for gmaps assets

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -17,7 +17,7 @@ class HomeController < ApplicationController
     @successful_ct = @diffusion_histories.get_by_successful_status.size
     @in_progress_ct = @diffusion_histories.get_by_in_progress_status.size
     @unsuccessful_ct = @diffusion_histories.get_by_unsuccessful_status.size
-
+    @include_google_maps = true
     @dh_markers = Gmaps4rails.build_markers(@diffusion_histories.exclude_clinical_resource_hubs.group_by(&:va_facility_id)) do |dhg, marker|
       diffusion_histories = dhg[1]
       facility = @va_facilities.find(dhg[0])

--- a/app/controllers/page_controller.rb
+++ b/app/controllers/page_controller.rb
@@ -5,6 +5,7 @@ class PageController < ApplicationController
   def show
     page_group = @page.page_group
     @map_components_with_markers = build_map_component_markers
+    @include_google_maps = @map_components_with_markers.present?
     @path_parts = request.path.split('/')
     @facilities_data = VaFacility.cached_va_facilities.order_by_station_name
     @practice_list_components = []

--- a/app/controllers/practices_controller.rb
+++ b/app/controllers/practices_controller.rb
@@ -34,6 +34,7 @@ class PracticesController < ApplicationController
     # This allows comments thread to show up without the need to click a link
     commontator_thread_show(@practice)
     diffusion_histories = @practice.diffusion_histories
+    @include_google_maps = diffusion_histories.present?
     @diffusion_history_markers = Gmaps4rails.build_markers(diffusion_histories.where(clinical_resource_hub_id: nil)) do |dhg, marker|
       facility = @va_facilities.find(dhg.va_facility_id)
       marker.lat facility.latitude
@@ -70,7 +71,6 @@ class PracticesController < ApplicationController
                   })
       marker.infowindow render_to_string(partial: 'maps/infowindow', locals: { diffusion_histories: dhg[1], facility: facility })
     end
-    @include_google_maps = @diffusion_history_markers.present?
 
     # get the VaFacilities and ClinicalResourceHubs associated with the practice's origin facilities and then order them alphabetically
     va_facility_origin_facilities = VaFacility.where(id: PracticeOriginFacility.get_va_facility_ids_by_practice(@practice.id)).get_relevant_attributes

--- a/app/controllers/practices_controller.rb
+++ b/app/controllers/practices_controller.rb
@@ -70,6 +70,7 @@ class PracticesController < ApplicationController
                   })
       marker.infowindow render_to_string(partial: 'maps/infowindow', locals: { diffusion_histories: dhg[1], facility: facility })
     end
+    @include_google_maps = @diffusion_history_markers.present?
 
     # get the VaFacilities and ClinicalResourceHubs associated with the practice's origin facilities and then order them alphabetically
     va_facility_origin_facilities = VaFacility.where(id: PracticeOriginFacility.get_va_facility_ids_by_practice(@practice.id)).get_relevant_attributes

--- a/app/controllers/visns_controller.rb
+++ b/app/controllers/visns_controller.rb
@@ -2,6 +2,7 @@ class VisnsController < ApplicationController
   include PracticeUtils
   before_action :set_visn, only: [:show, :load_facilities_show_rows]
   before_action :set_visns_and_visns_origin_and_adoption_counts, only: :index
+  before_action :set_include_google_maps, only: [:index, :show]
 
   def index
     @visn_markers = Gmaps4rails.build_markers(@visns) do |visn, marker|
@@ -110,5 +111,9 @@ class VisnsController < ApplicationController
   def set_visns_and_visns_origin_and_adoption_counts
     set_visns
     set_visns_origin_and_adoption_counts(@visns)
+  end
+
+  def set_include_google_maps
+    @include_google_maps = true
   end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -12,10 +12,12 @@
     <meta name="viewport" content= "width=device-width, initial-scale=1, minimum-scale=1">
     <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'false' %>
     <%= javascript_include_tag 'shared/_utilityFunctions', 'data-turbolinks-track': 'reload' %>
-    <%= javascript_include_tag "https://maps.googleapis.com/maps/api/js?key=#{ENV['GOOGLE_API_KEY']}&callback=Function.prototype", 'data-turbolinks-track': 'false' %>
-    <%= javascript_include_tag "https://cdn.jsdelivr.net/gh/mahnunchik/markerclustererplus@master/dist/markerclusterer.min.js", 'data-turbolinks-track': 'false' %>
-    <%= javascript_include_tag "https://cdn.jsdelivr.net/gh/printercu/google-maps-utility-library-v3-read-only@master/infobox/src/infobox_packed.js", 'data-turbolinks-track': 'false' %>
-    <%= javascript_include_tag "https://cdn.jsdelivr.net/gh/googlemaps/js-rich-marker@gh-pages/src/richmarker-compiled.js", 'data-turbolinks-track': 'false' %>
+    <% if @include_google_maps %>
+      <%= javascript_include_tag "https://maps.googleapis.com/maps/api/js?key=#{ENV['GOOGLE_API_KEY']}&callback=Function.prototype", 'data-turbolinks-track': 'false' %>
+      <%= javascript_include_tag "https://cdn.jsdelivr.net/gh/mahnunchik/markerclustererplus@master/dist/markerclusterer.min.js", 'data-turbolinks-track': 'false' %>
+      <%= javascript_include_tag "https://cdn.jsdelivr.net/gh/printercu/google-maps-utility-library-v3-read-only@master/infobox/src/infobox_packed.js", 'data-turbolinks-track': 'false' %>
+      <%= javascript_include_tag "https://cdn.jsdelivr.net/gh/googlemaps/js-rich-marker@gh-pages/src/richmarker-compiled.js", 'data-turbolinks-track': 'false' %>
+    <% end %>
     <%= javascript_include_tag 'application', 'data-turbolinks-track': 'false' %>
     <%= javascript_tag 'data-turbolinks-track': 'false' do %>
       <%= render partial: 'layouts/ahoy_event_tracking', formats: [:js] %>


### PR DESCRIPTION
### JIRA issue link
https://agile6.atlassian.net/browse/DM-4111

## Description - what does this code do?
Adds instance variable created in `show` actions of `PageController` and `PracticesController` to allow or prevent calls for gmaps assets from `application.html.erb`

## Testing done - how did you test it/steps on how can another person can test it 
1. Add a gmap component to an innovation
2. Verify the map component renders when viewing the innovation show page (make sure your `GOOGLE_API_KEY` is present and uncommented in `application.yml`)
3. Check the show page of an existing practice, such as `/innovations/flow3`, verify the map renders.
4. Visit `/diffusion-map` and `/visns` and verify the map renders.
5. To verify calls are not being made for gmaps assets when not needed check a page without a gmap component or go to `/search` and verify in the Network tab that no requests for gmaps are carried out.

## Screenshots, Gifs, Videos from application (if applicable)


## Link to mock-ups/mock ups (image file if you have it) (if applicable)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Unit tests written (if applicable)
- [ ] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating JIRA issue
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs