### PR TITLE
add rescue block to #is_internal_link?

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -128,7 +128,8 @@ module ApplicationHelper
   def is_internal_link?(url)
     return false if url.blank?
 
-    uri = URI.parse(url)
+    encoded_url = URI.encode(url)
+    uri = URI.parse(encoded_url)
     host_name = URI.parse(ENV.fetch('HOSTNAME'))
 
     uri.host == host_name.host && uri.port == host_name.port ||

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -128,15 +128,19 @@ module ApplicationHelper
   def is_internal_link?(url)
     return false if url.blank?
 
-    encoded_url = URI.encode(url)
-    uri = URI.parse(encoded_url)
-    host_name = URI.parse(ENV.fetch('HOSTNAME'))
+    begin
+      uri = URI.parse(url)
+      host_name = URI.parse(ENV.fetch('HOSTNAME'))
 
-    uri.host == host_name.host && uri.port == host_name.port ||
-      url.start_with?(host_name.host) ||
-      url.start_with?('/') ||
-      url.start_with?('.')
+      uri.host == host_name.host && uri.port == host_name.port ||
+        url.start_with?(host_name.host) ||
+        url.start_with?('/') ||
+        url.start_with?('.')
+    rescue URI::InvalidURIError
+      false
+    end
   end
+
 
   def set_link_classes(url)
     "usa-link#{' usa-link--external' if !is_internal_link?(url)}"

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -252,6 +252,10 @@ RSpec.describe ApplicationHelper, type: :helper do
       expect(is_internal_link?('.visns')).to eq(true)
       expect(is_internal_link?('https://dev.marketplace.va.gov/partners')).to eq(true)
       expect(is_internal_link?('dev.marketplace.va.gov/partners')).to eq(true)
+      expect(is_internal_link?('this is clearly not a link')).to eq(false)
+      expect(is_internal_link?(
+        'https://editions.mydigitalpublication.com/publication/?i=645297&p=&pn=#{"issue_id":645297,"publication_id":"60085","page":26}'
+      )).to eq(false)
     end
   end
 end


### PR DESCRIPTION
### JIRA issue link


## Description - what does this code do?
adds rescue block to `#is_internal_link?` to sanitize urls with special characters that would otherwise break `URI.parse`

## Testing done - how did you test it/steps on how can another person can test it 

1. for an existing page under the implementation tab add a few resource links
2. make the resource links any text that would break `URI.parse` such as "THIS IS OBVIOUSLY NOT A LINK" or "https://editions.mydigitalpublication.com/publication/?i=645297&p=&pn=#{"issue_id":645297,"publication_id":"60085","page":26}"
3. save and verify the show page renders.


## Screenshots, Gifs, Videos from application (if applicable)


## Link to mock-ups/mock ups (image file if you have it) (if applicable)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Unit tests written (if applicable)
- [ ] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating JIRA issue
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs