### PR TITLE
Dm 4136 implement practice card img placeholder

### DIFF
--- a/app/assets/javascripts/_page_show.es6
+++ b/app/assets/javascripts/_page_show.es6
@@ -115,7 +115,6 @@ const COMPONENT_CLASSES = [
 
             fetchSignedResource(filePath, fileUrl)
                 .then(signedUrl => {
-                        debugger
                         const fileElement = document.querySelector(`a[data-resource-id="${fileId}"]`);
                         if (fileElement) {
                             fileElement.href = signedUrl;

--- a/app/assets/javascripts/_page_show.es6
+++ b/app/assets/javascripts/_page_show.es6
@@ -113,12 +113,14 @@ const COMPONENT_CLASSES = [
             const fileUrl = element.href;
             const fileId = element.getAttribute('data-resource-id');
 
-            fetchSignedResource(
-                filePath,
-                fileUrl,
-                `a[data-resource-id="${fileId}"]`,
-                'file'
-            );
+            fetchSignedResource(filePath, fileUrl)
+                .then(signedUrl => {
+                        debugger
+                        const fileElement = document.querySelector(`a[data-resource-id="${fileId}"]`);
+                        if (fileElement) {
+                            fileElement.href = signedUrl;
+                        }
+                    });
         });
     }
 

--- a/app/assets/javascripts/shared/_signed_resource.es6
+++ b/app/assets/javascripts/shared/_signed_resource.es6
@@ -1,27 +1,11 @@
-// The 'dataAttributeSelector' param can be any selector for the target element(s)
 function fetchSignedResource(
     resourcePath,
     resourceUrl = '',
-    dataAttributeSelector,
-    resourceType = 'image'
 ) {
     const signedResourceUrl = `/signed_resource?path=${resourcePath}&url=${resourceUrl}`;
-
-    fetch(signedResourceUrl).then(response => {
-        response.text().then(signedUrl => {
-            const resourceElement = document.querySelector(dataAttributeSelector);
-
-            if (resourceElement) {
-                // TODO: Add other resource types here, e.g. 'file'
-                switch (resourceType) {
-                    case 'image':
-                        resourceElement.src = signedUrl;
-                        break;
-                    case 'file':
-                        resourceElement.href = signedUrl;
-                        break;
-                }
-            }
+    return fetch(signedResourceUrl).then(response => {
+        return response.text().then(signedUrl => {
+            return signedUrl;
         });
     });
 }

--- a/app/assets/stylesheets/dm/components/_practice_card.scss
+++ b/app/assets/stylesheets/dm/components/_practice_card.scss
@@ -83,8 +83,8 @@
   }
 
   .dm-practice-card-img-container {
-    height: 165px;
     min-width: 100%;
+    height: auto;
     display: flex;
     justify-content: center;
     align-items: center;

--- a/app/assets/stylesheets/dm/components/_practice_card.scss
+++ b/app/assets/stylesheets/dm/components/_practice_card.scss
@@ -118,7 +118,7 @@
   }
 
   // styling for when there is no practice thumbnail
-  .dm-bg-gray-80 {
+  .practice-card-img-placeholder {
     height: 165px;
     background-color: color($theme-color-base-darkest);
     display: flex;

--- a/app/assets/stylesheets/dm/components/_practice_card.scss
+++ b/app/assets/stylesheets/dm/components/_practice_card.scss
@@ -83,7 +83,7 @@
   }
 
   .dm-practice-card-img-container {
-    max-height: 165px;
+    height: 165px;
     min-width: 100%;
     display: flex;
     justify-content: center;

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -51,9 +51,7 @@ class ApplicationController < ActionController::Base
       parser = URI::Parser.new
       parsed_path = parser.escape(path).gsub(/[\(\)\*]/) {|m| "%#{m.ord.to_s(16).upcase}" }
 
-      signed_url = Rails.cache.fetch("signed_url_#{parsed_path}", expires_in: 45.minutes) do
-        signer.presigned_get_url(object_key: parsed_path)
-      end
+      signed_url = signer.presigned_get_url(object_key: parsed_path)
 
       render plain: parsed_path.blank? ? parsed_path : signed_url
     end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -51,9 +51,7 @@ class ApplicationController < ActionController::Base
       parser = URI::Parser.new
       parsed_path = parser.escape(path).gsub(/[\(\)\*]/) {|m| "%#{m.ord.to_s(16).upcase}" }
 
-      signed_url = signer.presigned_get_url(object_key: parsed_path)
-
-      render plain: parsed_path.blank? ? parsed_path : signed_url
+      render plain: parsed_path.blank? ? parsed_path : signer.presigned_get_url(object_key: parsed_path)
     end
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -41,14 +41,21 @@ class ApplicationController < ActionController::Base
     if Rails.env.test?
       render plain: params[:url]
     else
-      s3_bucket = Aws::S3::Bucket.new(ENV['S3_BUCKET_NAME'])
-      signer = WT::S3Signer.for_s3_bucket(s3_bucket, expires_in: 2700)
+      signer = Rails.cache.fetch('s3_signer', expires_in: 45.minutes) do
+        s3_bucket = Aws::S3::Bucket.new(ENV['S3_BUCKET_NAME'])
+        WT::S3Signer.for_s3_bucket(s3_bucket, expires_in: 45.minutes)
+      end
+
       path = params[:path].sub('/', '')
       # any special characters not escaped by paperclip also need to be escaped
       parser = URI::Parser.new
       parsed_path = parser.escape(path).gsub(/[\(\)\*]/) {|m| "%#{m.ord.to_s(16).upcase}" }
 
-      render plain: parsed_path.blank? ? parsed_path : signer.presigned_get_url(object_key: parsed_path)
+      signed_url = Rails.cache.fetch("signed_url_#{parsed_path}", expires_in: 45.minutes) do
+        signer.presigned_get_url(object_key: parsed_path)
+      end
+
+      render plain: parsed_path.blank? ? parsed_path : signed_url
     end
   end
 

--- a/app/views/practices/_search.js.erb
+++ b/app/views/practices/_search.js.erb
@@ -97,7 +97,7 @@ function buildPracticeCard(result) {
 
     // Default card image
     var cardImagePlaceholder = 
-        '<div class="dm-bg-gray-80" data-practice-id="' + practiceId + '" data-practice-image="' + practiceImage + '"></div>'
+        '<div class="practice-card-img-placeholder" data-practice-id="' + practiceId + '" data-practice-image="' + practiceImage + '"></div>'
 
     var cardRetiredBanner = '';
     if (result.item.retired) {
@@ -136,11 +136,10 @@ function replacePlaceholderWithImage(imageUrl, practiceId, practiceName) {
                 '" src="' +
                 loadedImageSrc +
                 '" alt="' + practiceName + ' Marketplace Card Image" ' +
-                'width="247.5" height="165" ' +
                 'class="grid-row marketplace-card-img radius-top-sm">' +
                 
             '<div>';
-        $('.dm-bg-gray-80[data-practice-id="' + practiceId + '"]').html(imgTag);
+        $('.practice-card-img-placeholder[data-practice-id="' + practiceId + '"]').html(imgTag);
     });
 }
 
@@ -282,7 +281,7 @@ function searchPracticesPage() {
             // After the html for the card has been built and applied to the DOM, replace the image 'src' based on the signed url
             $('#search-results .dm-practice-card').each(function() {
                 // If either the 'src' or the hidden input are undefined, return an empty string
-                var imageSelector = $(this).find('.dm-bg-gray-80');
+                var imageSelector = $(this).find('.practice-card-img-placeholder');
                 var imagePracticeId = imageSelector ? imageSelector.attr('data-practice-id') : null;
                 var practiceImagePath = imageSelector ? imageSelector.attr('data-practice-image') : null;
                 var practiceName = $(this).find('.dm-practice-title').text();

--- a/app/views/practices/_search.js.erb
+++ b/app/views/practices/_search.js.erb
@@ -136,7 +136,9 @@ function replacePlaceholderWithImage(imageUrl, practiceId, practiceName) {
                 '" src="' +
                 loadedImageSrc +
                 '" alt="' + practiceName + ' Marketplace Card Image" ' +
+                'width="247.5" height="165" ' +
                 'class="grid-row marketplace-card-img radius-top-sm">' +
+                
             '<div>';
         $('.dm-bg-gray-80[data-practice-id="' + practiceId + '"]').html(imgTag);
     });

--- a/app/views/practices/_search.js.erb
+++ b/app/views/practices/_search.js.erb
@@ -115,12 +115,12 @@ function buildPracticeCard(result) {
                 '<div class="padding-105 height-card-mobile">' +
                     cardHeaderHtml +
                     '<p class="multiline-ellipses-1 font-sans-sm practice-card-tagline">' + result.item.tagline + '</p>' +
+                    '<div class="dm-practice-card-origin margin-bottom-2">' +
+                        '<span class="font-sans-2xs text-italic line-height-sans-3 dm-practice-card-origin-info">' +
+                            'Created in ' + result.item.date_initiated + ' ' + result.item.initiating_facility_name +
+                        '</span>' +
+                    '</div>' +
                 '</div>' +
-            '</div>' +
-            '<div class="dm-practice-card-origin margin-bottom-2">' +
-                '<span class="font-sans-2xs text-italic line-height-sans-3 dm-practice-card-origin-info">' +
-                    'Created in ' + result.item.date_initiated + ' ' + result.item.initiating_facility_name +
-                '</span>' +
             '</div>' +
         '</div>';
 

--- a/app/views/practices/_search.js.erb
+++ b/app/views/practices/_search.js.erb
@@ -86,65 +86,71 @@ function buildPracticeCard(result) {
     var cardHtml = '';
     var practiceImage = result.item.image;
     var practiceName = result.item.name;
-    var practiceLinkClasses = practiceImage ? 'dm-practice-link' : 'text-white text-no-underline';
-    var cardHeaderClasses = practiceImage ? ' margin-top-0 margin-bottom-2' : ' margin-x-2 margin-y-4';
-    var cardImageHtml =
-        '<div class="dm-practice-card-img-container">' +
-        '<input type="hidden" value="' + practiceImage + '"/>' +
-        '<img ' +
-          'data-resource-id="' + result.item.id + '" ' +
-          'alt="' + practiceName + ' Marketplace Card Image" ' +
-          'class="grid-row marketplace-card-img radius-top-sm" ' +
-          'src="' + result.item.placeholder_image + '">';
-    var retiredBanner = '<div class="dm-practice-retired-banner"><h5>Retired</h5></div>';
-
-    if (result.item.retired) {
-        cardImageHtml += retiredBanner;
-    }
+    var practiceId = result.item.id;
 
     var cardHeaderHtml =
-        '<h3 class="text-normal font-sans-lg multiline-ellipses-2' + cardHeaderClasses + '">' +
-        '<a href="/innovations/' + result.item.slug + '" aria-label="Go to ' + result.item.name + '" class="' + practiceLinkClasses +'">' +
-        '<span class="dm-practice-title">' +
-        practiceName +
-        '</span>' +
-        '</a>' +
+        '<h3 class="text-normal font-sans-lg multiline-ellipses-2 margin-top-0 margin-bottom-2">' +
+            '<span class="dm-practice-title">' +
+                practiceName +
+            '</span>' +
         '</h3>';
 
-    cardImageHtml += '</div>';
+    // Default card image
+    var cardImagePlaceholder = 
+        '<div class="dm-bg-gray-80" data-practice-id="' + practiceId + '" data-practice-image="' + practiceImage + '"></div>'
 
-    var noCardImageHtml =
-        '<div class="dm-bg-gray-80">' +
-        cardHeaderHtml;
-
+    var cardRetiredBanner = '';
     if (result.item.retired) {
-        noCardImageHtml += retiredBanner;
+        cardRetiredBanner = '<div class="dm-practice-retired-banner"><h5>Retired</h5></div>';
     }
-
-    noCardImageHtml += '</div>';
-    var cardImage = practiceImage ? cardImageHtml : noCardImageHtml;
-    var assignPracticeHeader = practiceImage ? cardHeaderHtml : '';
+    
 
     cardHtml +=
         '<div class="dm-practice-card padding-bottom-3 tablet:grid-col-6 desktop:grid-col-4 position-relative">' +
-        '<a href="/innovations/' + result.item.slug + '" tabindex="-1" aria-hidden="true" class="dm-practice-link-aria-hidden position-absolute top-0 bottom-3 left-105 right-105 z-100"></a>' +
-        '<div class=" dm-practice-card-container">' +
-        cardImage +
-        '<div class="padding-105 height-card-mobile">' +
-        assignPracticeHeader +
-        '<div>' +
-        '<p class="multiline-ellipses-1 font-sans-sm practice-card-tagline">' + result.item.tagline + '</p>' +
-        '</div>' +
-        '<div class="dm-practice-card-origin margin-bottom-2">' +
-        '<span class="font-sans-2xs text-italic line-height-sans-3 dm-practice-card-origin-info">' +
-        'Created in ' + result.item.date_initiated + ' ' + result.item.initiating_facility_name +
-        '</span>' +
-        '</div>' +
-        '</div>' +
-        '</div>' +
+            '<a href="/innovations/' + result.item.slug + 
+                '" tabindex="-1" aria-hidden="true" class="dm-practice-link-aria-hidden position-absolute top-0 bottom-3 left-105 right-105 z-100"></a>' +
+            '<div class="dm-practice-card-container">' +
+                cardImagePlaceholder +
+                cardRetiredBanner +
+                '<div class="padding-105 height-card-mobile">' +
+                    cardHeaderHtml +
+                    '<p class="multiline-ellipses-1 font-sans-sm practice-card-tagline">' + result.item.tagline + '</p>' +
+                '</div>' +
+            '</div>' +
+            '<div class="dm-practice-card-origin margin-bottom-2">' +
+                '<span class="font-sans-2xs text-italic line-height-sans-3 dm-practice-card-origin-info">' +
+                    'Created in ' + result.item.date_initiated + ' ' + result.item.initiating_facility_name +
+                '</span>' +
+            '</div>' +
         '</div>';
 
     return cardHtml;
+}
+
+function replacePlaceholderWithImage(imageUrl, practiceId, practiceName) {
+    loadImage(imageUrl, function(loadedImageSrc) {
+        var imgTag =
+            '<div class="dm-practice-card-img-container">' +
+                '<img data-resource-id="' +
+                practiceId +
+                '" src="' +
+                loadedImageSrc +
+                '" alt="' + practiceName + ' Marketplace Card Image" ' +
+                'class="grid-row marketplace-card-img radius-top-sm">' +
+            '<div>';
+        $('.dm-bg-gray-80[data-practice-id="' + practiceId + '"]').html(imgTag);
+    });
+}
+
+function loadImage(imageSrc, callback) {
+    var img = new Image();
+    img.onload = function() {
+        callback(imageSrc);
+    };
+    img.onerror = function() {
+        console.error("Error loading image: " + imageSrc);
+    };
+    img.src = imageSrc;
 }
 
 function showSpinner() {
@@ -242,8 +248,9 @@ function searchPracticesPage() {
         var resultsArray = [];
         var finalResults = '';
         tmpResults.sort(sortByRetired).forEach(function (result) {
-            finalResults += buildPracticeCard(result);
-            resultsArray.push(buildPracticeCard(result));
+            const practiceCard = buildPracticeCard(result)
+            finalResults += practiceCard;
+            resultsArray.push(practiceCard);
 
             '<!-- Uncomment to show Fuse.js diagnostics -->' +
             '<!--' +
@@ -273,17 +280,16 @@ function searchPracticesPage() {
             // After the html for the card has been built and applied to the DOM, replace the image 'src' based on the signed url
             $('#search-results .dm-practice-card').each(function() {
                 // If either the 'src' or the hidden input are undefined, return an empty string
-                var practiceImagePath = $(this).find('input').val() || '';
-                var practiceImageUrl = $(this).find('img').attr('src') || '';
-                var imageSelector = $(this).find('img');
-                var imagePracticeId = imageSelector ? imageSelector.attr('data-resource-id') : null;
-
-                if (imagePracticeId) {
+                var imageSelector = $(this).find('.dm-bg-gray-80');
+                var imagePracticeId = imageSelector ? imageSelector.attr('data-practice-id') : null;
+                var practiceImagePath = imageSelector ? imageSelector.attr('data-practice-image') : null;
+                var practiceName = $(this).find('.dm-practice-title').text();
+                if (imagePracticeId && practiceImagePath) {
                     fetchSignedResource(
                         practiceImagePath,
-                        practiceImageUrl,
-                        `img[data-resource-id="${imagePracticeId}"]`
-                    );
+                    ).then(signedImgUrl => {
+                        replacePlaceholderWithImage(signedImgUrl, imagePracticeId, practiceName)
+                    });
                 }
             });
 

--- a/app/views/shared/_practice_card.html.erb
+++ b/app/views/shared/_practice_card.html.erb
@@ -32,7 +32,7 @@
         <% end %>
       </div>
     <% else %>
-      <div class="dm-bg-gray-80">
+      <div class="practice-card-img-placeholder">
         <h3 class="text-normal font-sans-lg multiline-ellipses-2 margin-x-2 margin-y-4">
           <a href="<%= practice_path(practice) %>" aria-label="Go to <%= practice.name %>" class="<%= practice_link_classes %>">
             <span class="dm-practice-title">

--- a/lib/modules/practice_utils.rb
+++ b/lib/modules/practice_utils.rb
@@ -4,7 +4,6 @@ module PracticeUtils
 
     practices.each do |practice|
       modified_practice = practice.as_json
-      modified_practice[:placeholder_image] = practice.main_display_image? ? practice.main_display_image_s3_presigned_url(:thumb) : ''
       modified_practice[:image] = practice.main_display_image&.path || ''
       if current_user.present?
         modified_practice[:user_favorited] = current_user.favorite_practice_ids.include?(practice[:id])

--- a/spec/lib/practice_utils_spec.rb
+++ b/spec/lib/practice_utils_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe PracticeUtils do
       expect(
         PracticeUtils.practices_json(Practice.all)
       ).to include(
+             @practice.id.to_s,
              @practice.name,
              @practice.slug,
              @practice.main_display_image.path, # custom 'image' key

--- a/spec/lib/practice_utils_spec.rb
+++ b/spec/lib/practice_utils_spec.rb
@@ -25,7 +25,6 @@ RSpec.describe PracticeUtils do
       ).to include(
              @practice.name,
              @practice.slug,
-             @practice.main_display_image.url, # custom 'placeholder_image' key
              @practice.main_display_image.path, # custom 'image' key
           )
       # Without a current_user


### PR DESCRIPTION
JIRA issue link
https://agile6.atlassian.net/browse/DM-4136

## Description - what does this code do?

The main point of these changes is to implement a `placeholder` for practice card images on the search page. 

Previously, there was a redundant image rendering happening in which the initial response for the `/search` page included signed S3 urls that were obtained by the server. Those urls were inserted into the practice cards' html and later on in within the same JS code were replaced by a different signed S2 url that were fetched by the client from the server (which in turn was requesting them from S3).

These changes remove the signed s3 urls from the initial response, render the practice cards with a simple solid color background in the image container, sends fetch requests to the server for the signed urls, and replaces the placeholder with an image tag containing the signed url for each image.

Other changes of note are the implementation of caching for the initialized S3 object that obtains the signed urls in the `#signed_resource` action, as well as simplification of the `fetchSignedResource` function.

## Testing done - how did you test it/steps on how can another person can test it 
1. Locally, sign in as admin and visit the '/search' page, verify the pics load.
2. To see a practice utilize the placeholder without replacing with an s3 image open rails console and run:

```
practice = Practice.find(46)
practice.main_display_image = nil
practice.save
```
3. reload the '/search' page and verify the results all render with the 'VHA Rapid Naloxone' practice rendering with just the placeholder background (see screenshot below)
4. For the change to `fetchSignedResource` add a downloadable file to a pagebuilder page, load that page and verify the download link works as expected.

## Screenshots, Gifs, Videos from application (if applicable)
![Screenshot 2023-08-31 at 5 08 00 PM](https://github.com/department-of-veterans-affairs/diffusion-marketplace/assets/65036872/17e7f608-d27a-456e-b969-eb5c643c2c39)


## Link to mock-ups/mock ups (image file if you have it) (if applicable)


## Acceptance criteria
- [ ]

## Definition of done
- [x] Unit tests written (if applicable)
- [ ] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating JIRA issue
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs