### PR TITLE
dm-4157 remove unnecessary eager loading from #origin_display_name

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -51,7 +51,7 @@ module ApplicationHelper
     if practice.initiating_facility_type?
       if practice.facility? && practice.practice_origin_facilities.present?
         fac_type = Practice.initiating_facility_types[practice.initiating_facility_type]
-        locs = practice.practice_origin_facilities.includes([:va_facility, :clinical_resource_hub]).where(facility_type: fac_type)
+        locs = practice.practice_origin_facilities.includes([:va_facility]).where(facility_type: fac_type)
         facility_names = String.new
         locs.each_with_index do |loc, index|
           has_va_facility = loc.va_facility.present?


### PR DESCRIPTION
### JIRA issue link
https://agile6.atlassian.net/browse/DM-4157

## Description - what does this code do?

edits query in `#origin_display_name`, removes eager loading of `:clinical_resource_hub association`

## Testing done - how did you test it/steps on how can another person can test it 
Verify the search page loads locally as expected, verify the warning does not appear in the dev tools console

## Screenshots, Gifs, Videos from application (if applicable)
<img width="504" alt="Screenshot 2023-09-07 at 1 37 53 PM" src="https://github.com/department-of-veterans-affairs/diffusion-marketplace/assets/65036872/a69719ff-32cb-463f-9a97-adb9069f43fe">


## Link to mock-ups/mock ups (image file if you have it) (if applicable)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Unit tests written (if applicable)
- [ ] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating JIRA issue
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs