### PR TITLE
Preload google fonts

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -35,7 +35,8 @@
     <%= javascript_include_tag '_terms_and_conditions', 'data-turbolinks-track': 'reload' %>
 
     <%= javascript_include_tag '_header_utilities', 'data-turbolinks-track': 'false' %>
-    <link href="https://fonts.googleapis.com/css?family=Open+Sans&display=swap" rel="preload" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css?family=Open+Sans&display=swap" rel="preload" as="style">
+    <link href="https://fonts.googleapis.com/css?family=Open+Sans&display=swap" rel="stylesheet">
     <meta name="turbolinks-cache-control" content="no-preview">
     <% if @reload_turbolinks %>
       <meta name="turbolinks-visit-control" content="reload">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -35,7 +35,7 @@
     <%= javascript_include_tag '_terms_and_conditions', 'data-turbolinks-track': 'reload' %>
 
     <%= javascript_include_tag '_header_utilities', 'data-turbolinks-track': 'false' %>
-    <link href="https://fonts.googleapis.com/css?family=Open+Sans&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css?family=Open+Sans&display=swap" rel="preload" rel="stylesheet">
     <meta name="turbolinks-cache-control" content="no-preview">
     <% if @reload_turbolinks %>
       <meta name="turbolinks-visit-control" content="reload">


### PR DESCRIPTION
### JIRA issue link


## Description - what does this code do?
Adds preload for google font assets fetch in `application.html.erb`

Fonts, especially those from external sources like Google Fonts, can be render-blocking. When a browser encounters a font it needs to load from an external source, it might delay the rendering of the text until that font is loaded, leading to what's often called the "Flash of Invisible Text" (or FOIT). This means users might see blank spaces where text should be until the font is loaded.

By preloading the font, we're giving the browser a hint to fetch this resource earlier in the loading process. Even though the actual time it takes to fully load the page might not change significantly, the perceived performance can improve since crucial text content can be rendered sooner, making the site feel faster to users.

## Testing done - how did you test it/steps on how can another person can test it 
load a few pages like landing and /search, verify everything is working normally, run a lighthouse report and verify the google fonts call does not appear under the "Eliminate render-blocking resources" tab (see screenshots)

## Screenshots, Gifs, Videos from application (if applicable)
current:
<img width="779" alt="Screenshot 2023-09-07 at 11 10 29 AM" src="https://github.com/department-of-veterans-affairs/diffusion-marketplace/assets/65036872/be63859c-1273-4ea8-addc-e22ea6410b11">

fixed:
<img width="782" alt="Screenshot 2023-09-07 at 11 11 54 AM" src="https://github.com/department-of-veterans-affairs/diffusion-marketplace/assets/65036872/f470bf15-f21b-430c-b26b-f9ca86c28dd9">


## Link to mock-ups/mock ups (image file if you have it) (if applicable)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Unit tests written (if applicable)
- [ ] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating JIRA issue
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs