### PR TITLE
dm-4156 add counter cache to practices

### DIFF
--- a/app/models/diffusion_history.rb
+++ b/app/models/diffusion_history.rb
@@ -2,6 +2,7 @@ class DiffusionHistory < ApplicationRecord
   belongs_to :practice
   belongs_to :va_facility, optional: true
   belongs_to :clinical_resource_hub, optional: true
+  belongs_to :practice, counter_cache: true
 
 
   validates_with DiffusionHistoryValidator, on: [:create, :update] # check CRH exists or facility exists

--- a/db/migrate/20230907210242_add_diffusion_histories_count_to_practices.rb
+++ b/db/migrate/20230907210242_add_diffusion_histories_count_to_practices.rb
@@ -1,0 +1,5 @@
+class AddDiffusionHistoriesCountToPractices < ActiveRecord::Migration[6.0]
+  def change
+    add_column :practices, :diffusion_histories_count, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_07_28_213402) do
+ActiveRecord::Schema.define(version: 2023_09_07_210242) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -1139,6 +1139,7 @@ ActiveRecord::Schema.define(version: 2023_07_28_213402) do
     t.datetime "highlight_attachment_updated_at"
     t.boolean "is_public", default: false
     t.text "main_display_image_alt_text"
+    t.integer "diffusion_histories_count", default: 0
     t.index ["slug"], name: "index_practices_on_slug", unique: true
     t.index ["user_id"], name: "index_practices_on_user_id"
   end

--- a/lib/tasks/dm.rake
+++ b/lib/tasks/dm.rake
@@ -32,6 +32,7 @@ namespace :dm do
     Rake::Task['documentation:port_publications_to_practice_resources'].execute
     Rake::Task['risk_and_mitigation:remove_unpaired_risks_and_mitigation'].execute
     Rake::Task['practice_editors:add_practice_owners_to_practice_editors'].execute
+    Rake::Task['practice:update_diffusion_histories_counts'].execute
   end
 
   # rails dm:reset_up

--- a/lib/tasks/update_counters.rake
+++ b/lib/tasks/update_counters.rake
@@ -1,0 +1,8 @@
+namespace :practice do
+  desc "Update diffusion histories counts"
+  task update_diffusion_histories_counts: :environment do
+    Practice.find_each do |practice|
+      Practice.reset_counters(practice.id, :diffusion_histories)
+    end
+  end
+end

--- a/lib/tasks/update_counters.rake
+++ b/lib/tasks/update_counters.rake
@@ -3,6 +3,9 @@ namespace :practice do
   task update_diffusion_histories_counts: :environment do
     Practice.find_each do |practice|
       Practice.reset_counters(practice.id, :diffusion_histories)
+
+      updated_practice = Practice.find(practice.id)
+      puts "Practice ID #{updated_practice.id} - Updated diffusion histories count: #{updated_practice.diffusion_histories_count}"
     end
   end
 end

--- a/spec/models/practice_spec.rb
+++ b/spec/models/practice_spec.rb
@@ -52,4 +52,43 @@ RSpec.describe Practice, type: :model do
     it { should have_many(:practice_emails) }
     it { should have_many(:practice_editors) }
   end
+
+  before do
+    user = User.create!(
+      email: 'mugurama.kensei@va.gov',
+      password: 'Password123',
+      password_confirmation: 'Password123',
+    )
+    @practice = Practice.create!(
+      name: 'A public practice',
+      slug: 'a-public-practice',
+      main_display_image: File.new(File.join(Rails.root, '/spec/assets/charmander.png')),
+      user: user
+    )
+    visn_1 = Visn.create!(name: 'VISN 1', number: 1)
+    @fac_1 = VaFacility.create!(
+      visn: visn_1,
+      station_number: "402GA",
+      official_station_name: "Caribou VA Clinic",
+      common_name: "Caribou",
+      latitude: "44.2802701",
+      longitude: "-69.70413586",
+      street_address_state: "ME",
+      station_phone_number: "207-623-2123 x",
+      fy17_parent_station_complexity_level: "1c-High Complexity"
+    )
+  end
+
+  it "increments counter cache on create" do
+    expect {
+      @practice.diffusion_histories.create!(practice: @practice, va_facility: @fac_1)
+    }.to change { @practice.reload.diffusion_histories_count }.by(1)
+  end
+
+  it "decrements counter cache on destroy" do
+    diffusion_history = @practice.diffusion_histories.create!(practice: @practice, va_facility: @fac_1)
+    expect {
+      diffusion_history.destroy
+    }.to change { @practice.reload.diffusion_histories_count }.by(-1)
+  end
 end


### PR DESCRIPTION
### JIRA issue link
https://agile6.atlassian.net/browse/DM-4156

## Description - what does this code do?
Adds counter cache column to `practices` to alleviate N+1 query identified by bullet gem (see jira ticket for details)

## Testing done - how did you test it/steps on how can another person can test it 
1. run the pending migration
2. run the rake task: `rake practice:update_diffusion_histories_counts`
3. run the app, login as admin, load the search page, verify expected render / functionality
4. verify the bullet warning no longer appears in the console (see screenshot)

## Screenshots, Gifs, Videos from application (if applicable)

before fix:
<img width="322" alt="Screenshot 2023-09-07 at 3 30 10 PM" src="https://github.com/department-of-veterans-affairs/diffusion-marketplace/assets/65036872/3ae8c6f5-70ee-4625-b730-a2b96010f17c">


## Link to mock-ups/mock ups (image file if you have it) (if applicable)


## Acceptance criteria
- [ ]

## Definition of done
- [x] Unit tests written (if applicable)
- [ ] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating JIRA issue
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs