### PR TITLE
dm-4123 defer render-blocking js tags

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -13,17 +13,17 @@
     <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'false' %>
     <%= javascript_include_tag 'shared/_utilityFunctions', 'data-turbolinks-track': 'reload', defer: true %>
     <% if @include_google_maps %>
-      <%= javascript_include_tag "https://maps.googleapis.com/maps/api/js?key=#{ENV['GOOGLE_API_KEY']}&callback=Function.prototype", 'data-turbolinks-track': 'false' %>
-      <%= javascript_include_tag "https://cdn.jsdelivr.net/gh/mahnunchik/markerclustererplus@master/dist/markerclusterer.min.js", 'data-turbolinks-track': 'false' %>
-      <%= javascript_include_tag "https://cdn.jsdelivr.net/gh/printercu/google-maps-utility-library-v3-read-only@master/infobox/src/infobox_packed.js", 'data-turbolinks-track': 'false' %>
-      <%= javascript_include_tag "https://cdn.jsdelivr.net/gh/googlemaps/js-rich-marker@gh-pages/src/richmarker-compiled.js", 'data-turbolinks-track': 'false' %>
+      <%= javascript_include_tag "https://maps.googleapis.com/maps/api/js?key=#{ENV['GOOGLE_API_KEY']}&callback=Function.prototype", 'data-turbolinks-track': 'false', defer: true %>
+      <%= javascript_include_tag "https://cdn.jsdelivr.net/gh/mahnunchik/markerclustererplus@master/dist/markerclusterer.min.js", 'data-turbolinks-track': 'false', defer: true %>
+      <%= javascript_include_tag "https://cdn.jsdelivr.net/gh/printercu/google-maps-utility-library-v3-read-only@master/infobox/src/infobox_packed.js", 'data-turbolinks-track': 'false', defer: true %>
+      <%= javascript_include_tag "https://cdn.jsdelivr.net/gh/googlemaps/js-rich-marker@gh-pages/src/richmarker-compiled.js", 'data-turbolinks-track': 'false', defer: true %>
     <% end %>
     <%= javascript_include_tag 'application', 'data-turbolinks-track': 'false' %>
     <%= javascript_tag 'data-turbolinks-track': 'false' do %>
       <%= render partial: 'layouts/ahoy_event_tracking', formats: [:js] %>
     <% end %>
     <% if current_user.present? %>
-      <%= javascript_include_tag 'session_timeout_poller.js', 'data-turbolinks-track': 'false' %>
+      <%= javascript_include_tag 'session_timeout_poller.js', 'data-turbolinks-track': 'false', defer: true %>
       <%= javascript_tag 'data-turbolinks-track': 'false' do %>
         var forceModal = <%= @force_terms_and_conditions_modal %>;
       <% end %>
@@ -35,6 +35,7 @@
     <%= javascript_include_tag '_terms_and_conditions', 'data-turbolinks-track': 'reload', defer: true %>
 
     <%= javascript_include_tag '_header_utilities', 'data-turbolinks-track': 'false', defer: true %>
+    <link href="https://fonts.googleapis.com/css?family=Open+Sans&display=swap" rel="preload" as="style">
     <link href="https://fonts.googleapis.com/css?family=Open+Sans&display=swap" rel="stylesheet">
     <meta name="turbolinks-cache-control" content="no-preview">
     <% if @reload_turbolinks %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,7 +11,7 @@
     <%= csp_meta_tag %>
     <meta name="viewport" content= "width=device-width, initial-scale=1, minimum-scale=1">
     <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'false' %>
-    <%= javascript_include_tag 'shared/_utilityFunctions', 'data-turbolinks-track': 'reload' %>
+    <%= javascript_include_tag 'shared/_utilityFunctions', 'data-turbolinks-track': 'reload', defer: true %>
     <% if @include_google_maps %>
       <%= javascript_include_tag "https://maps.googleapis.com/maps/api/js?key=#{ENV['GOOGLE_API_KEY']}&callback=Function.prototype", 'data-turbolinks-track': 'false' %>
       <%= javascript_include_tag "https://cdn.jsdelivr.net/gh/mahnunchik/markerclustererplus@master/dist/markerclusterer.min.js", 'data-turbolinks-track': 'false' %>
@@ -27,15 +27,14 @@
       <%= javascript_tag 'data-turbolinks-track': 'false' do %>
         var forceModal = <%= @force_terms_and_conditions_modal %>;
       <% end %>
-      <%= javascript_include_tag '_terms_and_conditions', 'data-turbolinks-track': 'false' %>
+      <%= javascript_include_tag '_terms_and_conditions', 'data-turbolinks-track': 'false', defer: true %>
     <% end %>
     <%= javascript_tag 'data-turbolinks-track': 'reload' do %>
       var forceModal = <%= @force_terms_and_conditions_modal %>;
     <% end %>
-    <%= javascript_include_tag '_terms_and_conditions', 'data-turbolinks-track': 'reload' %>
+    <%= javascript_include_tag '_terms_and_conditions', 'data-turbolinks-track': 'reload', defer: true %>
 
-    <%= javascript_include_tag '_header_utilities', 'data-turbolinks-track': 'false' %>
-    <link href="https://fonts.googleapis.com/css?family=Open+Sans&display=swap" rel="preload" as="style">
+    <%= javascript_include_tag '_header_utilities', 'data-turbolinks-track': 'false', defer: true %>
     <link href="https://fonts.googleapis.com/css?family=Open+Sans&display=swap" rel="stylesheet">
     <meta name="turbolinks-cache-control" content="no-preview">
     <% if @reload_turbolinks %>

--- a/app/views/practices/search.html.erb
+++ b/app/views/practices/search.html.erb
@@ -2,8 +2,8 @@
 <% provide :body_classes, 'bg-gray-2' %>
 <% provide :footer_classes, 'bg-gray-2' %>
 <% provide :head_tags do %>
-  <%= javascript_include_tag '_practice_card_utilities', 'data-turbolinks-track': 'false' %>
-  <%= javascript_include_tag 'shared/_signed_resource', 'data-turbolinks-track': 'false' %>
+  <%= javascript_include_tag '_practice_card_utilities', 'data-turbolinks-track': 'false', defer: true %>
+  <%= javascript_include_tag 'shared/_signed_resource', 'data-turbolinks-track': 'false', defer: true %>
   <%= javascript_tag 'data-turbolinks-track': 'false' do %>
     <%= render partial: 'search', formats: [:js] %>
   <% end %>

--- a/app/views/shared/_messages.erb
+++ b/app/views/shared/_messages.erb
@@ -1,5 +1,5 @@
 <% provide :head_tags do %>
-  <%= javascript_include_tag '_alert_message_utilities', 'data-turbolinks-track': 'false' %>
+  <%= javascript_include_tag '_alert_message_utilities', 'data-turbolinks-track': 'false', defer: true %>
 <% end %>
 
 <% if flash.keys.present? %>


### PR DESCRIPTION
### JIRA issue link
https://agile6.atlassian.net/browse/DM-4123

## Description - what does this code do?
Adds `defer` attributes to js scripts to prevent blocking initial page render, `defer ` is generally preferred over `async` so that the scripts run in their intended order.

## Testing done - how did you test it/steps on how can another person can test it

Various pieces of functionality that the deferred scripts enable should be checked:
 1. Save and publish button in practice editor works, leave a required field empty to verify the modal that pops up upon clicking the "Save and Publish" button appears, does not flicker, closes.
 2. Practice editor header does not flicker.
 3. Terms and conditions modal does not flicker, to verify sign in as user with `accepted_terms` set to false, modal closes
 4. Crisis line modal works / doesn’t flicker (top right of page)
 5. Gmaps appear and markers have aria labels and title (as per https://github.com/department-of-veterans-affairs/diffusion-marketplace/pull/560)

## Screenshots, Gifs, Videos from application (if applicable)
before:
<img width="820" alt="Screenshot 2023-09-13 at 10 49 16 AM" src="https://github.com/department-of-veterans-affairs/diffusion-marketplace/assets/65036872/b2c17746-3258-4005-b72e-214eb008bf46">

after:
<img width="839" alt="Screenshot 2023-09-13 at 10 47 42 AM" src="https://github.com/department-of-veterans-affairs/diffusion-marketplace/assets/65036872/aae42b83-4a79-4447-85b4-8cf68b6c8722">

## Link to mock-ups/mock ups (image file if you have it) (if applicable)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Unit tests written (if applicable)
- [ ] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating JIRA issue
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs