### PR TITLE
Add gmaps inst var to facilities show

### DIFF
--- a/app/controllers/va_facilities_controller.rb
+++ b/app/controllers/va_facilities_controller.rb
@@ -40,6 +40,7 @@ class VaFacilitiesController < ApplicationController
   def show
     station_number = @va_facility.station_number
     # google maps implementation
+    @include_google_maps = true
     @va_facility_marker = Gmaps4rails.build_markers(@va_facility) do |facility, marker|
       marker.lat facility.latitude
       marker.lng facility.longitude

--- a/app/views/va_facilities/map/_facility_map.html.erb
+++ b/app/views/va_facilities/map/_facility_map.html.erb
@@ -1,4 +1,4 @@
-<% if ENV['GOOGLE_API_KEY'].present? %>
+<% if ENV['GOOGLE_API_KEY'].present? || ENV['GOOGLE_TEST_API_KEY'].present? %>
   <% provide :head_tags do %>
     <%= javascript_tag 'data-turbolinks-track': 'reload' do %>
       var mapData = <%= raw @va_facility_marker.to_json %>;

--- a/spec/features/va_facility_spec.rb
+++ b/spec/features/va_facility_spec.rb
@@ -233,7 +233,7 @@ describe 'VA facility pages', type: :feature do
       visit '/facilities/a-first-facility-test-common-name'
       sleep 0.5
 
-      expect(page).to have_selector('#va_facility_map', visible: true)
+      expect(page).to have_selector('.gm-style', visible: true)
     end
 
     context 'when searching for adopted innovations' do

--- a/spec/features/va_facility_spec.rb
+++ b/spec/features/va_facility_spec.rb
@@ -227,6 +227,15 @@ describe 'VA facility pages', type: :feature do
       expect(page).to have_current_path(va_facility_path(@facility_1))
     end
 
+    it 'should render a gmap' do
+      login_and_visit_facility_page
+      find(:css, '.va_facilities')
+      visit '/facilities/a-first-facility-test-common-name'
+      sleep 0.5
+
+      expect(page).to have_selector('#va_facility_map', visible: true)
+    end
+
     context 'when searching for adopted innovations' do
       it 'should only display search results for practices that are public-facing if the user is a guest' do
         check_search_results_as_guest_user('#dm-facility-adopted-practice-search')


### PR DESCRIPTION
### JIRA issue link


## Description - what does this code do?
Adds `include_google_maps` instance var to `#show` in `VaFacilitiesController` in order to allow rendering of gmaps. 

The requirement for the instance variable was added recently with https://github.com/department-of-veterans-affairs/diffusion-marketplace/pull/679, the inclusion of the variable for this controller action was an oversight due to lack of testing and my own lack of familiarity with the app. Test added for posterity.

## Testing done - how did you test it/steps on how can another person can test it 
run the app locally and verify the map renders under facility show pages.

## Screenshots, Gifs, Videos from application (if applicable)
![Screenshot 2023-09-19 at 2 54 54 PM](https://github.com/department-of-veterans-affairs/diffusion-marketplace/assets/65036872/49a3d63f-8a80-4859-968a-ae7055d97449)

## Link to mock-ups/mock ups (image file if you have it) (if applicable)


## Acceptance criteria
- [ ]

## Definition of done
- [x] Unit tests written (if applicable)
- [ ] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating JIRA issue
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs