### PR TITLE
Bump up clashing dependencies in uswds-rails

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -102,7 +102,7 @@ gem 'ffi'
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 gem 'jquery-rails'
 gem 'jquery-ui-rails'
-gem 'uswds-rails', github: 'camillevilla/uswds-rails', branch: 'dm-rails-6-1'
+gem 'uswds-rails', github: 'agilesix/uswds-rails', ref: '52da189'
 
 gem 'activerecord-nulldb-adapter'
 gem 'acts_as_list'

--- a/Gemfile
+++ b/Gemfile
@@ -102,7 +102,7 @@ gem 'ffi'
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 gem 'jquery-rails'
 gem 'jquery-ui-rails'
-gem 'uswds-rails', github: 'agilesix/uswds-rails', ref: 'f8a3658'
+gem 'uswds-rails', github: 'camillevilla/uswds-rails', branch: 'dm-rails-6-1'
 
 gem 'activerecord-nulldb-adapter'
 gem 'acts_as_list'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -34,7 +34,7 @@ GIT
 
 GIT
   remote: https://github.com/camillevilla/uswds-rails.git
-  revision: 584ed53c81aa077c592aae37a5b28e96bd55f177
+  revision: 8cc7ed1aae26aa07b601fe9704908818713e6a59
   branch: dm-rails-6-1
   specs:
     uswds-rails (2.11.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -33,9 +33,9 @@ GIT
       httparty (~> 0.15)
 
 GIT
-  remote: https://github.com/camillevilla/uswds-rails.git
-  revision: 8cc7ed1aae26aa07b601fe9704908818713e6a59
-  branch: dm-rails-6-1
+  remote: https://github.com/agilesix/uswds-rails.git
+  revision: 52da189fd4f9b84f93387e611745ed327597ab59
+  ref: 52da189
   specs:
     uswds-rails (2.11.1)
       bourbon

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -33,13 +33,13 @@ GIT
       httparty (~> 0.15)
 
 GIT
-  remote: https://github.com/agilesix/uswds-rails.git
-  revision: f8a3658be91cf1e835df39575eb4a3fe09db16e3
-  ref: f8a3658
+  remote: https://github.com/camillevilla/uswds-rails.git
+  revision: 584ed53c81aa077c592aae37a5b28e96bd55f177
+  branch: dm-rails-6-1
   specs:
     uswds-rails (2.11.1)
-      bourbon (= 4.2.7)
-      neat (= 1.8)
+      bourbon
+      neat
       rails-assets-normalize-css (= 3.0.3)
 
 GEM
@@ -179,8 +179,7 @@ GEM
     bindex (0.8.1)
     bootsnap (1.4.6)
       msgpack (~> 1.0)
-    bourbon (4.2.7)
-      sass (~> 3.4)
+    bourbon (6.0.0)
       thor (~> 0.19)
     brakeman (5.0.2)
     builder (3.2.4)
@@ -362,8 +361,7 @@ GEM
     msgpack (1.5.3)
     multi_xml (0.6.0)
     naturalsorter (3.0.22)
-    neat (1.8.0)
-      sass (>= 3.3)
+    neat (4.0.0)
       thor (~> 0.19)
     nested_form (0.3.2)
     net-http-digest_auth (1.4.1)
@@ -669,11 +667,6 @@ GEM
     rubyzip (2.3.2)
     safely_block (0.3.0)
       errbase (>= 0.1.1)
-    sass (3.7.4)
-      sass-listen (~> 4.0.0)
-    sass-listen (4.0.0)
-      rb-fsevent (~> 0.9, >= 0.9.4)
-      rb-inotify (~> 0.9, >= 0.9.7)
     sass-rails (6.0.0)
       sassc-rails (~> 2.1, >= 2.1.1)
     sassc (2.4.0)

--- a/app/assets/stylesheets/dm_uswds/theme/_uswds-theme-general.scss
+++ b/app/assets/stylesheets/dm_uswds/theme/_uswds-theme-general.scss
@@ -37,6 +37,7 @@ mixins use non-standard tokens.
 */
 
 $theme-show-compile-warnings: true;
+$theme-show-notifications: false;
 
 /*
 ----------------------------------------


### PR DESCRIPTION
### JIRA issue link
Part of [DM-3774](https://agile6.atlassian.net/browse/DM-3771)

## Description - what does this code do?
- Uses a version of uswds-rails with `bourbon` and `neat` dependencies unpinned in the upstream gem (see [branch](https://github.com/agilesix/uswds-rails/compare/dm-ruby-2.7-uswds-2.11.1...camillevilla:uswds-rails:dm-rails-6-1?expand=1) 
  - [ ] make sure this branch gets pushed to [agilesix/uswds-rails](https://github.com/agilesix/uswds-rails/)

## Testing done - how did you test it/steps on how can another person can test it 


## Screenshots, Gifs, Videos from application (if applicable)


## Link to mock-ups/mock ups (image file if you have it) (if applicable)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Unit tests written (if applicable)
- [ ] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating JIRA issue
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs