### PR TITLE
Remove JS for "Return to top" links and replace with HTML-based implementation

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -36,7 +36,6 @@
 //= require timeago
 //= require replies
 //= require gmaps/google
-//= require return-to-top
 //= require comment
 //= require richmarker
 //= require infowindow

--- a/app/assets/javascripts/return-to-top.es6
+++ b/app/assets/javascripts/return-to-top.es6
@@ -1,6 +1,0 @@
-$(document).on('turbolinks:load', () => {
-    $('.dm-return-to-top').on('click', () => {
-        $(window).animate({
-            scrollTop: 0}, 0);
-    });
-});

--- a/app/views/practices/shared/_practice_editor_footer.html.erb
+++ b/app/views/practices/shared/_practice_editor_footer.html.erb
@@ -30,7 +30,7 @@
 <footer class="<%= yield(:footer_classes) %>">
   <%# only show return to top on mobile views, practice show page and long practice editor pages (per design 9/21/21) %>
   <div class="grid-container usa-footer__return-to-top<%= params[:controller] === 'practices' && NavigationHelper::RETURN_TO_TOP_PAGES.include?(params[:action]) ? ' desktop:display-block' : ' tablet:display-none' %>">
-    <button class="dm-button--unstyled-primary dm-return-to-top width-auto">Return to top</button>
+    <a href="#dm-practice-editor-header"class="dm-button--unstyled-primary width-auto">Return to top</a>
   </div>
 
   <% if params[:action] === 'metrics' %>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -3,7 +3,7 @@
   <div
     class="grid-container usa-footer__return-to-top<%= params[:controller] === 'practices' && NavigationHelper::RETURN_TO_TOP_PAGES.include?(params[:action]) ? ' desktop:display-block' : ' tablet:display-none' %> margin-top-8 tablet:margin-top-0"
   >
-    <button class="dm-button--unstyled-primary dm-return-to-top width-auto">Return to top</button>
+    <a href="#dm-nav-header" class="dm-button--unstyled-primary width-auto">Return to top</a>
   </div>
 
   <div class="usa-footer__primary-section bg-primary-darker padding-y-4 desktop:padding-x-7">


### PR DESCRIPTION
### JIRA issue link
N/A

## Description - what does this code do?
- remove JS used in "Return to top" links
- implement "Return to top" as anchor links 

## Testing done - how did you test it/steps on how can another person can test it 
1. Open the homepage at a mobile width. Click on "Return to top" link. The browser should scroll to the top of the page
2. Go to any innovation and click on the "Edit innovation" button. 
3. Click on the "Return to top" link. The browser should scroll to the top of the page.
