### PR TITLE
Dm 4213 fix practice imgs on crh pages

### DIFF
--- a/app/views/clinical_resource_hubs/_crh_show.js.erb
+++ b/app/views/clinical_resource_hubs/_crh_show.js.erb
@@ -79,6 +79,7 @@ function searchPracticesByCrh() {
             moreText: 'Load more',
             noMoreText: 'No more results'
         });
+        replaceImagePlaceholders('#search-results .dm-practice-card');
     }
     // Search practices and populate the page
     function search(query, category, radioVal) {

--- a/app/views/clinical_resource_hubs/show.html.erb
+++ b/app/views/clinical_resource_hubs/show.html.erb
@@ -7,6 +7,7 @@
 
 <% provide :head_tags do %>
   <%= javascript_include_tag '_practice_card_utilities', 'data-turbolinks-track': 'reload' %>
+  <%= javascript_include_tag 'shared/_signed_resource', 'data-turbolinks-track': 'false', defer: true %>
   <%= javascript_tag 'data-turbolinks-track': 'reload' do %>
 
     <%= render partial: 'crh_show', formats: [:js] %>

--- a/app/views/practices/_search.js.erb
+++ b/app/views/practices/_search.js.erb
@@ -127,6 +127,22 @@ function buildPracticeCard(result) {
     return cardHtml;
 }
 
+function replaceImagePlaceholders(parentSelector) {
+    $(parentSelector).each(function() {
+        // If either the 'src' or the hidden input are undefined, return an empty string
+        var imageSelector = $(this).find('.practice-card-img-placeholder');
+        var imagePracticeId = imageSelector ? imageSelector.attr('data-practice-id') : null;
+        var practiceImagePath = imageSelector ? imageSelector.attr('data-practice-image') : null;
+        var practiceName = $(this).find('.dm-practice-title').text();
+
+        if (imagePracticeId && practiceImagePath) {
+            fetchSignedResource(practiceImagePath).then(signedImgUrl => {
+                replacePlaceholderWithImage(signedImgUrl, imagePracticeId, practiceName);
+            });
+        }
+    });
+}
+
 function replacePlaceholderWithImage(imageUrl, practiceId, practiceName) {
     loadImage(imageUrl, function(loadedImageSrc) {
         var imgTag =
@@ -279,20 +295,7 @@ function searchPracticesPage() {
             // Print results to the page
             document.querySelector('#search-results').innerHTML = finalResults;
             // After the html for the card has been built and applied to the DOM, replace the image 'src' based on the signed url
-            $('#search-results .dm-practice-card').each(function() {
-                // If either the 'src' or the hidden input are undefined, return an empty string
-                var imageSelector = $(this).find('.practice-card-img-placeholder');
-                var imagePracticeId = imageSelector ? imageSelector.attr('data-practice-id') : null;
-                var practiceImagePath = imageSelector ? imageSelector.attr('data-practice-image') : null;
-                var practiceName = $(this).find('.dm-practice-title').text();
-                if (imagePracticeId && practiceImagePath) {
-                    fetchSignedResource(
-                        practiceImagePath,
-                    ).then(signedImgUrl => {
-                        replacePlaceholderWithImage(signedImgUrl, imagePracticeId, practiceName)
-                    });
-                }
-            });
+            replaceImagePlaceholders('#search-results .dm-practice-card');
 
             $(SEARCH_RESULTS).showMoreItems({
                 startNum: 12,


### PR DESCRIPTION
### JIRA issue link
https://agile6.atlassian.net/browse/DM-4213

## Description - what does this code do?
Updates js involved in replacing practice card images, separates logic that handles identifying the placeholder divs with s3 images into a new function that can be utilized elsewhere such as in the js that deals with practice cards for crh show where the function is now also utilized.

## Testing done - how did you test it/steps on how can another person can test it 
1. locally, log in as admin, nav to the `/search` page and verify the practice card images render as expected.
2. in rails console run: 
```
include FactoryBot::Syntax::Methods
create(:practice_origin_facility, practice: Practice.find(1), clinical_resource_hub: ClinicalResourceHub.find(1))
create(:practice_origin_facility, practice: Practice.find(2), clinical_resource_hub: ClinicalResourceHub.find(1))
create(:practice_origin_facility, practice: Practice.find(3), clinical_resource_hub: ClinicalResourceHub.find(1))
```
* Note: this branch will need to be rebased with master once https://github.com/department-of-veterans-affairs/diffusion-marketplace/pull/709 is merged in order to use these commands. However, if your local data is unchanged since running local tests indicated in the aforementioned pr, these commands have already been run and rebasing is not necessary.

3. nav to `/crh/1` and verify the S3 images replace the black placeholder background

## Screenshots, Gifs, Videos from application (if applicable)
![Screenshot 2023-09-28 at 4 13 39 PM](https://github.com/department-of-veterans-affairs/diffusion-marketplace/assets/65036872/eaa9ae1c-01a9-475d-9efc-69611c76b558)


## Link to mock-ups/mock ups (image file if you have it) (if applicable)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Unit tests written (if applicable)
- [ ] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating JIRA issue
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs