### PR TITLE
Bump up bundler version to 2.4.20

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -870,4 +870,4 @@ RUBY VERSION
    ruby 2.7.8p225
 
 BUNDLED WITH
-   2.4.13
+   2.4.20


### PR DESCRIPTION
Our lockfile's bundler version is a couple of versions behind what we're using in PROD. Bumping up our bundler version after seeing a reminder during deploy.