### PR TITLE
dm-4241 facilities index bullet warnings

### DIFF
--- a/app/controllers/va_facilities_controller.rb
+++ b/app/controllers/va_facilities_controller.rb
@@ -2,22 +2,22 @@ class VaFacilitiesController < ApplicationController
   include PracticeUtils, VaFacilitiesHelper
   before_action :set_va_facility, only: [:show, :created_practices, :update_practices_adopted_at_facility]
   def index
-    va_facilities = VaFacility.cached_va_facilities.select(:common_name, :id, :visn_id, :official_station_name).order_by_station_name.includes([:visn])
+    va_facilities = VaFacility.cached_va_facilities.select(:common_name, :id, :visn_id, :official_station_name).order_by_station_name
     clinical_resource_hubs = ClinicalResourceHub.cached_clinical_resource_hubs
-    @facilities = (va_facilities.includes(:visn).sort_by(&:official_station_name.downcase) + clinical_resource_hubs.includes([:visn]).sort_by(&:id))
+    @facilities = (va_facilities.sort_by(&:official_station_name.downcase) + clinical_resource_hubs.sort_by(&:id))
     @visns = Visn.cached_visns.select(:name, :number)
     @types = VaFacility.cached_va_facilities.order_by_station_name.get_complexity
   end
 
   def load_facilities_index_rows
     if params[:facility].present?
-      @facilities = [VaFacility.cached_va_facilities.order_by_station_name.includes([:visn]).find(params[:facility])]
+      @facilities = [VaFacility.cached_va_facilities.order_by_station_name.find(params[:facility])]
 
     elsif params[:crh].present?
       @facilities = [ClinicalResourceHub.find_by_id(params[:crh].to_i)]
     else
       @facilities = VaFacility.cached_va_facilities.order_by_station_name.includes([:visn]).get_relevant_attributes
-      @clinical_resource_hubs = ClinicalResourceHub.cached_clinical_resource_hubs
+      @clinical_resource_hubs = ClinicalResourceHub.cached_clinical_resource_hubs.includes([:visn])
 
       if params[:visn].present?
         @facilities = @facilities.where(visns: { number: params[:visn] })

--- a/spec/factories/diffusion_history_statuses.rb
+++ b/spec/factories/diffusion_history_statuses.rb
@@ -2,6 +2,8 @@ FactoryBot.define do
   factory :diffusion_history_status do
     association :diffusion_history
     status { 'Complete' }
+    start_time { DateTime.now }
+    end_time{ DateTime.now + 1.day }
 
     trait :in_progress do
       status { 'In progress' }


### PR DESCRIPTION
### JIRA issue link
https://agile6.atlassian.net/browse/DM-4241

## Description - what does this code do?
Various alterations to queries involved in response for `/facilities` endpoint, removes and adds eager loading in a few places as per warnings from bullet gem.

## Testing done - how did you test it/steps on how can another person can test it 
1. As admin go to the `/facilities` page, verify no bullet gem warnings appear in devtools console or in the terminal by keyword searching "Eager" (sometimes warnings will appear in the terminal but not the console).
2. Filter search by facility and then by visn, checking for bullet gem warnings as in previous step.

## Screenshots, Gifs, Videos from application (if applicable)


## Link to mock-ups/mock ups (image file if you have it) (if applicable)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Unit tests written (if applicable)
- [ ] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating JIRA issue
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs