### PR TITLE
dm-4157 refactor #origin_display_name

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -51,8 +51,10 @@ module ApplicationHelper
     if practice.initiating_facility_type?
       if practice.facility? && practice.practice_origin_facilities.present?
         generate_facility_names(practice)
-      else
+      elsif practice.initiating_facility?
         handle_initiating_facility(practice)
+      else
+        ''
       end
     else
       ''
@@ -91,8 +93,6 @@ module ApplicationHelper
       office['name']
     when 'other'
       practice.initiating_facility
-    else
-      ''
     end
   end
 


### PR DESCRIPTION
### JIRA issue link
https://agile6.atlassian.net/browse/DM-4157

## Description - what does this code do?
I realized that my original fix for this bullet warning wasn't working as I'd thought, the query results were being cached and so subsequent page loads that were absent of the bullet warning were not telling the full truth.

This refactors the `#origin_display_name` method in `ApplicationHelper` to conditionally preload associations, which alleviates the bullet gem warning.

## Testing done - how did you test it/steps on how can another person can test it 
1. Locally, signed in as admin, visting `/search` and verify no bullet gem warning appears in either devtools console or the server output in the terminal (always appears towards the bottom but keyword searching for `Eager` is a good idea to be sure).
2. In rails console run: `Rails.cache.clear`
3. Reload the page and reverify no bullet warnings appear.

## Screenshots, Gifs, Videos from application (if applicable)


## Link to mock-ups/mock ups (image file if you have it) (if applicable)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Unit tests written (if applicable)
- [ ] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating JIRA issue
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs