### PR TITLE
dm-4157 search page bullet warning fix

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -51,8 +51,10 @@ module ApplicationHelper
     if practice.initiating_facility_type?
       if practice.facility? && practice.practice_origin_facilities.present?
         generate_facility_names(practice)
-      else
+      elsif practice.initiating_facility?
         handle_initiating_facility(practice)
+      else
+        ''
       end
     else
       ''
@@ -91,8 +93,6 @@ module ApplicationHelper
       office['name']
     when 'other'
       practice.initiating_facility
-    else
-      ''
     end
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -76,10 +76,14 @@ module ApplicationHelper
   end
 
   def construct_facility_name(loc)
-    has_va_facility = loc.va_facility.present?
-    official_station_name = has_va_facility ? loc.va_facility.official_station_name : loc.clinical_resource_hub.official_station_name
-    common_name = loc.va_facility.common_name if has_va_facility
-    has_va_facility ? facility_name_with_common_name(official_station_name, common_name) : official_station_name
+    if loc.va_facility.present?
+      facility_name_with_common_name(
+        loc.va_facility.official_station_name, 
+        loc.va_facility.common_name
+      )
+    else
+      loc.clinical_resource_hub.official_station_name
+    end
   end
 
   def handle_initiating_facility(practice)


### PR DESCRIPTION
### JIRA issue link
https://agile6.atlassian.net/browse/DM-4157

## Description - what does this code do?
follow up to https://github.com/department-of-veterans-affairs/diffusion-marketplace/pull/720, forgot to add change to `#construct_facility_name` method

I realized that my original fix for this bullet warning wasn't working as I'd thought, the query results were being cached and so subsequent page loads that were absent of the bullet warning were not telling the full truth.

This refactors the `#origin_display_name` method in `ApplicationHelper` to conditionally preload associations, which alleviates the bullet gem warning.

## Testing done - how did you test it/steps on how can another person can test it 
1. Locally, signed in as admin, visting `/search` and verify no bullet gem warning appears in either devtools console or the server output in the terminal (always appears towards the bottom but keyword searching for `Eager` is a good idea to be sure).
2. In rails console run: `Rails.cache.clear`
3. Reload the page and reverify no bullet warnings appear.

## Screenshots, Gifs, Videos from application (if applicable)


## Link to mock-ups/mock ups (image file if you have it) (if applicable)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Unit tests written (if applicable)
- [ ] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating JIRA issue
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs