### PR TITLE
DM-4258: Improve fallback behavior for innovation show page images

### DIFF
--- a/app/assets/javascripts/practice_page.es6
+++ b/app/assets/javascripts/practice_page.es6
@@ -109,7 +109,11 @@
             $('.practice-editor-impact-photo').each(function () {
                 $(this).parent().show();
                 if ($(window).width() > 1023) {
-                    $(this).next().width(`${$(this).width()}`);
+                    if ($(this).width() > 450){ // avoid narrow columns when image requests break
+                        $(this).next().width(`${$(this).width()}`);
+                    } else {
+                        $(this).next().width(450); // minimum 450px captions for narrow images
+                    }
                 }
             })
         })


### PR DESCRIPTION
### JIRA issue link
[DM-4258](https://agile6.atlassian.net/browse/DM-4258)

## Description - what does this code do?
- This PR improves the fallback behavior for innovation show pages where image requests fail. Previously, captions would be set to 50px wide columns when S3 image requests failed. This PR adds a conditional so that broken image captions appear at full column width instead. 

## Testing done - how did you test it/steps on how can another person can test it 
As an innovation editor:
1. upload an image that is 50px wide. Give it a caption that is about 190 characters long. 
2. upload an image that is 500px wide. Give it a caption that is about 190 characters long. 
3. Save changes
4. Go to the innovation page
5. Confirm that the 500px wide image caption is as wide as the image
6. Confirm that the narrow image's caption is 450px wide.

## Screenshots, Gifs, Videos from application (if applicable)
### Before
![image003](https://github.com/department-of-veterans-affairs/diffusion-marketplace/assets/5402927/f3d1d292-144a-4201-b6e8-371bad2c3012)

### After

![Screenshot 2023-10-19 at 4 17 46 PM](https://github.com/department-of-veterans-affairs/diffusion-marketplace/assets/5402927/9d9bc292-f316-457b-8632-52c82ab29380)

