### PR TITLE
Use a grey placeholder if Featured Topic/Innovation images fail

### DIFF
--- a/app/views/home/_featured_section.html.erb
+++ b/app/views/home/_featured_section.html.erb
@@ -6,7 +6,10 @@
         <img
           class="display-block"
           src="<%= image_source %>"
-          alt="<%= image_alt_text %>"/>
+          alt="<%= image_alt_text %>"
+          onerror="this.classList.add('display-none');
+          this.parentNode.parentNode.classList.add('bg-base-lightest');"
+        />
       </a>
     </div>
     <div class="display-none desktop:display-block desktop:grid-col-1"></div>


### PR DESCRIPTION
### JIRA issue link
[DM-4267](https://agile6.atlassian.net/browse/DM-4267)

## Description - what does this code do?
- In cases where the homepage image requests for Featured Innovation and Feature Topic breaks: 
  - Hides the broken icon
  - adds a light grey background to the parent div

## Testing done - how did you test it/steps on how can another person can test it 
1. Log in as an admin 
2. In `/admin/topics` add a topic with an image attachment. Save.
3. In `/admin/topics`, click on `Feature`
4. In `/admin/practices`, select an innovation to Feature. Make sure it's also Public. 
5. In `/admin/practices`, go to Edit, add an image and feature body text
6. On the homepage, confirm you see the images load. 
7. in the browser, edit the `src` of one of the images to something invalid. (e.g. `src="nonsense"`). 
8. The image should immediately change to a light grey placeholder.

## Screenshots, Gifs, Videos from application (if applicable)
### Before
<img width="1022" alt="Screenshot 2023-10-26 at 1 43 18 PM" src="https://github.com/department-of-veterans-affairs/diffusion-marketplace/assets/5402927/758d4ada-87f5-49ae-83f3-1b331283930c">

### After
<img width="1088" alt="Screenshot 2023-10-26 at 1 42 45 PM" src="https://github.com/department-of-veterans-affairs/diffusion-marketplace/assets/5402927/30ce966a-8513-4f08-92b7-b1faf6d596e7">

