### PR TITLE
dm-4281 clear signer cache endpoint

### DIFF
--- a/app/controllers/system/operational_tasks_controller.rb
+++ b/app/controllers/system/operational_tasks_controller.rb
@@ -1,7 +1,6 @@
 module System
   class OperationalTasksController < ApplicationController
-    skip_before_action  :verify_authenticity_token,
-                        :setup_breadcrumb_navigation, 
+    skip_before_action  :setup_breadcrumb_navigation, 
                         :reload_turbolinks, 
                         :store_user_location!, 
                         :set_paper_trail_whodunnit, 
@@ -10,7 +9,6 @@ module System
                         :set_visit_props, 
                         :set_visitor_props, 
                         only: [:clear_signer_cache]
-    before_action :custom_verify_authenticity_token, only: [:clear_signer_cache]
 
     def clear_signer_cache
       begin
@@ -23,10 +21,7 @@ module System
 
     private
 
-    def custom_verify_authenticity_token
- 
-      return unless Rails.env.production? || Rails.env.development?
-
+    def verify_authenticity_token
       secure_token = ENV['CLEAR_SIGNER_CACHE_TOKEN']
       authorization_header = request.headers['Authorization']
 

--- a/app/controllers/system/operational_tasks_controller.rb
+++ b/app/controllers/system/operational_tasks_controller.rb
@@ -1,6 +1,16 @@
 module System
   class OperationalTasksController < ApplicationController
-    before_action :check_token_authentication, only: [:clear_signer_cache]
+    skip_before_action  :verify_authenticity_token,
+                        :setup_breadcrumb_navigation, 
+                        :reload_turbolinks, 
+                        :store_user_location!, 
+                        :set_paper_trail_whodunnit, 
+                        :log_in_va_user, 
+                        :user_accepted_terms?, 
+                        :set_visit_props, 
+                        :set_visitor_props, 
+                        only: [:clear_signer_cache]
+    before_action :custom_verify_authenticity_token, only: [:clear_signer_cache]
 
     def clear_signer_cache
       begin
@@ -13,8 +23,9 @@ module System
 
     private
 
-    def check_token_authentication
-      return unless Rails.env.production?
+    def custom_verify_authenticity_token
+ 
+      return unless Rails.env.production? || Rails.env.development?
 
       secure_token = ENV['CLEAR_SIGNER_CACHE_TOKEN']
       authorization_header = request.headers['Authorization']

--- a/app/controllers/system/operational_tasks_controller.rb
+++ b/app/controllers/system/operational_tasks_controller.rb
@@ -1,0 +1,25 @@
+module System
+  class OperationalTasksController < ApplicationController
+    before_action :check_ip_whitelist, only: [:clear_signer_cache]
+
+    def clear_signer_cache
+      begin
+        Rails.cache.delete('s3_signer')
+        render json: { status: 'Cache cleared successfully' }, status: :ok
+      rescue => e
+        render json: { error: 'Failed to clear cache', details: e.message }, status: :internal_server_error
+      end
+    end
+
+    private
+
+    def check_ip_whitelist
+      return unless Rails.env.production?
+
+      allowed_ips = ENV['WHITELISTED_IPS'].split(',')
+      unless allowed_ips.include?(request.remote_ip)
+        render json: { error: 'Access Denied' }, status: :forbidden
+      end
+    end
+  end
+end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -22,7 +22,7 @@ Rails.application.configure do
   config.consider_all_requests_local       = true
   config.action_controller.perform_caching = true
 
-  config.cache_store = :redis_cache_store, { url: ENV.fetch("REDIS_URL", "redis://localhost:6379/0") }
+  config.cache_store = :redis_cache_store, { url: ENV.fetch("REDIS_URL", "redis://localhost:6379/1") }
 
   # Raise exceptions instead of rendering exception templates.
   config.action_dispatch.show_exceptions = false

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -105,7 +105,7 @@ Rails.application.routes.draw do
 
   namespace :system do
     get 'status' => 'status#index', as: 'status'
-    post 'clear_signer_cache', to: 'operational_tasks#clear_signer_cache'
+    post 'clear-signer-cache', to: 'operational_tasks#clear_signer_cache'
   end
 
   # set the param to the visn number instead of the visn id

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -105,6 +105,7 @@ Rails.application.routes.draw do
 
   namespace :system do
     get 'status' => 'status#index', as: 'status'
+    post 'clear_signer_cache', to: 'operational_tasks#clear_signer_cache'
   end
 
   # set the param to the visn number instead of the visn id

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -105,7 +105,7 @@ Rails.application.routes.draw do
 
   namespace :system do
     get 'status' => 'status#index', as: 'status'
-    post 'clear-signer-cache', to: 'operational_tasks#clear_signer_cache'
+    post 'clear-signer-cache' => 'operational_tasks#clear_signer_cache'
   end
 
   # set the param to the visn number instead of the visn id

--- a/spec/requests/operational_tasks_controller_spec.rb
+++ b/spec/requests/operational_tasks_controller_spec.rb
@@ -2,34 +2,41 @@ require 'rails_helper'
 
 RSpec.describe System::OperationalTasksController, type: :controller do
   describe 'POST #clear_signer_cache' do
-    let(:whitelisted_ip) { '123.45.67.89' }
-    let(:non_whitelisted_ip) { '98.76.54.32' }
+    let(:secure_token) { 'correct_secure_token_value' }
     let(:cache_key) { 's3_signer' }
 
     before do
       allow(Rails).to receive(:env).and_return(ActiveSupport::StringInquirer.new("production"))
-      ENV['WHITELISTED_IPS'] = '123.45.67.89,124.77.55.67'
-      request.env['REMOTE_ADDR'] = ip_address
+      ENV['CLEAR_SIGNER_CACHE_TOKEN'] = secure_token
       Rails.cache.write(cache_key, 'cached data')
+      request.headers['Authorization'] = "Bearer #{token}"
     end
 
-    context 'when called from a whitelisted IP' do
-      let(:ip_address) { whitelisted_ip }
-      
-      context 'when cache clearance is successful' do
-        it 'returns status ok' do
-          post :clear_signer_cache
-          expect(response).to have_http_status(:ok)
-          expect(response.body).to match(/Cache cleared successfully/)
-          expect(Rails.cache.read(cache_key)).to be_nil
-        end
+    context 'with valid authorization token' do
+      let(:token) { secure_token }
+
+      it 'returns status ok and clears the cache' do
+        post :clear_signer_cache
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to match(/Cache cleared successfully/)
+        expect(Rails.cache.read(cache_key)).to be_nil
       end
     end
 
-    context 'when called from a non-whitelisted IP' do
-      let(:ip_address) { non_whitelisted_ip }
+    context 'with invalid authorization token' do
+      let(:token) { 'incorrect_token' }
 
-      it 'returns forbidden' do
+      it 'returns forbidden status' do
+        post :clear_signer_cache
+        expect(response).to have_http_status(:forbidden)
+        expect(response.body).to match(/Access Denied/)
+      end
+    end
+
+    context 'without any authorization token' do
+      let(:token) { nil }
+
+      it 'returns forbidden status' do
         post :clear_signer_cache
         expect(response).to have_http_status(:forbidden)
         expect(response.body).to match(/Access Denied/)

--- a/spec/requests/operational_tasks_controller_spec.rb
+++ b/spec/requests/operational_tasks_controller_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+
+RSpec.describe System::OperationalTasksController, type: :controller do
+  describe 'POST #clear_signer_cache' do
+    let(:whitelisted_ip) { '123.45.67.89' }
+    let(:non_whitelisted_ip) { '98.76.54.32' }
+    let(:cache_key) { 's3_signer' }
+
+    before do
+      allow(Rails).to receive(:env).and_return(ActiveSupport::StringInquirer.new("production"))
+      ENV['WHITELISTED_IPS'] = '123.45.67.89,124.77.55.67'
+      request.env['REMOTE_ADDR'] = ip_address
+      Rails.cache.write(cache_key, 'cached data')
+    end
+
+    context 'when called from a whitelisted IP' do
+      let(:ip_address) { whitelisted_ip }
+      
+      context 'when cache clearance is successful' do
+        it 'returns status ok' do
+          post :clear_signer_cache
+          expect(response).to have_http_status(:ok)
+          expect(response.body).to match(/Cache cleared successfully/)
+          expect(Rails.cache.read(cache_key)).to be_nil
+        end
+      end
+    end
+
+    context 'when called from a non-whitelisted IP' do
+      let(:ip_address) { non_whitelisted_ip }
+
+      it 'returns forbidden' do
+        post :clear_signer_cache
+        expect(response).to have_http_status(:forbidden)
+        expect(response.body).to match(/Access Denied/)
+      end
+    end
+  end
+end


### PR DESCRIPTION
### JIRA issue link
https://agile6.atlassian.net/browse/DM-4281

## Description - what does this code do?
Adds controller with action with the sole purpose of clearing the `s3_signer` object from the Rails cache. Authorization will be handled by checking a bearer token sent in the authorization header of the request.

## Testing done - how did you test it/steps on how can another person can test it 
1. set a `CLEAR_SIGNER_CACHE_TOKEN` env variable in `application.yml`
2. run the server locally and `redis-server`, load the home page
3. in rails console, run: `Rails.cache.fetch('s3_signer')` and verify it returns a `WT::S3Signer` object
4. from a separate terminal window send a request to the endpoint with:

```
curl -X POST http://localhost:3200/system/clear-signer-cache \
-H "Authorization: Bearer 123456" \
-H "Content-Type: application/json"
```
6. It should respond with `{"status":"Cache cleared successfully"}% `
7. re-run `Rails.cache.fetch('s3_signer')` in the rails console and verify it returns `nil`
8. reload the page in the local browswer
9. in rails console, rerun: `Rails.cache.fetch('s3_signer')` and verify it returns a `WT::S3Signer` object
10. resend the curl command with an incorrect security token:

```
curl -X POST http://localhost:3200/system/clear-signer-cache \
-H "Authorization: Bearer 123456dsfasdfas" \
-H "Content-Type: application/json"
```
11. it should respond with `{"error":"Access Denied"}%  `
## Screenshots, Gifs, Videos from application (if applicable)


## Link to mock-ups/mock ups (image file if you have it) (if applicable)


## Acceptance criteria
- [ ]

## Definition of done
- [x] Unit tests written (if applicable)
- [ ] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating JIRA issue
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs