### PR TITLE
Update Diffusion of Excellence link on About us page

### DIFF
--- a/app/views/about/index.html.erb
+++ b/app/views/about/index.html.erb
@@ -13,7 +13,7 @@
         <h1 class="usa-prose-h1 margin-bottom-4 margin-top-0">About us</h1>
         <p class="usa-prose-body">
           The Diffusion Marketplace is a discovery and collaboration tool that curates promising clinical, operational, and strategic innovations from VA. We are managed by the
-          <a href="https://www.innovation.va.gov/ecosystem/views/diffusion-excellence/doe.html" class="usa-link usa-link--external" target="_blank">Diffusion of Excellence</a>, an organization within
+          <a href="https://www.innovation.va.gov/ecosystem/views/diffusion-excellence" class="usa-link usa-link--external" target="_blank">Diffusion of Excellence</a>, an organization within
           the <a href="https://www.innovation.va.gov/ecosystem/views/home.html" class="usa-link usa-link--external" target="_blank">VHA Innovation Ecosystem</a>. Our goal is to
           represent the best of VA and to reflect the spirit of service and collaboration for Veterans and the communities we serve.
         </p>


### PR DESCRIPTION
### JIRA issue link
N/A

## Description - what does this code do?
The Diffusion of Excellence team recently updated their program website. I noticed this when a test started failing on a [recent PR](https://github.com/department-of-veterans-affairs/diffusion-marketplace/actions/runs/6802885776/job/18496968353):
https://github.com/department-of-veterans-affairs/diffusion-marketplace/blob/51c744850c35d4272add9babf518d2e2564528f5/spec/features/about_spec.rb#L12-L22

## Testing done - how did you test it/steps on how can another person can test it 
1. Go to About Us page on PROD (https://marketplace.va.gov/about)
2. Click on Diffusion of Excellence and confirm the current link leads to a 404 page
3. In local dev, go to `/about` and click on Diffusion of Excellence. 
4. Confirm that it successfully loads the cc


## Screenshots, Gifs, Videos
![Screenshot 2023-11-08 at 4 41 31 PM](https://github.com/department-of-veterans-affairs/diffusion-marketplace/assets/5402927/b69ae983-ec2b-406a-bd54-1707f2fd4fd2)
 from application (if applicable)

![Screenshot 2023-11-08 at 4 41 43 PM](https://github.com/department-of-veterans-affairs/diffusion-marketplace/assets/5402927/65850738-0850-48f4-9ffb-0858e4c60bdf)
