### PR TITLE
update `expires_in` for cached s3 signer

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -65,7 +65,7 @@ class ApplicationController < ActionController::Base
   end
 
   def s3_signer
-    Rails.cache.fetch('s3_signer', expires_in: 40.minutes) do
+    Rails.cache.fetch('s3_signer', expires_in: 45.minutes) do
       s3_bucket = Aws::S3::Bucket.new(ENV['S3_BUCKET_NAME'])
       WT::S3Signer.for_s3_bucket(s3_bucket, expires_in: 45.minutes)
     end


### PR DESCRIPTION
### JIRA issue link


## Description - what does this code do?
reverts change to the expiration timing of `s3_signer` object in rails cache, 45 minutes seems to be the ideal time given the token refresh interval appears to be set to 45 min as well:

<img width="866" alt="Screenshot 2023-11-13 at 11 17 45 AM" src="https://github.com/department-of-veterans-affairs/diffusion-marketplace/assets/65036872/9f227049-9aed-4923-9d99-51682ea990d3">

## Testing done - how did you test it/steps on how can another person can test it 


## Screenshots, Gifs, Videos from application (if applicable)


## Link to mock-ups/mock ups (image file if you have it) (if applicable)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Unit tests written (if applicable)
- [ ] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating JIRA issue
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs