### PR TITLE
DM-4315: Upgrade jquery-ui-rails

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -104,7 +104,8 @@ gem 'ffi'
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 gem 'jquery-rails'
-gem 'jquery-ui-rails'
+# pinned until maintainers publish to RubyGems
+gem 'jquery-ui-rails', github: 'jquery-ui-rails/jquery-ui-rails', tag: 'v7.0.0'
 gem 'uswds-rails', github: 'agilesix/uswds-rails', ref: '52da189'
 
 gem 'activerecord-nulldb-adapter'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -42,6 +42,14 @@ GIT
       neat
       rails-assets-normalize-css (= 3.0.3)
 
+GIT
+  remote: https://github.com/jquery-ui-rails/jquery-ui-rails.git
+  revision: 413265e81f790f795239e07e7e25e01429b2f18d
+  tag: v7.0.0
+  specs:
+    jquery-ui-rails (7.0.0)
+      railties (>= 3.2.16)
+
 GEM
   remote: https://rails-assets.org/
   specs:
@@ -316,8 +324,6 @@ GEM
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
-    jquery-ui-rails (6.0.1)
-      railties (>= 3.2.16)
     json (2.3.1)
     kaminari (1.2.2)
       activesupport (>= 4.1.0)
@@ -835,7 +841,7 @@ DEPENDENCIES
   jbuilder (~> 2.5)
   jquery-cropper
   jquery-rails
-  jquery-ui-rails
+  jquery-ui-rails!
   json (~> 2.3.0)
   kaminari
   letter_opener


### PR DESCRIPTION
### JIRA issue link
[DM-4315](https://agile6.atlassian.net/browse/DM-4315)

## Description - what does this code do?
Updates `jquery-ui-rails` to `7.0.0` per security advice. This Gemfile update points to the repo directly. The maintainer who cut the new release does not have permissions to push the package to Rubygems.org and is waiting for other maintainers to publish.

## Testing done - how did you test it/steps on how can another person can test it 


## Screenshots, Gifs, Videos from application (if applicable)


## Link to mock-ups/mock ups (image file if you have it) (if applicable)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Unit tests written (if applicable)
- [ ] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating JIRA issue
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs