### PR TITLE
Bump GitHub Actions CI PostgreSQL version to 12

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -31,7 +31,7 @@ jobs:
       GOOGLE_API_KEY: ${{ secrets.GOOGLE_TEST_API_KEY }}
     services:
       postgres:
-        image: postgres:11-alpine
+        image: postgres:12-alpine
         ports: ["5432:5432"]
         options: >-
           --health-cmd pg_isready


### PR DESCRIPTION
### JIRA issue link
[DM-4333](https://agile6.atlassian.net/browse/DM-4333)

## Description - what does this code do?
Bumps up our GitHub Actions CI Postgres version to match our Docker image & AWS RDS 