### PR TITLE
Bump activeadmin to 2.14

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -140,7 +140,7 @@ gem 'acts_as_votable'
 gem 'json', '~> 2.3.0'
 
 # Active Admin
-gem 'activeadmin', '~> 2.12.0'
+gem 'activeadmin', '~> 2.14.0'
 gem 'activeadmin_addons'
 gem 'active_skin'
 gem 'active_admin_theme'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -104,14 +104,14 @@ GEM
     active_admin_theme (1.1.4)
     active_material (1.5.2)
     active_skin (0.0.13)
-    activeadmin (2.12.0)
+    activeadmin (2.14.0)
       arbre (~> 1.2, >= 1.2.1)
       formtastic (>= 3.1, < 5.0)
       formtastic_i18n (~> 0.4)
       inherited_resources (~> 1.7)
       jquery-rails (~> 4.2)
       kaminari (~> 1.0, >= 1.2.1)
-      railties (>= 6.0, < 7.1)
+      railties (>= 6.1, < 7.1)
       ransack (>= 2.1.1, < 4)
     activeadmin_addons (1.9.0)
       active_material
@@ -152,9 +152,9 @@ GEM
       activesupport (>= 5.2)
       device_detector
       safely_block (>= 0.2.1)
-    arbre (1.6.0)
-      activesupport (>= 3.0.0, < 7.1)
-      ruby2_keywords (>= 0.0.2, < 1.0)
+    arbre (1.7.0)
+      activesupport (>= 3.0.0)
+      ruby2_keywords (>= 0.0.2)
     autoprefixer-rails (10.4.7.0)
       execjs (~> 2)
     aws-eventstream (1.2.0)
@@ -295,7 +295,7 @@ GEM
       google-protobuf (~> 3.14)
     groupdate (6.1.0)
       activesupport (>= 5.2)
-    has_scope (0.8.1)
+    has_scope (0.8.2)
       actionpack (>= 5.2)
       activesupport (>= 5.2)
     hiredis (0.6.3)
@@ -309,11 +309,11 @@ GEM
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
     ice_nine (0.11.2)
-    inherited_resources (1.13.1)
-      actionpack (>= 5.2, < 7.1)
-      has_scope (~> 0.6)
-      railties (>= 5.2, < 7.1)
-      responders (>= 2, < 4)
+    inherited_resources (1.14.0)
+      actionpack (>= 6.0)
+      has_scope (>= 0.6)
+      railties (>= 6.0)
+      responders (>= 2)
     jbuilder (2.11.5)
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
@@ -640,9 +640,9 @@ GEM
       rake (>= 12.2)
       thor (~> 1.0)
     rake (13.0.6)
-    ransack (3.1.0)
-      activerecord (>= 6.0.4)
-      activesupport (>= 6.0.4)
+    ransack (3.2.1)
+      activerecord (>= 6.1.5)
+      activesupport (>= 6.1.5)
       i18n
     rb-fsevent (0.11.2)
     rb-inotify (0.10.1)
@@ -798,7 +798,7 @@ PLATFORMS
 DEPENDENCIES
   active_admin_theme
   active_skin
-  activeadmin (~> 2.12.0)
+  activeadmin (~> 2.14.0)
   activeadmin_addons
   activerecord-nulldb-adapter
   acts_as_list


### PR DESCRIPTION
### JIRA issue link


## Description - what does this code do?
- Minor version updates for `activeadmin`
- Release notes: https://github.com/activeadmin/activeadmin/blob/master/CHANGELOG.md#2140-
- Upstream code diff: https://github.com/activeadmin/activeadmin/compare/v2.12.0...v2.14.0
Note: There are some breaking changes in the major version update. I'll work on this in a separate PR.

## Testing done - how did you test it/steps on how can another person can test it 
- Log in as an admin and confirm that `/admin` functions are still working
