### PR TITLE
Update paperclip to include patched schema method

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -113,7 +113,7 @@ gem 'acts_as_list'
 gem 'aws-sdk-s3'
 gem 'aws-sdk-rds'
 gem 'wt_s3_signer'
-gem 'paperclip', github: 'agilesix/paperclip', branch: 'ruby-2.7.x-deprecation-fix'
+gem 'paperclip', github: 'agilesix/paperclip', branch: 'ruby-3-2-patched'
 gem 'font-awesome-sass', '~> 5.13.0'
 
 gem 'survey_monkey_api', github: 'agilesix/surveymonkey'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,8 +15,8 @@ GIT
 
 GIT
   remote: https://github.com/agilesix/paperclip.git
-  revision: 3aa328d6131b8338591e2a44e4ac35fe9de6dfe3
-  branch: ruby-2.7.x-deprecation-fix
+  revision: c88a79391f9ec823f0977c8e321350857b246f53
+  branch: ruby-3-2-patched
   specs:
     paperclip (6.1.0)
       activemodel (>= 4.2.0)

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1435,7 +1435,8 @@ ActiveRecord::Schema.define(version: 2023_11_27_172710) do
   end
 
   create_table "versions", force: :cascade do |t|
-    t.string "item_type", null: false
+    t.string "item_type"
+    t.string "{:null=>false}"
     t.bigint "item_id", null: false
     t.string "event", null: false
     t.string "whodunnit"


### PR DESCRIPTION
### JIRA issue link


## Description - what does this code do?
- This fixes an error we were getting when running migrations in local dev: https://stackoverflow.com/questions/71006085/paperclip-gem-rails-6-1-migration-error-wrong-number-of-arguments-given-3
- Updates `paperclip` to include additional Ruby 3.2 patches: https://github.com/agilesix/paperclip/compare/ruby-2.7.x-deprecation-fix...agilesix:paperclip:ruby-3-2-patched

## Testing done - how did you test it/steps on how can another person can test it 
1. On `master`, run `rails dm:reset_up` in local dev. Confirm that it fails with the error below:
![Screenshot 2023-12-08 at 11 41 28 AM](https://github.com/department-of-veterans-affairs/diffusion-marketplace/assets/5402927/7b2fa095-6ba0-4708-ba28-20cbbcd2d255)

2. Using this branch, run `rails dm:reset_up` in local dev and confirm that it reaches the end of the data seeding process