### PR TITLE
DM-4349: Disable contact form on About page

### DIFF
--- a/app/views/about/index.html.erb
+++ b/app/views/about/index.html.erb
@@ -131,7 +131,6 @@
       <p class="usa-prose-body">
         Have feedback or questions for the Diffusion Marketplace team? Send a message to <a href="mailto:marketplace@va.gov?subject=(About) Diffusion Marketplace Inquiry" class="usa-link">marketplace@va.gov</a> and we’ll get back to you as soon as we can.
       </p>
-      <%= render partial: 'shared/email_form', locals: { path: about_path, additional_label_text: nil } %>
     </div>
   </section>
 </div>

--- a/app/views/shared/_email_form.html.erb
+++ b/app/views/shared/_email_form.html.erb
@@ -19,5 +19,5 @@
     <input type="submit" value="Send message" class="usa-button margin-right-0">
   </div>
 
-  <%= recaptcha_v3(action: 'email', site_key: ENV['RECAPTCHA_SITE_KEY_V3']) %>
+  <%= recaptcha_v3(action: 'email', site_key: ENV['RECAPTCHA_SITE_KEY_V3']) if ENV['RECAPTCHA_SITE_KEY_V3'] %>
 <% end %>

--- a/spec/features/about_spec.rb
+++ b/spec/features/about_spec.rb
@@ -42,7 +42,7 @@ describe 'About us page', type: :feature do
   end
 
   describe 'Send us feedback section' do
-    it 'should allow the user to send an email to the marketplace team' do
+    xit 'should allow the user to send an email to the marketplace team' do
       fill_in('Your email', with: 'test@test.com')
       # all fields should be required
       click_button('Send message')
@@ -58,7 +58,7 @@ describe 'About us page', type: :feature do
       expect(page).to have_content('You successfully sent a message to the Diffusion Marketplace team.')
     end
     #spam detector................................................................
-    it 'should log and redirect user to homepage if phone field is populated' do
+    xit 'should log and redirect user to homepage if phone field is populated' do
       fill_in('Your email', with: 'test@test.com')
       fill_in('Subject line', with: 'Test subject')
       fill_in('Your message', with: 'This is a test message')


### PR DESCRIPTION
### JIRA issue link
[DM-4349](https://agile6.atlassian.net/browse/DM-4349)


## Description - what does this code do?
- Removes the contact form from the "About us" page
- temporarily disables relevant tests until we have confirmation this experiment has been successful

## Testing done - how did you test it/steps on how can another person can test it 
1. Go to the "About page"
1. Confirm that the alert banner with info about getting patient care is still present
1. Confirm that the marketplace contact email is still present

## Screenshots, Gifs, Videos from application (if applicable)


## Link to mock-ups/mock ups (image file if you have it) (if applicable)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Unit tests written (if applicable)
- [ ] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating JIRA issue
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs