### PR TITLE
DM-4339: Add a URL to messages sent from non-PROD forms

### DIFF
--- a/app/controllers/nominate_practices_controller.rb
+++ b/app/controllers/nominate_practices_controller.rb
@@ -8,7 +8,7 @@ class NominatePracticesController < ApplicationController
       log_spam_attempt "Nominate"
       redirect_to root_path
     else
-      NominateAPracticeMailer.send_contact_email(options = { email: params[:email], subject: params[:subject], message: params[:message] }, 'Nominate', 'nominate_a_practice_mailer/nominate_a_practice_email').deliver_now
+      NominateAPracticeMailer.send_contact_email(options = { email: params[:email], subject: params[:subject], message: params[:message], message_url: request.url }, 'Nominate', 'nominate_a_practice_mailer/nominate_a_practice_email').deliver_now
       success = 'Message sent. The Diffusion Marketplace team will review your nomination.'
       flash[:success] = success
       respond_to do |format|

--- a/app/helpers/contact_email_helper.rb
+++ b/app/helpers/contact_email_helper.rb
@@ -3,13 +3,14 @@ module ContactEmailHelper
     email = options[:email]
     subject = options[:subject]
     message = options[:message]
+    url = options[:message_url]
 
     mail(
       from: email,
       to: 'marketplace@va.gov',
       subject: "(#{origin}) #{subject}"
     ) do |format|
-      format.html { render "#{mailer_view_file}".html_safe, locals: { message: message } }
+      format.html { render "#{mailer_view_file}".html_safe, locals: { message: message, message_url: url } }
     end
   end
 end

--- a/app/views/nominate_a_practice_mailer/nominate_a_practice_email.html.erb
+++ b/app/views/nominate_a_practice_mailer/nominate_a_practice_email.html.erb
@@ -1,1 +1,4 @@
 <p><%= message %></p>
+<% if ENV['PROD_SERVERNAME'] !='PROD' %>
+	<p>Sent from <%= message_url %></p>
+<% end %>

--- a/spec/features/nominate_practices/nominate_a_practice_page_spec.rb
+++ b/spec/features/nominate_practices/nominate_a_practice_page_spec.rb
@@ -1,22 +1,28 @@
 require 'rails_helper'
 
 describe 'Nominate a practice page', type: :feature do
-  context 'VA user' do
-    before do
-      user = User.create!(email: 'admin-dmva@va.gov', password: 'Password123', password_confirmation: 'Password123', skip_va_validation: true, confirmed_at: Time.now, accepted_terms: true)
-      login_as(user, :scope => :user, :run_callbacks => false)
+  context 'Render' do
+    it 'renders form' do
       visit '/nominate-an-innovation'
-    end
-
-    it 'should be there' do
       expect(page).to be_accessible.according_to :wcag2a, :section508
       expect(page).to have_content('Nominate an innovation')
       expect(page).to have_content('VA staff and collaborators are welcome to nominate active innovations for consideration on the Diffusion Marketplace using the form below.')
     end
 
-    it 'should allow the user to send an email to the DM team about nominating an innovation' do
+    it 'redirect the user to /nominate-an-innovation if they try to visit the old /nominate-a-practice URL' do
+      visit '/nominate-a-practice'
+      expect(page).to have_current_path(nominate_an_innovation_path)
+    end
+  end
+
+  context 'Email' do
+    before do
+      visit '/nominate-an-innovation'
       fill_in('Your email address', with: 'test@test.com')
       fill_in('Subject line', with: 'Test subject')
+    end
+
+    it 'validates message body is filled out' do
       # all fields should be required
       click_button('Send message')
       message = find('#message').native.attribute('validationMessage')
@@ -30,29 +36,20 @@ describe 'Nominate a practice page', type: :feature do
       expect(page).to have_content('Message sent. The Diffusion Marketplace team will review your nomination.')
     end
 
+    it 'adds debug URL if sent from a non-PROD environment' do
+      fill_in('Your message', with: 'This is a different test message')
+      click_button('Send message')
+      expect(ActionMailer::Base.deliveries.last.body.raw_source).to have_content('Sent from')
+    end
+
     #spam detector................................................................
     it 'should log and redirect user to homepage if phone field is populated' do
-      fill_in('Your email', with: 'test@test.com')
-      fill_in('Subject line', with: 'Test subject')
       fill_in('Your message', with: 'This is a test message')
       fill_in('phone', visible: false, with: 'this is spam')
       # make sure the FormSpam records increase by 1
       expect { click_button('Send message') }.to change(FormSpam, :count).by(1)
       # make sure user is redirected to home page.
       expect(page).to have_current_path(root_path)
-    end
-
-    it 'should redirect the user to /nominate-an-innovation if they try to visit the old /nominate-a-practice URL' do
-      visit '/nominate-a-practice'
-      expect(page).to have_current_path(nominate_an_innovation_path)
-    end
-
-    it 'adds debug URL if sent from a non-PROD environment' do
-      fill_in('Your email', with: 'test@different.com')
-      fill_in('Subject line', with: 'Test stuff')
-      fill_in('Your message', with: 'This is a different test message')
-      click_button('Send message')
-      expect(ActionMailer::Base.deliveries.last.body.raw_source).to have_content('Sent from')
     end
   end
 end

--- a/spec/features/nominate_practices/nominate_a_practice_page_spec.rb
+++ b/spec/features/nominate_practices/nominate_a_practice_page_spec.rb
@@ -42,12 +42,17 @@ describe 'Nominate a practice page', type: :feature do
       expect(page).to have_current_path(root_path)
     end
 
-
-
-
     it 'should redirect the user to /nominate-an-innovation if they try to visit the old /nominate-a-practice URL' do
       visit '/nominate-a-practice'
       expect(page).to have_current_path(nominate_an_innovation_path)
+    end
+
+    it 'adds debug URL if sent from a non-PROD environment' do
+      fill_in('Your email', with: 'test@different.com')
+      fill_in('Subject line', with: 'Test stuff')
+      fill_in('Your message', with: 'This is a different test message')
+      click_button('Send message')
+      expect(ActionMailer::Base.deliveries.last.body.raw_source).to have_content('Sent from')
     end
   end
 end


### PR DESCRIPTION
### JIRA issue link
[DM-4339](https://agile6.atlassian.net/browse/DM-4339)

## Description - what does this code do?
- Adds a URL to emails sent via the Nominate form from DEV and STG
- cleans up and reorganizes the related spec
  - reflects that public users are able to nominate an innovation
  - separate messages involving email messages from render / redirect tests

## Testing done - how did you test it/steps on how can another person can test it 
- Go to `/nominate-an-innovation` in local dev
- Fill out the form fields and send the message
- The email generated by `letter_opener` should say `Sent from http://localhost...` under the message

## Screenshots, Gifs, Videos from application (if applicable)
![Screenshot 2023-12-12 at 4 17 20 PM](https://github.com/department-of-veterans-affairs/diffusion-marketplace/assets/5402927/a3b03560-97dd-41ba-994d-b8334f8a4007)
