### PR TITLE
Update node version in GitHub Actions CI

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -51,7 +51,7 @@ jobs:
         with:
           bundler-cache: true
       - name: Setup Node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: 16
       - name: Install PostgreSQL


### PR DESCRIPTION
## Description - what does this code do?
Address GitHub Actions warning:
```
The following actions uses node12 which is deprecated and will be forced to run on node16: actions/setup-node@v2. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/
```

## Testing done - how did you test it/steps on how can another person can test it 
- Inspect GitHub Actions output for [an old workflow run](https://github.com/department-of-veterans-affairs/diffusion-marketplace/actions/runs/7294807368?pr=756) and compare it with [one for this PR](https://github.com/department-of-veterans-affairs/diffusion-marketplace/actions/runs/7295213948). 
