### PR TITLE
Dm-4391 fix versions item type column

### DIFF
--- a/db/migrate/20240102214641_fix_versions_item_type.rb
+++ b/db/migrate/20240102214641_fix_versions_item_type.rb
@@ -1,0 +1,17 @@
+class FixVersionsItemType < ActiveRecord::Migration[6.1]
+  def up
+    remove_column :versions, :"{:null=>false}", :string, if_exists: true
+
+    default_item_type = 'DefaultItemType'
+    Version.where(item_type: nil).update_all(item_type: default_item_type)
+    change_column_null :versions, :item_type, false
+    unless index_exists?(:versions, [:item_type, :item_id])
+      add_index :versions, [:item_type, :item_id], name: 'index_versions_on_item_type_and_item_id'
+    end
+  end
+
+  def down
+    change_column_null :versions, :item_type, true
+    remove_index :versions, name: 'index_versions_on_item_type_and_item_id', if_exists: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_11_27_172710) do
+ActiveRecord::Schema.define(version: 2024_01_02_214641) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -1435,8 +1435,7 @@ ActiveRecord::Schema.define(version: 2023_11_27_172710) do
   end
 
   create_table "versions", force: :cascade do |t|
-    t.string "item_type"
-    t.string "{:null=>false}"
+    t.string "item_type", null: false
     t.bigint "item_id", null: false
     t.string "event", null: false
     t.string "whodunnit"


### PR DESCRIPTION
### JIRA issue link
https://agile6.atlassian.net/browse/DM-4391

## Description - what does this code do?
* adds migration to remove "{:null=>false}" column from `versions` table
* changes `item_type` column to be non-null, backfills any existing null `item_type` values with default string

## Testing done - how did you test it/steps on how can another person can test it 
* locally, sign in as admin and verify the filtration options appear as the second screenshot below with the `"{:null=>false}"` filter removed
* verify the `"{:null=>false}"` column is removed from the `versions` table in the db and schema

## Screenshots, Gifs, Videos from application (if applicable)
![Screenshot 2024-01-02 at 2 40 20 PM](https://github.com/department-of-veterans-affairs/diffusion-marketplace/assets/65036872/b59e3801-1a30-4bea-b39a-352a01c57522)
![Screenshot 2024-01-02 at 3 14 17 PM](https://github.com/department-of-veterans-affairs/diffusion-marketplace/assets/65036872/a6be5367-aa1c-40f8-a2f9-1f0a8a062745)


## Link to mock-ups/mock ups (image file if you have it) (if applicable)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Unit tests written (if applicable)
- [ ] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating JIRA issue
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs