### PR TITLE
DM-4389 add eager loading to queries for `admin/adoptions` page

### DIFF
--- a/app/helpers/active_admin_helpers.rb
+++ b/app/helpers/active_admin_helpers.rb
@@ -16,8 +16,8 @@ module ActiveAdminHelpers
   end
 
   def get_adoption_values(p, complete_map)
-    facility_data = VaFacility.cached_va_facilities.get_relevant_attributes
-    practice_diffusion_histories = p.diffusion_histories.exclude_clinical_resource_hubs.map { |dh|
+    facility_data = VaFacility.cached_va_facilities.get_relevant_attributes.includes(:visn)
+    practice_diffusion_histories = p.diffusion_histories.includes(:va_facility).exclude_clinical_resource_hubs.map { |dh|
       selected_facility = facility_data.select { |fd| fd.station_number === dh.va_facility.station_number }
       origin_facilities = origin_display_name(Practice.find_by(id: dh.practice_id))
       dh_status = dh.diffusion_history_statuses.first


### PR DESCRIPTION
### JIRA issue link
https://agile6.atlassian.net/browse/DM-4389

## Description - what does this code do?
fixes `bullet` gem warning for N+1 query on `admin/adoptions` page

## Testing done - how did you test it/steps on how can another person can test it 
verify the `admin/adoptions` page loads without the `bullet` warning appearing in the devtools console (should load a bit faster as well)

## Screenshots, Gifs, Videos from application (if applicable)


## Link to mock-ups/mock ups (image file if you have it) (if applicable)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Unit tests written (if applicable)
- [ ] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating JIRA issue
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs