### PR TITLE
DM-4390 add `user_email` as "Owner Email" to admin/practices filters

### DIFF
--- a/app/admin/practices.rb
+++ b/app/admin/practices.rb
@@ -4,7 +4,7 @@ include PracticeEditorUtils
 include UserUtils
 include ActiveAdminUtils
 
-ActiveAdmin.register Practice do
+ActiveAdmin.register Practice do # rubocop:disable Metrics/BlockLength
   actions :all, except: [:destroy]
   permit_params :name, :user_email, :retired, :retired_reason
   config.create_another = true
@@ -310,7 +310,7 @@ ActiveAdmin.register Practice do
 
   filter :name
   filter :support_network_email
-  filter :owner_email
+  filter :user_email, label: "Owner Email"
 
   controller do
     helper_method :adoption_facility_name
@@ -468,6 +468,15 @@ ActiveAdmin.register Practice do
         practice.update(highlight_body: params[:practice][:highlight_body])
         practice.update(highlight_attachment: params[:practice][:highlight_attachment]) if practice_highlight_attachment_params.present?
       end
+    end
+  end
+
+  controller do
+    def scoped_collection
+      relation = super
+      relation = relation.joins(:user)
+      relation = relation.includes(:user)
+      relation
     end
   end
 end

--- a/app/models/practice.rb
+++ b/app/models/practice.rb
@@ -463,4 +463,8 @@ class Practice < ApplicationRecord
       adoption_count: diffusion_histories.size
     )
   end
+
+  ransacker :user_email do
+    Arel.sql("users.email")
+  end
 end


### PR DESCRIPTION
### JIRA issue link
https://agile6.atlassian.net/browse/DM-4390

## Description - what does this code do?
Within the code for the admin/practices page its clear that there was an intended filter for an "owner email" that does not appear on the page. This was likely due to a misunderstanding about there being no `owner_email` attribute on the practices table, a bit of custom code is needed for such a filter to exist.

* adds `scoped_collection` to `admin/practices.rb` (added bonus, the eager loading added here fixes the `bullet` gem N+1 warning for the `admin/practices` page) and edits the `owner_email` filter to be `user_email`
* adds `ransacker` block to `Practice` model to make `user.email` available in `activeadmin` as filter

## Testing done - how did you test it/steps on how can another person can test it 
1. Locally, as admin, create a new practice and assign a user's email as the "user email`, some user email other than the "marketplace@va.gov"
2. Go to the `admin/practices` page and verify the "Owner Email" filter is present and functions as expected.
3. Verify there is no bullet gem warning in the devtools console.

## Screenshots, Gifs, Videos from application (if applicable)
![Screenshot 2024-01-02 at 4 07 12 PM](https://github.com/department-of-veterans-affairs/diffusion-marketplace/assets/65036872/01934852-9ee4-40b4-a38e-3bcf1464feef)


## Link to mock-ups/mock ups (image file if you have it) (if applicable)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Unit tests written (if applicable)
- [ ] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating JIRA issue
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs