### PR TITLE
Bump shoulda-matchers to v6.0.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -751,7 +751,7 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
-    shoulda-matchers (5.1.0)
+    shoulda-matchers (6.0.0)
       activesupport (>= 5.2.0)
     simplecov (0.21.2)
       docile (~> 1.1)


### PR DESCRIPTION
### JIRA issue link
N/A

## Description - what does this code do?
- bumps `shoulda-matchers` from v5.1.0 to v6.0.0
- Release notes: 
  - https://github.com/thoughtbot/shoulda-matchers/releases/tag/v6.0.0
  - https://github.com/thoughtbot/shoulda-matchers/releases/tag/v5.3.0
  - https://github.com/thoughtbot/shoulda-matchers/releases/tag/v5.2.0
- Diff: https://github.com/thoughtbot/shoulda-matchers/compare/v5.1.0...v6.0.0

## Testing done - how did you test it/steps on how can another person can test it 
- Confirm that CI runs as expected
