### PR TITLE
Feature: Homepage refresh

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -6,6 +6,7 @@ name: CodeQL
   pull_request:
     branches:
       - master
+      - feature/homepage-refresh
   schedule:
     - cron: 1 12 * * 1
   workflow_dispatch: null

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -58,3 +58,4 @@
 //= require category_usage.js
 //= require tinymce
 //= require page/page_infowindow
+//= require homepage

--- a/app/assets/javascripts/homepage.es6
+++ b/app/assets/javascripts/homepage.es6
@@ -1,0 +1,136 @@
+function setupSearchDropdown() {
+    const searchInput = $(`#dm-homepage-search-form .usa-input`);
+    const dropdown = $('#search-dropdown');
+
+    const allCategories = JSON.parse($('.homepage-search').attr('data-categories') || '[]');
+    const mostPopularCategories = allCategories.slice(0, 3);
+
+    const allInnovations = JSON.parse($('.homepage-search').attr('data-innovations') || '[]');
+    const mostRecentInnovations = allInnovations.slice(0, 3);
+
+    searchInput.focus(function() {
+        dropdown.show();
+        searchInput.attr('aria-expanded', 'true');
+    });
+
+    searchInput.on('input', function() {
+        let searchTerm = searchInput.val().toLowerCase();
+        let filteredCategories = searchTerm ? allCategories.filter(category => category.name.toLowerCase().includes(searchTerm)).slice(0,3) : mostPopularCategories;
+        let filteredInnovations = searchTerm ? allInnovations.filter(innovation => innovation.name.toLowerCase().includes(searchTerm)).slice(0,3) : mostRecentInnovations;
+        updateDropdown(filteredCategories, filteredInnovations);
+    });
+
+    $(document).keydown(function(e) {
+        if (searchInput.attr('aria-expanded') === 'true') {
+            const items = $('#search-dropdown .search-result a, #search-dropdown .browse-all-link');
+            const focusedElement = document.activeElement;
+            const focusedIndex = items.index(focusedElement);
+
+            if (e.keyCode === 40 || e.keyCode === 38) {
+                e.preventDefault();
+                if (e.keyCode === 40 && focusedIndex < items.length - 1) {
+                    items.eq(focusedIndex + 1).focus();
+                } else if (e.keyCode === 38 && focusedIndex > 0) {
+                    items.eq(focusedIndex - 1).focus();
+                }
+            }
+        }
+    });
+
+    $(document).on('click', function(event) {
+        if (!$(event.target).closest(`#dm-homepage-search-form, #search-dropdown`).length) {
+            dropdown.hide();
+            searchInput.attr('aria-expanded', 'false');
+        }
+    });
+
+    $(document).on('focusin', function(event) {
+        if (!$(event.target).closest(`#dm-homepage-search-form, #search-dropdown`).length) {
+            dropdown.hide();
+            searchInput.attr('aria-expanded', 'false');
+        }
+    });
+}
+
+function updateDropdown(categories, innovations) {
+  $('#category-list, #practice-list').empty();
+
+  categories.forEach(function(category) {
+      let link = $('<a></a>')
+          .attr('href', `/search?category=${encodeURIComponent(category.name)}`)
+          .text(category.name);
+      let listItem = $('<li></li>')
+          .addClass('search-result')
+          .attr('data-category-id', category.id)
+          .append(link);
+
+      $('#category-list').append(listItem);
+  });
+
+  innovations.forEach(function(innovation) {
+      let link = $('<a></a>')
+          .attr('href', `/innovations/${encodeURIComponent(innovation.slug)}`)
+          .text(innovation.name);
+      let listItem = $('<li></li>')
+          .addClass('search-result')
+          .attr('data-practice-id', innovation.id)
+          .append(link);
+
+      $('#practice-list').append(listItem);
+  });
+}
+
+function setupClickTracking(listSelector, eventName, dataAttribute) {
+  const dropdownContent = document.querySelector('.dropdown-content');
+  const list = dropdownContent ? dropdownContent.querySelector(listSelector) : null;
+  if (!list) return;
+
+  list.addEventListener('click', function(e) {
+    if (e.target && e.target.nodeName === 'A') {
+      e.preventDefault();
+
+      const name = e.target.innerText;
+      const url = e.target.getAttribute('href');
+      const id = e.target.closest('.search-result').getAttribute(dataAttribute);
+
+      let properties = { from_homepage: true};
+      properties[dataAttribute === 'data-practice-id' ? 'practice_name' : 'category_name'] = name;
+      properties[dataAttribute.slice(5)] = id; // Removes 'data-' and uses the rest as the key
+
+      ahoy.track(eventName, properties);
+
+      setTimeout(function() {
+        window.location.href = url;
+      }, 100);
+    }
+  });
+}
+
+function setupBrowseAllTracking() {
+  const browseAllLinks = document.querySelectorAll('.browse-all-link');
+  browseAllLinks.forEach(link => {
+    link.addEventListener('click', function(e) {
+      e.preventDefault();
+      const url = this.getAttribute('href');
+      const isCategoryLink = this.closest('.result-section').querySelector('#category-list') != null;
+
+      ahoy.track("Dropdown Browse-all Link Clicked", {
+        type: isCategoryLink ? 'category' : 'innovation',
+        url: url
+      });
+
+      setTimeout(function() {
+        window.location.href = url;
+      }, 100);
+    });
+  });
+};
+
+addEventListener('turbolinks:load', function () {
+  if ($('#dm-homepage-search-button').length > 0) {
+    setupSearchDropdown();
+    setupClickTracking('#practice-list', "Dropdown Practice Link Clicked", 'data-practice-id');
+    setupClickTracking('#category-list', "Category selected", 'data-category-id');
+    setupBrowseAllTracking();
+  }
+});

--- a/app/assets/javascripts/search.es6
+++ b/app/assets/javascripts/search.es6
@@ -27,7 +27,7 @@ function setupSearchDropdown(formId) {
     searchInput.on('input', function() {
         let searchTerm = searchInput.val().toLowerCase();
         let filteredCategories = searchTerm ? allCategories.filter(category =>
-            category.toLowerCase().includes(searchTerm)) : mostPopularCategories;
+            category.toLowerCase().includes(searchTerm)).slice(0,3) : mostPopularCategories;
         updateDropdown(filteredCategories);
     });
 

--- a/app/assets/javascripts/search.es6
+++ b/app/assets/javascripts/search.es6
@@ -16,12 +16,13 @@ function setupSearchDropdown(formId) {
     const dropdown = $('#search-dropdown');
 
     const allCategoriesString = $('.homepage-search').attr('data-categories');
-    const allCategories = allCategoriesString ? allCategoriesString.match(/[^",\[\]]+/g) : [];
-    const mostPopularCategories = allCategories ? allCategories.slice(0, 3) : [];
+    const allCategories = (allCategoriesString !== "[]") ? allCategoriesString.match(/[^",\[\]]+/g) : [];
+    const mostPopularCategories = allCategories ? allCategories.slice(0, 5).filter( str => str.startsWith(" ") == false ) : [];
 
     const allInnovationsString = $('.homepage-search').attr('data-innovations');
-    const allInnovations = allInnovationsString ? allInnovationsString.match(/[^",\[\]]+/g) : [];
-    const mostRecentInnovations = allInnovations ? allInnovations.slice(0, 3) : [];
+    const allInnovations = (allInnovationsString !== "[]") ? allInnovationsString.match(/[^",\[\]]+/g) : [];
+    const mostRecentInnovations = allInnovations ? allInnovations.slice(0, 5).filter( str => str.startsWith(" ") == false ) : [];
+
 
     searchInput.focus(function() {
         dropdown.show();

--- a/app/assets/javascripts/search.es6
+++ b/app/assets/javascripts/search.es6
@@ -11,12 +11,50 @@ function executePracticeSearch(formId) {
     });
 }
 
+function setupSearchDropdown(formId) {
+    const searchInput = $(`${formId} .usa-input`);
+    const dropdown = $('#search-dropdown');
+
+    const allCategoriesString = $('.homepage-search').attr('data-categories');
+
+    const allCategories = allCategoriesString ? allCategoriesString.match(/[^",\[\]]+/g) : [];
+    const mostPopularCategories = allCategories ? allCategories.slice(0, 3) : [];
+
+    searchInput.focus(function() {
+        dropdown.show();
+    });
+
+    searchInput.on('input', function() {
+        let searchTerm = $(this).val().toLowerCase();
+        let filteredCategories = searchTerm ? allCategories.filter(category =>
+            category.toLowerCase().includes(searchTerm)) : mostPopularCategories;
+        updateDropdown(filteredCategories);
+    });
+
+    $(document).click(function(event) {
+        if (!$(event.target).closest(`${formId}, #search-dropdown`).length) {
+            dropdown.hide();
+        }
+    });
+}
+
+function updateDropdown(categories) {
+    let categoryList = $('#category-list');
+    categoryList.empty();
+
+    categories.forEach(function(category) {
+        let link = $('<a></a>').attr('href', `/search?category=${encodeURIComponent(category)}`).text(category).addClass('public-sans');
+        let listItem = $('<li></li>').addClass('category-item padding-bottom-1').append(link);
+
+        categoryList.append(listItem);
+    });
+}
+
 addEventListener('turbolinks:load', function () {
-    // search in navbar
+    if ($('#dm-homepage-search-button').length > 0) {
+        setupSearchDropdown('#dm-homepage-search-form');
+    }
     executePracticeSearch('#dm-navbar-search-desktop-form');
-    // search in mobile navbar
     executePracticeSearch('#dm-navbar-search-mobile-form');
-    // search on homepage
     executePracticeSearch('#dm-homepage-search-form');
 });
-

--- a/app/assets/javascripts/search.es6
+++ b/app/assets/javascripts/search.es6
@@ -19,6 +19,10 @@ function setupSearchDropdown(formId) {
     const allCategories = allCategoriesString ? allCategoriesString.match(/[^",\[\]]+/g) : [];
     const mostPopularCategories = allCategories ? allCategories.slice(0, 3) : [];
 
+    const allInnovationsString = $('.homepage-search').attr('data-innovations');
+    const allInnovations = allInnovationsString ? allInnovationsString.match(/[^",\[\]]+/g) : [];
+    const mostRecentInnovations = allInnovations ? allInnovations.slice(0, 3) : [];
+
     searchInput.focus(function() {
         dropdown.show();
         searchInput.attr('aria-expanded', 'true');
@@ -28,12 +32,14 @@ function setupSearchDropdown(formId) {
         let searchTerm = searchInput.val().toLowerCase();
         let filteredCategories = searchTerm ? allCategories.filter(category =>
             category.toLowerCase().includes(searchTerm)).slice(0,3) : mostPopularCategories;
-        updateDropdown(filteredCategories);
+        let filteredInnovations = searchTerm ? allInnovations.filter(innovation =>
+            innovation.toLowerCase().includes(searchTerm)).slice(0,3) : mostRecentInnovations;
+        updateDropdown(filteredCategories, filteredInnovations);
     });
 
     $(document).keydown(function(e) {
         if (searchInput.attr('aria-expanded') === 'true') {
-            const items = $('#search-dropdown .category-item a, #search-dropdown .browse-all-link');
+            const items = $('#search-dropdown .search-result a, #search-dropdown .browse-all-link');
             const focusedElement = document.activeElement;
             const focusedIndex = items.index(focusedElement);
 
@@ -59,16 +65,26 @@ function setupSearchDropdown(formId) {
     $(document).on('focusin', hideDropdownOutsideClickOrFocus);
 }
 
-function updateDropdown(categories) {
+function updateDropdown(categories, innovations) {
+    const innovationLinks = JSON.parse($('.homepage-search').attr('data-innovation-links'));
     let categoryList = $('#category-list');
-    categoryList.empty();
+    let innovationList = $('#practice-list');
+    $('li').remove('.search-result');
 
     categories.forEach(function(category) {
-        let link = $('<a></a>').attr('href', `/search?category=${encodeURIComponent(category)}`).text(category).addClass('public-sans');
-        let listItem = $('<li></li>').addClass('category-item padding-bottom-1').append(link);
+        let link = $('<a></a>').attr('href', `/search?category=${encodeURIComponent(category)}`).text(category);
+        let listItem = $('<li></li>').addClass('search-result').append(link);
 
         categoryList.append(listItem);
     });
+
+    innovations.forEach(function(innovation) {
+        let link = $('<a></a>').attr('href', `/innovations/${encodeURIComponent(innovationLinks[innovation])}` ).text(innovation);
+        let listItem = $('<li></li>').addClass('search-result').append(link);
+
+        innovationList.append(listItem);
+    });
+
 }
 
 addEventListener('turbolinks:load', function () {

--- a/app/assets/javascripts/search.es6
+++ b/app/assets/javascripts/search.es6
@@ -89,9 +89,6 @@ function updateDropdown(categories, innovations) {
 }
 
 addEventListener('turbolinks:load', function () {
-    if ($('#dm-homepage-search-button').length > 0) {
-        setupSearchDropdown('#dm-homepage-search-form');
-    }
     executePracticeSearch('#dm-navbar-search-desktop-form');
     executePracticeSearch('#dm-navbar-search-mobile-form');
     executePracticeSearch('#dm-homepage-search-form');

--- a/app/assets/javascripts/search.es6
+++ b/app/assets/javascripts/search.es6
@@ -16,26 +16,47 @@ function setupSearchDropdown(formId) {
     const dropdown = $('#search-dropdown');
 
     const allCategoriesString = $('.homepage-search').attr('data-categories');
-
     const allCategories = allCategoriesString ? allCategoriesString.match(/[^",\[\]]+/g) : [];
     const mostPopularCategories = allCategories ? allCategories.slice(0, 3) : [];
 
     searchInput.focus(function() {
         dropdown.show();
+        searchInput.attr('aria-expanded', 'true');
     });
 
     searchInput.on('input', function() {
-        let searchTerm = $(this).val().toLowerCase();
+        let searchTerm = searchInput.val().toLowerCase();
         let filteredCategories = searchTerm ? allCategories.filter(category =>
             category.toLowerCase().includes(searchTerm)) : mostPopularCategories;
         updateDropdown(filteredCategories);
     });
 
-    $(document).click(function(event) {
-        if (!$(event.target).closest(`${formId}, #search-dropdown`).length) {
-            dropdown.hide();
+    $(document).keydown(function(e) {
+        if (searchInput.attr('aria-expanded') === 'true') {
+            const items = $('#search-dropdown .category-item a, #search-dropdown .browse-all-link');
+            const focusedElement = document.activeElement;
+            const focusedIndex = items.index(focusedElement);
+
+            if (e.keyCode === 40 || e.keyCode === 38) {
+                e.preventDefault();
+                if (e.keyCode === 40 && focusedIndex < items.length - 1) {
+                    items.eq(focusedIndex + 1).focus();
+                } else if (e.keyCode === 38 && focusedIndex > 0) {
+                    items.eq(focusedIndex - 1).focus();
+                }
+            }
         }
     });
+
+    function hideDropdownOutsideClickOrFocus(event) {
+        if (!$(event.target).closest(`${formId}, #search-dropdown`).length) {
+            dropdown.hide();
+            searchInput.attr('aria-expanded', 'false');
+        }
+    }
+
+    $(document).on('click', hideDropdownOutsideClickOrFocus);
+    $(document).on('focusin', hideDropdownOutsideClickOrFocus);
 }
 
 function updateDropdown(categories) {

--- a/app/assets/stylesheets/dm/components/_buttons.scss
+++ b/app/assets/stylesheets/dm/components/_buttons.scss
@@ -187,3 +187,14 @@
   @include u-bg($theme-color-dm-white, !important);
   @include u-text('base-darkest', !important);
 }
+
+@mixin transition-btn-colors { // homepage refresh 2024 colors - delete and update primary palette later
+  @include u-bg('primary-darker');
+
+  &:hover {
+    @include u-bg('primary-dark');
+  }
+  &:active {
+    @include u-bg('primary-vivid');
+  }
+}

--- a/app/assets/stylesheets/dm/components/_links.scss
+++ b/app/assets/stylesheets/dm/components/_links.scss
@@ -67,7 +67,7 @@
   &-dark {
     color: color($theme-color-base-ink);
     text-decoration: none;
-    @include u-text('semibold', !important);
+    @include u-text('semibold');
 
     &:hover {
       color: color($theme-color-primary-vivid);

--- a/app/assets/stylesheets/dm/pages/_home.scss
+++ b/app/assets/stylesheets/dm/pages/_home.scss
@@ -40,6 +40,21 @@
     #dm-homepage-search-button {
       @include transition-btn-colors;
     }
+
+    .search-dropdown {
+      top: 100%; /* Position below the input */
+      @include u-border('gray-30');
+      @include u-position('absolute');
+      z-index: 2000;
+    }
+
+    #category-list .category-item {
+      cursor: pointer;
+    }
+
+    #category-list .category-item:hover {
+      @include u-text-decoration('underline');
+    }
   }
 
   .featured-innovation-content-container {

--- a/app/assets/stylesheets/dm/pages/_home.scss
+++ b/app/assets/stylesheets/dm/pages/_home.scss
@@ -36,6 +36,10 @@
         color: color($theme-color-base-ink) !important;
       }
     }
+
+    #dm-homepage-search-button {
+      @include transition-btn-colors;
+    }
   }
 
   .featured-innovation-content-container {
@@ -86,16 +90,12 @@
   }
 
   .shark-tank-banner {
-    @include u-line-height('sans', 3, !important);
-    @include u-height(8);
-    background-color: color($theme-color-accent-warm);
+    @include u-line-height('sans', 3);
+    background-color: color($theme-color-warning-lighter);
 
     a {
-      @include u-text-decoration('underline', !important);
-    }
-
-    @media screen and (min-width: 640px) {
-      @include u-height(7);
+      @include u-text-decoration('underline');
+      font-weight: 600;
     }
   }
 }

--- a/app/assets/stylesheets/dm/pages/_home.scss
+++ b/app/assets/stylesheets/dm/pages/_home.scss
@@ -46,15 +46,37 @@
       @include u-border('gray-30');
       @include u-position('absolute');
       z-index: 2000;
+
+      .browse-all-link {
+        color: color($theme-color-base-ink);
+        @include u-text-decoration('underline');
+
+        &:hover, &:focus {
+          color: color('primary-dark');
+        }
+
+        &:active {
+          color: color('primary-vivid');
+        }
+      }
     }
 
-    #category-list .category-item {
-      cursor: pointer;
-    }
+    #category-list {
+      a {
+        text-decoration: none;
+        color: color($theme-color-base-ink);
 
-    #category-list .category-item:hover {
-      @include u-text-decoration('underline');
-    }
+
+        &:hover, &:active, &:focus {
+          @include u-text-decoration('underline');
+        }
+
+
+        &:visited {
+          color: color($theme-color-base-ink);
+        }
+      }
+    };
   }
 
   .featured-innovation-content-container {

--- a/app/assets/stylesheets/dm/pages/_home.scss
+++ b/app/assets/stylesheets/dm/pages/_home.scss
@@ -41,13 +41,14 @@
       @include transition-btn-colors;
     }
 
-    .search-dropdown {
+    #search-dropdown {
       top: 100%; /* Position below the input */
       @include u-border('gray-30');
       @include u-position('absolute');
       z-index: 2000;
+    }
 
-      .browse-all-link {
+    .browse-all-link {
         color: color($theme-color-base-ink);
         @include u-text-decoration('underline');
 
@@ -58,13 +59,23 @@
         &:active {
           color: color('primary-vivid');
         }
-      }
     }
 
-    #category-list {
+    .result-section:not(:last-child) {
+      padding-bottom: 1rem;
+      border-bottom: 1px solid black;
+    }
+
+    #category-list, #practice-list {
       a {
         text-decoration: none;
         color: color($theme-color-base-ink);
+        padding-bottom: 0.5rem; // == padding-bottom-1
+        // truncation
+        display: block;
+        text-overflow: ellipsis;
+        overflow: hidden;
+        white-space: nowrap;
 
 
         &:hover, &:active, &:focus {
@@ -76,7 +87,7 @@
           color: color($theme-color-base-ink);
         }
       }
-    };
+    }
   }
 
   .featured-innovation-content-container {

--- a/app/assets/stylesheets/dm/pages/_home.scss
+++ b/app/assets/stylesheets/dm/pages/_home.scss
@@ -3,28 +3,7 @@
 // You can use Sass (SCSS) here: http://sass-lang.com/
 
 .dm-homepage {
-  .homepage-welcome-banner {
-    .homepage-welcome-banner-body-text-container {
-      margin-bottom: 119px;
-
-      @media screen and (min-width: 1024px) {
-        @include u-margin-bottom(0);
-      }
-    }
-  }
-
-  .homepage-welcome-banner-image-container {
-    @include u-position('absolute');
-    bottom: -87px;
-
-    @media screen and (min-width: 1024px) {
-      height: 223px;
-      @include u-right(0);
-      bottom: unset;
-    }
-  }
-
-  .homepage-welcome-banner-image-container, .homepage-featured-topic-image-container, .homepage-featured-innovation-image-container {
+  .homepage-featured-topic-image-container, .homepage-featured-innovation-image-container {
     max-width: 308px;
 
     img {
@@ -49,7 +28,7 @@
 
   .homepage-search {
     @media screen and (max-width: 1023px) {
-      margin-top: 119px;
+      margin-top: 1rem;
     }
 
     #dm-homepage-search-field {

--- a/app/assets/stylesheets/dm/pages/_partials/_navbar_search.scss
+++ b/app/assets/stylesheets/dm/pages/_partials/_navbar_search.scss
@@ -11,16 +11,12 @@
   }
 
   .dm-navbar-search-button {
-    @include u-bg('primary-vivid');
+    @include transition-btn-colors;
     @include u-radius-right('md');
     height: 2rem;
     width: 3.0625rem;
     font-size: 1rem;
     padding-top: 0.75rem;
-
-    &:hover {
-      @include u-bg('primary-dark');
-    }
   }
 
   // desktop

--- a/app/assets/stylesheets/dm/pages/_search.scss
+++ b/app/assets/stylesheets/dm/pages/_search.scss
@@ -128,10 +128,19 @@
       @include u-margin-bottom(0);
     }
   }
+
+  #update-search-results-button {
+    @include transition-btn-colors;
+  }
 }
 
 #update-search-results-form {
+  #mobile_filters_button {
+    @include transition-btn-colors;
+  }
+
   #dm-practice-search-button {
+    @include transition-btn-colors;
     background-image: none !important;
     width: 85px !important;
     padding: 8px 16px 8px 16px !important;

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -5,7 +5,7 @@ class HomeController < ApplicationController
 
   def index
     @highlighted_pr = Practice.where(highlight: true, published: true, enabled: true, approved: true).first
-    @popular_categories = get_most_popular_categories
+    @category_names_by_popularity = get_category_names_by_popularity
     @featured_topic = Topic.find_by(featured: true)
   end
 

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -7,6 +7,8 @@ class HomeController < ApplicationController
     @highlighted_pr = Practice.where(highlight: true, published: true, enabled: true, approved: true).first
     @category_names_by_popularity = get_category_names_by_popularity
     @featured_topic = Topic.find_by(featured: true)
+    @practice_names_and_slugs = practice_names_and_slugs_hash
+    @practice_names = @practice_names_and_slugs.keys
   end
 
   def diffusion_map
@@ -74,6 +76,17 @@ class HomeController < ApplicationController
   end
 
   private
+
+  def practice_names_and_slugs_hash
+    dropdown_practices.pluck("name", "slug").to_h
+  end
+
+  def dropdown_practices
+    scope = Practice.where(published: true, retired: false)
+    scope = scope.where(is_public: true) if !current_user
+    scope = scope.order("created_at DESC")
+    scope
+  end
 
   def get_diffusion_histories(is_public_practice)
     DiffusionHistory.get_with_practices(is_public_practice).order(Arel.sql("lower(practices.name)"))

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -5,10 +5,9 @@ class HomeController < ApplicationController
 
   def index
     @highlighted_pr = Practice.where(highlight: true, published: true, enabled: true, approved: true).first
-    @category_names_by_popularity = get_category_names_by_popularity
+    @dropdown_categories = get_categories_by_popularity
     @featured_topic = Topic.find_by(featured: true)
-    @practice_names_and_slugs = practice_names_and_slugs_hash
-    @practice_names = @practice_names_and_slugs.keys
+    @dropdown_practices, @practice_names = get_dropdown_practices
   end
 
   def diffusion_map
@@ -77,8 +76,14 @@ class HomeController < ApplicationController
 
   private
 
-  def practice_names_and_slugs_hash
-    dropdown_practices.pluck("name", "slug").to_h
+  def get_dropdown_practices
+    practice_names = []
+    practices_hash = dropdown_practices.pluck(:id, :name, :slug).map do |id, name, slug|
+      practice_names << name
+      {name: name, id: id, slug: slug }
+    end
+
+    return practices_hash, practice_names
   end
 
   def dropdown_practices

--- a/app/helpers/categories_helper.rb
+++ b/app/helpers/categories_helper.rb
@@ -1,13 +1,23 @@
 module CategoriesHelper
-  def get_most_popular_categories
-    pop_cat_names = []
-    categories_count = Ahoy::Event.where(name: "Category selected").where("time > ?", Time.now-90.days).pluck(:properties).map { |d| d["category_id"].to_i }.tally
-    if categories_count.present?
-      pop_cats = categories_count.sort_by { |rec, number| number  }.last(20).reverse
-      pop_cat_ids = pop_cats.map {|row| row[0]}
-      pop_cat_names = Category.where(id: pop_cat_ids).pluck(:name)
+  def get_category_names_by_popularity
+    time_limit = Time.now - 90.days
+    Rails.cache.fetch('categories_with_popularity', expires_in: 24.hours) do
+      # returns only category names that can be found in the filters on the /search page,
+      # raw SQL allows for joining category selection events to be used for ordering,
+      # left joins allows categories with no selection events to be returned
+      Category.where(is_other: false)
+              .joins(
+                'LEFT JOIN ahoy_events ' \
+                'ON categories.id = CAST(ahoy_events.properties ->> \'category_id\' AS INTEGER) ' \
+                'AND ahoy_events.name = \'Category selected\' ' \
+                'AND ahoy_events.time > \'' + time_limit.to_s(:db) + '\''
+              )
+              .joins(:parent_category)
+              .where.not(parent_category: nil)
+              .group('categories.id')
+              .order('COUNT(ahoy_events.id) DESC, categories.name')
+              .pluck('categories.name')
     end
-    pop_cat_names
   end
 
   def update_category_usages

--- a/app/helpers/categories_helper.rb
+++ b/app/helpers/categories_helper.rb
@@ -1,5 +1,5 @@
 module CategoriesHelper
-  def get_category_names_by_popularity
+  def get_categories_by_popularity
     time_limit = Time.now - 90.days
     Rails.cache.fetch('categories_with_popularity', expires_in: 24.hours) do
       # returns only category names that can be found in the filters on the /search page,
@@ -16,7 +16,8 @@ module CategoriesHelper
               .where.not(parent_category: nil)
               .group('categories.id')
               .order('COUNT(ahoy_events.id) DESC, categories.name')
-              .pluck('categories.name')
+              .pluck('categories.id', 'categories.name')
+              .map { |id, name| { id: id, name: name } }
     end
   end
 

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -51,9 +51,7 @@
                 </li>
               <% end %>
             </ul>
-            <span class="public-sans extra-bold padding-top-1">
-              <a class="public-sans text-bold" href="<%= search_path %>">View all categories</a>
-            </span>
+            <a class="browse-all-link public-sans text-bold padding-top-1" href="<%= search_path %>">Browse all categories</a>
           </div>
         </div>
         <button id="dm-homepage-search-button" class="usa-button height-5 margin-right-0" type="submit">

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -19,23 +19,49 @@
     </div>
   </section>
 
-  <section class="homepage-search grid-container margin-top-4 margin-bottom-4 desktop:margin-bottom-8 margin-top-10" role="region" aria-label="Homepage search section">
+  <section
+    class="homepage-search grid-container margin-top-4 margin-bottom-4 desktop:margin-bottom-8 margin-top-10"
+    role="region"
+    aria-label="Homepage search section"
+    data-categories="<%= ERB::Util.html_escape(@category_names_by_popularity.to_json) %>"
+  >
     <form id="dm-homepage-search-form" class="usa-search margin-bottom-2" role="search">
-      <label class="usa-sr-only" for="dm-homepage-search-form">
-        Homepage search
-      </label>
+      <label class="usa-sr-only" for="dm-homepage-search-form">Homepage search</label>
       <div class="dm-homepage-search-container width-full">
-        <input class="usa-input height-5" id="dm-homepage-search-field" type="search" name="search" title="Search for innovations" placeholder="&quot;Search terms&quot;">
+        <input
+          class="usa-input height-5"
+          id="dm-homepage-search-field"
+          type="search"
+          name="search"
+          title="Search for innovations"
+          autocomplete="off"
+          placeholder="Innovations, categories, partners..."
+        >
+        <div
+          id="search-dropdown"
+          class="search-dropdown radius-md bg-white shadow-5 left-0 right-0"
+          style="display: none;"
+        >
+          <div class="dropdown-content margin-4">
+            <span class="category-header usa-prose-h3 text-bold" aria-label="Categories">Categories</span>
+            <ul id="category-list" class="usa-list usa-list--unstyled padding-top-1">
+              <% @category_names_by_popularity[0..2].each do |category_name| %>
+                <li class="category-item padding-bottom-1">
+                  <a class="public-sans" href=<%= "/search?category=#{category_name}" %>><%= category_name %></a>
+                </li>
+              <% end %>
+            </ul>
+            <span class="public-sans extra-bold padding-top-1">
+              <a class="public-sans text-bold" href="<%= search_path %>">View all categories</a>
+            </span>
+          </div>
+        </div>
         <button id="dm-homepage-search-button" class="usa-button height-5 margin-right-0" type="submit">
           <span class="usa-search__submit-text">Search</span>
         </button>
       </div>
     </form>
-    <p class="usa-prose-body">
-      <%= link_to 'Browse all innovations', search_path, class: 'dm-button--unstyled-primary' %>
-    </p>
   </section>
-  <%= render partial: 'home/popular_categories_section', locals: { section_name: 'popular categories' } if @popular_categories.any? %>
 
   <% if @featured_topic.present? && @featured_topic.title.present? && @featured_topic.description.present? && @featured_topic.url.present? && @featured_topic.cta_text.present? && @featured_topic.attachment.exists?%>
     <%= render partial: 'home/featured_section', locals: {

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -24,34 +24,48 @@
     role="region"
     aria-label="Homepage search section"
     data-categories="<%= @category_names_by_popularity %>"
+    data-innovations="<%= @practice_names %>"
+    data-innovation-links="<%= @practice_names_and_slugs.to_json %>"
   >
-    <form id="dm-homepage-search-form" class="usa-search margin-bottom-2" role="search">
-      <label class="usa-sr-only" for="dm-homepage-search-form">Homepage search</label>
+    <form id="dm-homepage-search-form" class="usa-search margin-bottom-2" role="search" aria-label="Search innovations and categories">
       <div class="dm-homepage-search-container width-full">
         <input
           class="usa-input height-5"
           id="dm-homepage-search-field"
           type="search"
           name="search"
-          title="Search for innovations"
           autocomplete="off"
-          placeholder="Innovations, categories, partners..."
+          placeholder="Innovations, categories..."
+          aria-labelledby="dm-homepage-search-form"
         >
         <div
           id="search-dropdown"
-          class="search-dropdown radius-md bg-white shadow-5 left-0 right-0"
+          class="radius-md bg-white shadow-5 left-0 right-0"
           style="display: none;"
         >
           <div class="dropdown-content margin-4">
-            <span class="category-header usa-prose-h3 text-bold" aria-label="Categories">Categories</span>
-            <ul id="category-list" class="usa-list usa-list--unstyled padding-top-1">
-              <% @category_names_by_popularity[0..2].each do |category_name| %>
-                <li class="category-item padding-bottom-1">
-                  <a class="public-sans" href=<%= "/search?category=#{category_name}" %>><%= category_name %></a>
-                </li>
-              <% end %>
-            </ul>
-            <a class="browse-all-link public-sans text-bold padding-top-1" href="<%= search_path %>">Browse all categories</a>
+            <div class="result-section">
+              <h3 class="search-header usa-prose-h3 margin-bottom-0">Innovations</h3>
+              <ul id="practice-list" class="usa-list usa-list--unstyled padding-top-1">
+                <% @practice_names[0..2].each do |practice_name| %>
+                  <li class="search-result">
+                    <a href="/innovations/<%= @practice_names_and_slugs[practice_name] %>"><%= practice_name %></a>
+                  </li>
+                <% end %>
+              </ul>
+              <a class="browse-all-link text-bold" href="<%= search_path %>">Browse all innovations</a>
+            </div>
+            <div class="result-section">
+              <h3 class="search-header usa-prose-h3 margin-bottom-0" aria-label="Categories">Categories</h3>
+              <ul id="category-list" class="usa-list usa-list--unstyled padding-top-1">
+                <% @category_names_by_popularity[0..2].each do |category_name| %>
+                  <li class="search-result">
+                    <a href=<%= "/search?category=#{category_name}" %>><%= category_name %></a>
+                  </li>
+                <% end %>
+              </ul>
+              <a class="browse-all-link text-bold" href="<%= search_path %>">Browse all categories</a>
+            </div>
           </div>
         </div>
         <button id="dm-homepage-search-button" class="usa-button height-5 margin-right-0" type="submit">

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -23,9 +23,8 @@
     class="homepage-search grid-container margin-top-4 margin-bottom-4 desktop:margin-bottom-8 margin-top-10"
     role="region"
     aria-label="Homepage search section"
-    data-categories="<%= @category_names_by_popularity %>"
-    data-innovations="<%= @practice_names %>"
-    data-innovation-links="<%= @practice_names_and_slugs.to_json %>"
+    data-categories="<%= @dropdown_categories.to_json %>"
+    data-innovations="<%= @dropdown_practices.to_json %>"
   >
     <form id="dm-homepage-search-form" class="usa-search margin-bottom-2" role="search" aria-label="Search innovations and categories">
       <div class="dm-homepage-search-container width-full">
@@ -47,9 +46,9 @@
             <div class="result-section">
               <h3 class="search-header usa-prose-h3 margin-bottom-0">Innovations</h3>
               <ul id="practice-list" class="usa-list usa-list--unstyled padding-top-1">
-                <% @practice_names[0..2].each do |practice_name| %>
-                  <li class="search-result">
-                    <a href="/innovations/<%= @practice_names_and_slugs[practice_name] %>"><%= practice_name %></a>
+                <% @dropdown_practices[0..2].each do |practice| %>
+                  <li class="search-result" data-practice-id=<%= practice[:id] %>>
+                    <a href="/innovations/<%= practice[:slug] %>"><%= practice[:name] %></a>
                   </li>
                 <% end %>
               </ul>
@@ -58,9 +57,9 @@
             <div class="result-section">
               <h3 class="search-header usa-prose-h3 margin-bottom-0" aria-label="Categories">Categories</h3>
               <ul id="category-list" class="usa-list usa-list--unstyled padding-top-1">
-                <% @category_names_by_popularity[0..2].each do |category_name| %>
-                  <li class="search-result">
-                    <a href=<%= "/search?category=#{category_name}" %>><%= category_name %></a>
+                <% @dropdown_categories[0..2].each do |category| %>
+                  <li class="search-result" data-category-id=<%= category[:id] %>>
+                    <a href=<%= "/search?category=#{category[:name]}" %>><%= category[:name] %></a>
                   </li>
                 <% end %>
               </ul>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -6,35 +6,22 @@
     </div>
   </div>
   <!-- "Welcome" section -->
-  <section class="homepage-welcome-banner dm-gradient-banner-318" role="region" aria-label="Homepage welcome banner">
-    <div class="grid-container height-full">
-      <div class="grid-row height-full flex-align-center">
-        <div class="grid-col-12">
-          <h1 class="usa-prose-h1 text-white margin-top-4 margin-bottom-4 desktop:margin-top-0">
+  <section class="usa-section padding-top-3 padding-bottom-7 bg-primary-darker" role="region" aria-label="Homepage welcome banner">
+    <div class="grid-container">
+      <div class="grid-row flex-justify-center text-white">
+          <h1 class="usa-prose-h1 text-left desktop:text-center">
             Discover VA innovations to adopt at your facility
           </h1>
-          <div class="grid-row position-relative">
-            <div class="homepage-welcome-banner-body-text-container grid-col-12 desktop:grid-col-7 padding-right-105">
-              <p class="usa-prose-body text-white margin-bottom-2">
-                We’re a discovery and collaboration tool that curates VA’s promising innovations, encourages their diffusion, and fosters engagement with greater healthcare communities.
-              </p>
-              <%= link_to 'Learn more', about_path, class: 'dm-button--unstyled-gold' %>
-            </div>
-            <div class="homepage-welcome-banner-image-container text-white grid-col-12 tablet:grid-col-6 desktop:grid-col-5 desktop:padding-left-105">
-              <%= image_tag(
-                    'homepage-image.png',
-                    class: 'display-block padding-left-0',
-                    alt: 'VA Secretary McDonough speaks with a clinician during his visit to the D.C. VA Medical Center in February 2021.'
-                  )
-              %>
-            </div>
+        <div class="grid-col-12 desktop:grid-col-9">
+            <p class="usa-prose-body margin-top-1 text-center">
+              We’re a discovery and collaboration tool that curates VA’s promising innovations, encourages their diffusion, and fosters engagement with greater healthcare communities.
+            </p>
           </div>
-        </div>
       </div>
     </div>
   </section>
 
-  <section class="homepage-search grid-container margin-top-4 margin-bottom-4 desktop:margin-bottom-8 desktop:margin-top-10" role="region" aria-label="Homepage search section">
+  <section class="homepage-search grid-container margin-top-4 margin-bottom-4 desktop:margin-bottom-8 margin-top-10" role="region" aria-label="Homepage search section">
     <form id="dm-homepage-search-form" class="usa-search margin-bottom-2" role="search">
       <label class="usa-sr-only" for="dm-homepage-search-form">
         Homepage search

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -23,7 +23,7 @@
     class="homepage-search grid-container margin-top-4 margin-bottom-4 desktop:margin-bottom-8 margin-top-10"
     role="region"
     aria-label="Homepage search section"
-    data-categories="<%= ERB::Util.html_escape(@category_names_by_popularity.to_json) %>"
+    data-categories="<%= @category_names_by_popularity %>"
   >
     <form id="dm-homepage-search-form" class="usa-search margin-bottom-2" role="search">
       <label class="usa-sr-only" for="dm-homepage-search-form">Homepage search</label>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,9 +1,7 @@
 <div class="dm-homepage">
   <%= render partial: "shared/messages", locals: {small_text: false} %>
-  <div class="font-sans-2xs shark-tank-banner display-flex flex-align-center">
-    <div class="padding-x-2 desktop:padding-x-7">
-      <span>Learn more about the <a href="/competitions/shark-tank" class="text-bold dm-alt-link-dark">2024 VHA Shark Tank competition</a></span>
-    </div>
+  <div class="font-sans-2xs shark-tank-banner padding-x-2 desktop:padding-x-7 padding-y-105">
+    <p>Learn more about the <a href="/competitions/shark-tank" class="dm-alt-link-dark">2024 VHA Shark Tank competition</a></p>
   </div>
   <!-- "Welcome" section -->
   <section class="usa-section padding-top-3 padding-bottom-7 bg-primary-darker" role="region" aria-label="Homepage welcome banner">

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -59,7 +59,7 @@
               <ul id="category-list" class="usa-list usa-list--unstyled padding-top-1">
                 <% @dropdown_categories[0..2].each do |category| %>
                   <li class="search-result" data-category-id=<%= category[:id] %>>
-                    <a href=<%= "/search?category=#{category[:name]}" %>><%= category[:name] %></a>
+                    <a href=<%= "/search?category=#{URI.encode_www_form_component(category[:name])}" %>><%= category[:name] %></a>
                   </li>
                 <% end %>
               </ul>

--- a/app/views/practices/_search.js.erb
+++ b/app/views/practices/_search.js.erb
@@ -96,18 +96,18 @@ function buildPracticeCard(result) {
         '</h3>';
 
     // Default card image
-    var cardImagePlaceholder = 
+    var cardImagePlaceholder =
         '<div class="practice-card-img-placeholder" data-practice-id="' + practiceId + '" data-practice-image="' + practiceImage + '" data-practice-name="' + practiceName + '"  ></div>'
 
     var cardRetiredBanner = '';
     if (result.item.retired) {
         cardRetiredBanner = '<div class="dm-practice-retired-banner"><h5>Retired</h5></div>';
     }
-    
+
 
     cardHtml +=
         '<div class="dm-practice-card padding-bottom-3 tablet:grid-col-6 desktop:grid-col-4 position-relative">' +
-            '<a href="/innovations/' + result.item.slug + 
+            '<a href="/innovations/' + result.item.slug +
                 '" tabindex="-1" aria-hidden="true" class="dm-practice-link-aria-hidden position-absolute top-0 bottom-3 left-105 right-105 z-100"></a>' +
             '<div class="dm-practice-card-container">' +
                 cardImagePlaceholder +
@@ -1065,12 +1065,16 @@ function searchPracticesPage() {
         $(containerEl).addClass('display-none');
     }
 
+    var accordionButton = $('.search-filters-accordion-button')
+    function accordionText(checkboxCount, inputCount) {
+        return accordionButton.text('Filters ' + '(' + (checkboxCount + inputCount) + ')');
+    }
+
     $(document).on('submit', '#update-search-results-form', function (e) {
         e.preventDefault();
         hideResultsSectionElAndShowSpinner();
 
         // Close search filter accordion if it's open
-        var accordionButton = $('.search-filters-accordion-button')
         if (accordionButton.attr('aria-expanded') == 'true') {
             accordionButton.attr('aria-expanded', 'false');
             $('#search_filters_dropdown').attr('hidden', 'true');
@@ -1137,9 +1141,6 @@ function searchPracticesPage() {
         var noAdoptingFacilityText = adoptingFacilityInput.val() === '';
         var adoptingFacilityTextPresent = adoptingFacilityInput.val() !== '';
 
-        function accordionText(checkboxCount, inputCount) {
-            return accordionButton.text('Filters ' + '(' + (checkboxCount + inputCount) + ')');
-        }
 
         if (checkboxCount > 0 && originatingFacilityTextPresent && noAdoptingFacilityText) {
             accordionText(checkboxCount, 1);
@@ -1204,13 +1205,23 @@ function searchPracticesPage() {
 
     if (window.location.pathname === '/search' && window.location.search !== '' && searchLocation[0] !== '?filter_by') {
         hideResultsSectionElAndShowSpinner();
-        var query = window.location.search.split('=')[1];
+        const params = new URLSearchParams(window.location.search);
+        const query = params.get('query');
+        const category = params.get('category');
 
-        search(decodeURI(query));
-        if (query !== undefined) {
-            searchField.value = decodeURI(query.split('&')[0]);
+        if (category) {
+            const checkboxSelector = `input[type="checkbox"][name="${category}"]`;
+            const checkbox = $(checkboxSelector);
+            checkbox.prop('checked', true);
+            accordionText(1, 0)
+            search('', [category]);
+        } else if (query) {
+            search(decodeURI(query));
+            searchField.value = decodeURI(query);
         } else {
+            // No query or category filter
             searchField.value = '';
+            search('');
         }
     } else if ((searchLocation[0] === '?filter_by') || (window.location.pathname === '/search' && window.location.search === '')) {
         hideResultsSectionElAndShowSpinner();

--- a/app/views/shared/_navbar_search.html.erb
+++ b/app/views/shared/_navbar_search.html.erb
@@ -3,12 +3,9 @@
   search_field_id ||= 'dm-navbar-search-field'
   search_button_id ||= 'dm-navbar-search-button'
 %>
-<form id="<%= search_form_id %>" class="dm-navbar-search-form usa-search usa-search--small<%= ' margin-right-0' if ENV['VAEC_ENV'] === 'true' && session[:user_type] === 'guest' %>" role="search">
-  <label class="usa-sr-only" for="<%= search_form_id %>">
-    practice search
-  </label>
+<form id="<%= search_form_id %>" class="dm-navbar-search-form usa-search usa-search--small<%= ' margin-right-0' if ENV['VAEC_ENV'] === 'true' && session[:user_type] === 'guest' %>" role="search" aria-label="search innovations">
   <div class="dm-navbar-search-container">
-    <input class="usa-input dm-navbar-search-field" id="<%= search_field_id %>" type="search" name="search" title="Search practices">
+    <input class="usa-input dm-navbar-search-field" id="<%= search_field_id %>" type="search" name="search" aria-labelledby="<%= search_form_id %>">
     <button id="<%= search_button_id %>" class="usa-button dm-navbar-search-button" type="submit">
       <span class="usa-sr-only">Search</span>
     </button>

--- a/spec/factories/ahoy_events.rb
+++ b/spec/factories/ahoy_events.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :ahoy_event, class: 'Ahoy::Event' do
+    name { 'Category selected' }
+    properties { {} }
+    time { Time.current }
+    visit factory: %i[ahoy_visit]
+  end
+end

--- a/spec/factories/ahoy_visits.rb
+++ b/spec/factories/ahoy_visits.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :ahoy_visit, class: 'Ahoy::Visit' do
+    started_at { Time.current }
+  end
+end

--- a/spec/factories/categories.rb
+++ b/spec/factories/categories.rb
@@ -1,5 +1,6 @@
 FactoryBot.define do
   factory :category do
     name { Faker::Company.unique.name }
+    is_other { false }
   end
 end

--- a/spec/features/homepage_spec.rb
+++ b/spec/features/homepage_spec.rb
@@ -133,7 +133,7 @@ describe 'Homepage', type: :feature do
 
       it 'should have a link to the search page' do
         within '#search-dropdown' do
-          click_link('View all categories')
+          click_link('Browse all categories')
         end
         expect(page).to have_current_path('/search')
       end

--- a/spec/features/homepage_spec.rb
+++ b/spec/features/homepage_spec.rb
@@ -10,10 +10,11 @@ describe 'Homepage', type: :feature do
 
     @user = create(:user, :admin, email: 'naofumi.iwatani@va.gov', password: 'Password123', password_confirmation: 'Password123', skip_va_validation: true, confirmed_at: Time.now, accepted_terms: true)
 
-    create(:practice, name: 'Project HAPPEN', slug: 'project-happen', approved: true, published: true, tagline: "HAPPEN tagline", support_network_email: 'contact-happen@happen.com', user: @user)
-    @practice = create(:practice, name: 'The Best Practice Ever!', initiating_facility_type: 'facility', tagline: 'Test tagline', date_initiated: 'Sun, 05 Feb 1992 00:00:00 UTC +00:00', summary: 'This is the best practice ever.', overview_problem: 'overview-problem', published: true, approved: true, user: @user)
-    @practice_2 = create(:practice, name: 'The Second Best Practice Ever!', initiating_facility_type: 'facility', tagline: 'Test tagline', date_initiated: 'Sun, 05 Feb 1992 00:00:00 UTC +00:00', summary: 'This is the best practice ever.', overview_problem: 'overview-problem', published: true, approved: true, user: @user)
-    @practice_3 = create(:practice, name: 'The Third Best Practice Ever!', initiating_facility_type: 'facility', tagline: 'Test tagline', date_initiated: 'Sun, 05 Feb 1992 00:00:00 UTC +00:00', summary: 'This is the best practice ever.', overview_problem: 'overview-problem', published: true, approved: true, user: @user)
+    create(:practice, name: 'Project HAPPEN', slug: 'project-happen', is_public: true, approved: true, published: true, tagline: "HAPPEN tagline", date_initiated: 'Sun, 04 Feb 1992 00:00:00 UTC +00:00', created_at: 'Sun, 04 Feb 1992 00:00:00 UTC +00:00', support_network_email: 'contact-happen@happen.com', user: @user)
+    @practice = create(:practice, name: 'The Best Practice Ever!', initiating_facility_type: 'facility', tagline: 'Test tagline', date_initiated: 'Sun, 05 Feb 1992 00:00:00 UTC +00:00', created_at: 'Sun, 05 Feb 1992 00:00:00 UTC +00:00', summary: 'This is the best practice ever.', overview_problem: 'overview-problem', is_public: true, published: true, approved: true, user: @user)
+    @practice_2 = create(:practice, name: 'The Second Best Practice Ever!', initiating_facility_type: 'facility', tagline: 'Test tagline', date_initiated: 'Sun, 06 Feb 1992 00:00:00 UTC +00:00', created_at: 'Sun, 06 Feb 1992 00:00:00 UTC +00:00', summary: 'This is the best practice ever.', overview_problem: 'overview-problem', is_public: true, published: true, approved: true, user: @user)
+    @practice_3 = create(:practice, name: 'The Third Best Practice Ever!', initiating_facility_type: 'facility', tagline: 'Test tagline', date_initiated: 'Sun, 07 Feb 1992 00:00:00 UTC +00:00', created_at: 'Sun, 07 Feb 1992 00:00:00 UTC +00:00', summary: 'This is the best practice ever.', overview_problem: 'overview-problem', is_public: true, published: true, approved: true, user: @user)
+    @va_only_practice = create(:practice, name: 'Recent VA-only practice!', initiating_facility_type: 'facility', tagline: 'Test tagline', date_initiated: 'Sun, 08 Feb 1992 00:00:00 UTC +00:00', created_at: 'Sun, 07 Feb 1992 00:00:00 UTC +00:00', summary: 'This is the best practice ever.', overview_problem: 'overview-problem', is_public: false, published: true, approved: true, user: @user)
 
     create(:practice_origin_facility, practice: @practice, facility_type: 0, va_facility_id: 1)
 
@@ -26,11 +27,14 @@ describe 'Homepage', type: :feature do
     create(:category_practice, practice: @practice_2, category: @cat_2)
     create(:category_practice, practice: @practice_3, category: @cat_1)
 
-    login_as(@user, :scope => :user, :run_callbacks => false)
+    ampersand_practice = create(:practice, name: 'Coaching & More', slug: 'coaching-and-more', is_public: true, approved: true, published: true, tagline: "HAPPEN tagline", date_initiated: 'Sun, 04 Feb 1992 00:00:00 UTC +00:00', created_at: 'Sun, 04 Feb 1992 00:00:00 UTC +00:00', support_network_email: 'contact-happen@happen.com', user: @user)
+    ampersand_category = create(:category, name: 'Nutrition & Food', parent_category: @parent_cat)
+    create(:category_practice, practice: ampersand_practice, category: ampersand_category)
+
     visit '/'
   end
 
-  it 'should have a link to the Shark Tank page' do
+  it 'links to the Shark Tank page' do
     expect(page).to have_link(href: '/competitions/shark-tank')
   end
 
@@ -48,7 +52,7 @@ describe 'Homepage', type: :feature do
   end
 
   describe 'featured section' do
-    it 'should display the featured practice, if there is one' do
+    it 'displays the featured practice, if there is one' do
       # make sure the featured section is not present without a featured practice and completed featured fields
       expect(page).to_not have_content('The Best Practice Ever!')
       expect(page).to_not have_content('Highlighted body text')
@@ -80,14 +84,14 @@ describe 'Homepage', type: :feature do
     end
   end
 
-  it "it should allow the user to visit the 'Nominate an innovation' page" do
+  it "allows the user to visit the 'Nominate an innovation' page" do
     click_link('Start nomination')
 
     expect(page).to have_content('Nominate an innovation')
     expect(page).to have_content('VA staff and collaborators are welcome to nominate active innovations for consideration on the Diffusion Marketplace using the form below.')
   end
 
-  it 'should allow the user to subscribe to the DM newsletter by taking them to the GovDelivery site' do
+  it 'allows the user to subscribe to the DM newsletter by taking them to the GovDelivery site' do
     fill_in('Your email address', with: 'vladilena.milize@test.com')
 
     new_window = window_opened_by { click_button('Subscribe today') }
@@ -107,36 +111,69 @@ describe 'Homepage', type: :feature do
     end
   end
 
-  context 'with chrome headless driver', js: true do
-    describe 'search dropdown functionality' do
-      before do
+  describe 'search dropdown functionality', js: true do
+    before do
+      find('#dm-homepage-search-field').click
+    end
+
+    it 'lists most recently created innovations' do
+      within '#practice-list' do
+        expect(page).to have_content('The Best Practice Ever!')
+        expect(page).to have_content('The Second Best Practice Ever!')
+        expect(page).to have_content('The Third Best Practice Ever!')
+
+        expect(page).not_to have_content('Project HAPPEN') # oldest practice
+        expect(page).not_to have_content('Recent VA-only practice!') # private practice
+      end
+    end
+
+    it 'shows VA-only innovations to logged in users' do
+      login_as(@user, scope: :user, run_callbacks: false)
+        visit '/'
         find('#dm-homepage-search-field').click
-      end
 
-      it 'should display the dropdown when the search input is focused' do
-        expect(page).to have_selector('#search-dropdown', visible: :visible)
-      end
+        expect(page).to have_content('Recent VA-only practice!')
+        expect(page).to have_content('The Second Best Practice Ever!')
+        expect(page).to have_content('The Third Best Practice Ever!')
+    end
 
-      it 'should list popular categories in the dropdown initially' do
-        within '#search-dropdown' do
-          expect(page).to have_content('COVID')
-          expect(page).to have_content('Telehealth')
-        end
+    it 'lists popular categories' do
+      within '#category-list' do
+        expect(page).to have_content('COVID')
+        expect(page).to have_content('Telehealth')
       end
+    end
 
-      it 'should navigate to search page with category filter when a category is clicked' do
-        within '#search-dropdown' do
-          first('.category-item').find('a').click
-        end
-        expect(page).to have_current_path('/search?category=COVID')
+    it 'lets a user search for innovations' do
+      fill_in('dm-homepage-search-field', with: 'HAPPEN')
+      within '#search-dropdown' do
+        expect(page).to have_link('Project HAPPEN', href: '/innovations/project-happen')
       end
+    end
 
-      it 'should have a link to the search page' do
-        within '#search-dropdown' do
-          click_link('Browse all categories')
-        end
-        expect(page).to have_current_path('/search')
+    it 'should navigate to search page with category filter when a category is clicked' do
+      within '#category-list' do
+        expect(page).to have_link('COVID', href: '/search?category=COVID')
       end
+    end
+
+    it 'links to the search page' do
+      within '#search-dropdown' do
+        expect(page).to have_link('Browse all innovations', href: '/search')
+        expect(page).to have_link('Browse all categories', href: '/search')
+      end
+    end
+
+    it 'lets a user navigate results with arrow keys' do
+      page.send_keys :down, :down, :down, :down, :down # navigate to first category
+      page.send_keys :enter # select category
+      expect(page).to have_current_path('/search?category=COVID')
+    end
+
+    it 'encodes categories & innovations with ampersands' do
+      fill_in('dm-homepage-search-field', with: '&')
+      expect(page).to have_link('Nutrition & Food', href: '/search?category=Nutrition%20%26%20Food')
+      expect(page).to have_link('Coaching & More', href: '/innovations/coaching-and-more')
     end
   end
 end

--- a/spec/features/homepage_spec.rb
+++ b/spec/features/homepage_spec.rb
@@ -30,13 +30,6 @@ describe 'Homepage', type: :feature do
     expect(page).to have_link(href: '/competitions/shark-tank')
   end
 
-  it "it should allow the user to visit the 'About' page" do
-    click_link('Learn more')
-
-    expect(page).to have_content('About us')
-    expect(page).to have_current_path(about_path)
-  end
-
   describe 'search section' do
     it 'should allow the user to search for practices in a number of ways' do
       expect(page).to be_accessible.according_to :wcag2a, :section508

--- a/spec/features/homepage_spec.rb
+++ b/spec/features/homepage_spec.rb
@@ -175,5 +175,61 @@ describe 'Homepage', type: :feature do
       expect(page).to have_link('Nutrition & Food', href: '/search?category=Nutrition%20%26%20Food')
       expect(page).to have_link('Coaching & More', href: '/innovations/coaching-and-more')
     end
+
+    it 'tracks clicks on practice links' do
+      expect {
+        find('a', text: 'The Best Practice Ever!').click
+        wait_for_ajax
+      }.to change(Ahoy::Event, :count).by(1)
+
+      event = Ahoy::Event.last
+      expect(event.name).to eq("Dropdown Practice Link Clicked")
+      expect(event.properties["practice_name"]).to eq("The Best Practice Ever!")
+      expect(event.properties["from_homepage"]).to be_truthy
+    end
+
+    it 'tracks clicks on category links' do
+      expect {
+        find('a', text: 'COVID').click
+        wait_for_ajax
+      }.to change(Ahoy::Event, :count).by(1)
+
+      event = Ahoy::Event.last
+      expect(event.name).to eq("Category selected")
+      expect(event.properties["category_name"]).to eq("COVID")
+      expect(event.properties["from_homepage"]).to be_truthy
+    end
+
+    it 'tracks clicks on "Browse all innovations" link' do
+      expect {
+        find('a', text: 'Browse all innovations').click
+        wait_for_ajax
+      }.to change(Ahoy::Event, :count).by(1)
+
+      event = Ahoy::Event.last
+      expect(event.name).to eq("Dropdown Browse-all Link Clicked")
+      expect(event.properties["type"]).to eq("innovation")
+    end
+
+    it 'tracks clicks on "Browse all categories" link' do
+      expect {
+        find('a', text: 'Browse all categories').click
+        wait_for_ajax
+      }.to change(Ahoy::Event, :count).by(1)
+
+      event = Ahoy::Event.last
+      expect(event.name).to eq("Dropdown Browse-all Link Clicked")
+      expect(event.properties["type"]).to eq("category")
+    end
+  end
+
+  def wait_for_ajax
+    Timeout.timeout(Capybara.default_max_wait_time) do
+      loop until finished_all_ajax_requests?
+    end
+  end
+
+  def finished_all_ajax_requests?
+    page.evaluate_script('jQuery.active').zero?
   end
 end

--- a/spec/features/practice_spec.rb
+++ b/spec/features/practice_spec.rb
@@ -72,7 +72,6 @@ describe 'Practices', type: :feature do
       expect(page).to be_accessible.according_to :wcag2a, :section508
       expect(page).to have_content('We’re a discovery and collaboration tool that curates VA’s promising innovations, encourages their diffusion, and fosters engagement with greater healthcare communities.')
       expect(page).to have_link(href: '/about')
-      expect(page).to have_content('Browse all innovations')
       expect(page).to have_content(@highlighted_practice.name)
       expect(page).to have_content('Highlight body text')
       expect(page).to have_content('View innovation')

--- a/spec/features/shared/breadcrumbs_spec.rb
+++ b/spec/features/shared/breadcrumbs_spec.rb
@@ -78,11 +78,6 @@ describe 'Breadcrumbs', type: :feature do
       expect(page).to_not have_css('#breadcrumbs')
     end
 
-    it 'should not display breadcrumbs for the search page when clicking "Browse all innovations"' do
-      expect(page).to have_link('Browse all innovations', href: search_path)
-      expect(page).to_not have_css('#breadcrumbs')
-    end
-
     it 'should not display breadcrumbs for the search page when clicking the homepage search' do
       find('#dm-navbar-search-desktop-button').click
       expect(page).to_not have_css('#breadcrumbs')

--- a/spec/helpers/categories_helper_spec.rb
+++ b/spec/helpers/categories_helper_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+RSpec.describe 'CategoriesHelper', type: :helper do
+  describe '#get_category_names_by_popularity' do
+    before do
+      parent_category1 = create(:category, name: 'Parent Category 1')
+      parent_category2 = create(:category, name: 'Parent Category 2')
+
+      category1 = create(:category, name: 'Category 1', parent_category: parent_category1)
+      category2 = create(:category, name: 'Category 2', parent_category: parent_category1)
+      category3 = create(:category, name: 'Category 3', parent_category: parent_category2)
+      category4 = create(:category, name: 'Category 4', parent_category: parent_category2)
+      create(:category, name: 'Category 5', parent_category: parent_category2)
+
+      admin = create(:user, :admin)
+      ahoy_visit = create(:ahoy_visit, user: admin)
+
+      5.times { create(:ahoy_event, visit: ahoy_visit, properties: { category_id: category1.id.to_s }, time: 45.days.ago) }
+      4.times { create(:ahoy_event, visit: ahoy_visit, properties: { category_id: category4.id.to_s }, time: 60.days.ago) }
+      3.times { create(:ahoy_event, visit: ahoy_visit, properties: { category_id: category3.id.to_s }, time: 30.days.ago) }
+      2.times { create(:ahoy_event, visit: ahoy_visit, properties: { category_id: category2.id.to_s }, time: 30.days.ago) }
+    end
+
+    it 'returns the most popular categories based on Ahoy::Event records within the last 90 days' do
+      popular_categories = helper.get_category_names_by_popularity
+      expect(popular_categories).to eq(['Category 1', 'Category 4', 'Category 3', 'Category 2', 'Category 5'])
+    end
+  end
+end

--- a/spec/helpers/categories_helper_spec.rb
+++ b/spec/helpers/categories_helper_spec.rb
@@ -1,29 +1,36 @@
 require 'rails_helper'
 
 RSpec.describe 'CategoriesHelper', type: :helper do
-  describe '#get_category_names_by_popularity' do
+  describe '#get_categories_by_popularity' do
     before do
-      parent_category1 = create(:category, name: 'Parent Category 1')
-      parent_category2 = create(:category, name: 'Parent Category 2')
+      @parent_category1 = create(:category, name: 'Parent Category 1')
+      @parent_category2 = create(:category, name: 'Parent Category 2')
 
-      category1 = create(:category, name: 'Category 1', parent_category: parent_category1)
-      category2 = create(:category, name: 'Category 2', parent_category: parent_category1)
-      category3 = create(:category, name: 'Category 3', parent_category: parent_category2)
-      category4 = create(:category, name: 'Category 4', parent_category: parent_category2)
-      create(:category, name: 'Category 5', parent_category: parent_category2)
+      @category1 = create(:category, name: 'Category 1', parent_category: @parent_category1)
+      @category2 = create(:category, name: 'Category 2', parent_category: @parent_category1)
+      @category3 = create(:category, name: 'Category 3', parent_category: @parent_category2)
+      @category4 = create(:category, name: 'Category 4', parent_category: @parent_category2)
+      @category5 = create(:category, name: 'Category 5', parent_category: @parent_category2)
 
       admin = create(:user, :admin)
       ahoy_visit = create(:ahoy_visit, user: admin)
 
-      5.times { create(:ahoy_event, visit: ahoy_visit, properties: { category_id: category1.id.to_s }, time: 45.days.ago) }
-      4.times { create(:ahoy_event, visit: ahoy_visit, properties: { category_id: category4.id.to_s }, time: 60.days.ago) }
-      3.times { create(:ahoy_event, visit: ahoy_visit, properties: { category_id: category3.id.to_s }, time: 30.days.ago) }
-      2.times { create(:ahoy_event, visit: ahoy_visit, properties: { category_id: category2.id.to_s }, time: 30.days.ago) }
+      5.times { create(:ahoy_event, visit: ahoy_visit, properties: { category_id: @category1.id.to_s }, time: 45.days.ago) }
+      4.times { create(:ahoy_event, visit: ahoy_visit, properties: { category_id: @category4.id.to_s }, time: 60.days.ago) }
+      3.times { create(:ahoy_event, visit: ahoy_visit, properties: { category_id: @category3.id.to_s }, time: 30.days.ago) }
+      2.times { create(:ahoy_event, visit: ahoy_visit, properties: { category_id: @category2.id.to_s }, time: 30.days.ago) }
     end
 
     it 'returns the most popular categories based on Ahoy::Event records within the last 90 days' do
-      popular_categories = helper.get_category_names_by_popularity
-      expect(popular_categories).to eq(['Category 1', 'Category 4', 'Category 3', 'Category 2', 'Category 5'])
+      popular_categories = helper.get_categories_by_popularity
+      expected_result = [
+        { id: @category1.id, name: 'Category 1' },
+        { id: @category4.id, name: 'Category 4' },
+        { id: @category3.id, name: 'Category 3' },
+        { id: @category2.id, name: 'Category 2' },
+        { id: @category5.id, name: 'Category 5' }
+      ]
+      expect(popular_categories).to match_array(expected_result)
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -149,6 +149,10 @@ RSpec.configure do |config|
     Capybara.page.driver.browser.manage.window.resize_to(1920, 1080)
     Capybara.page.driver.browser.download_path = "#{Rails.root}/tmp/downloads"
   end
+
+  config.after do
+    Rails.cache.clear
+  end
 end
 
 # Capybara.javascript_driver = :webkit


### PR DESCRIPTION
### JIRA issue link
[DM-4077](https://agile6.atlassian.net/browse/DM-4077)


## Description - what does this code do?
- Adds a dropdown to the homepage that provides autocomplete suggestions from innovations and categories
- Updates visual design of homepage
- Removes "Explore popular categories" section from homepage

1. [Marketplace summary update](https://github.com/department-of-veterans-affairs/diffusion-marketplace/pulls?q=is%3Apr+sort%3Aupdated-desc+is%3Aclosed#:~:text=DM%2D4398%20update%20homepage%20welcome%20banner%20styling)
1. #770
2. #772
3. #776
4. #778
5. #779
7. #784
8. #786
9. #787
10. #793 
11. #823 
12. #824

## Screenshots, Gifs, Videos from application (if applicable)
![Screenshot 2024-03-20 at 3 48 54 PM](https://github.com/department-of-veterans-affairs/diffusion-marketplace/assets/5402927/5605f7fb-1150-41c8-a5f9-ecebeafe0828)
