### PR TITLE
Add Publications page to VA Immersive dropdown

### DIFF
--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -6,6 +6,7 @@
   va_immersive_events_and_news_url = '/communities/va-immersive/events-and-news'
   va_immersive_innovations_url = '/communities/va-immersive/innovations'
   va_immersive_getting_started_url = '/communities/va-immersive/getting-started'
+  va_immersive_publications_url = '/communities/va-immersive/publications'
 %>
 <!-- source: https://designsystem.digital.gov/components/header/#extended -->
 <a class="usa-skipnav" href="#main-content">Skip to main content</a>
@@ -110,6 +111,11 @@
             <li class="usa-nav__submenu-item border-base-light">
               <a class="font-sans-sm desktop:font-sans-2xs margin-y-2px desktop:margin-y-0 <%= 'usa-current' if request.fullpath === va_immersive_getting_started_url %>" href="<%= va_immersive_getting_started_url %>">
                 Getting Started
+              </a>
+            </li>
+            <li class="usa-nav__submenu-item border-base-light">
+              <a class="font-sans-sm desktop:font-sans-2xs margin-y-2px desktop:margin-y-0 <%= 'usa-current' if request.fullpath === va_immersive_publications_url %>" href="<%= va_immersive_publications_url %>">
+                Publications
               </a>
             </li>
           </ul>


### PR DESCRIPTION
### JIRA issue link
[DM-4424](https://agile6.atlassian.net/browse/DM-4424)

## Description - what does this code do?
Adds a link to the VA Immersive Publications page to the nav dropdown.

## Testing done - how did you test it/steps on how can another person can test it 
1. Go to the VA Immersive dropdown and hover over Publications.
2. Check that the relative link directs to `/communities/va-immersive/publications` (Note that you will run into an error if your local dev environment doesn't have the relevant page group and page)

## Screenshots, Gifs, Videos from application (if applicable)
<img width="450" alt="Screenshot 2024-01-30 at 1 50 46 PM" src="https://github.com/department-of-veterans-affairs/diffusion-marketplace/assets/5402927/86b156ae-46b0-4b6f-b418-b96b4bf21070">


