### PR TITLE
Address rendering deprecation warning

### DIFF
--- a/app/controllers/practices_controller.rb
+++ b/app/controllers/practices_controller.rb
@@ -488,7 +488,7 @@ class PracticesController < ApplicationController
         params[:created] = true
       end
       params[:reload] = true
-      format.js { render 'practices/form/adoptions_forms/create_or_update_diffusion_history.js.erb' }
+      format.js { render 'practices/form/adoptions_forms/create_or_update_diffusion_history' }
     end
   end
 


### PR DESCRIPTION
### JIRA issue link
N/A

## Description - what does this code do?
Addresses a deprecation warning that shows up in CI runs / when you run tests locally. 
```
DEPRECATION WARNING: Rendering actions with '.' in the name is deprecated: practices/form/adoptions_forms/create_or_update_diffusion_history.js.erb (called from block (2 levels) in create_or_update_diffusion_history at /home/runner/work/diffusion-marketplace/diffusion-marketplace/app/controllers/practices_controller.rb:491)
```

## Testing done - how did you test it/steps on how can another person can test it 
1. Log in and navigate to an innovation page
2. Edit your innovation and 
3. Go to the "Adoptions" tab
4. Confirm that you can successfully add and save adoptions
5. Go to the CI run for this PR and confirm the deprecation warning does not appear. 
6. Go to a CI run for a previous build (e.g. latest PR to `master` or `feature/` and confirm the deprecation warning is present. 
