### PR TITLE
Truncate dropdown results to a simple list of 3

### DIFF
--- a/app/assets/javascripts/search.es6
+++ b/app/assets/javascripts/search.es6
@@ -27,7 +27,7 @@ function setupSearchDropdown(formId) {
     searchInput.on('input', function() {
         let searchTerm = searchInput.val().toLowerCase();
         let filteredCategories = searchTerm ? allCategories.filter(category =>
-            category.toLowerCase().includes(searchTerm)) : mostPopularCategories;
+            category.toLowerCase().includes(searchTerm)).slice(0,3) : mostPopularCategories;
         updateDropdown(filteredCategories);
     });
 


### PR DESCRIPTION
### JIRA issue link
[DM-4396](https://agile6.atlassian.net/browse/DM-4396)

## Description - what does this code do?
- Truncates homepage search dropdown results to the first 3 substring matches. This is a temporary solution until sort-by-popularity #783 is resolved

## Testing done - how did you test it/steps on how can another person can test it 
1. Type `he` into the search bar and confirm that only 3 or fewer results are returned. 
2. On STG or a local copy of `feature/homepage-refresh` type `he` into the search bar and confirm that more than 3 results are returned (i.e. every category with the term "health")

## Screenshots, Gifs, Videos from application (if applicable)

### Before
![list of 7 results](https://github.com/department-of-veterans-affairs/diffusion-marketplace/assets/5402927/f6016c37-abdf-4084-a46a-2f7f52956366)

### After
![list of 3 results](https://github.com/department-of-veterans-affairs/diffusion-marketplace/assets/5402927/04fe743a-6b56-42f3-911a-d37b15e98589)
