### PR TITLE
DM-4435: Handle categories with ampersands in homepage search dropdown

### DIFF
--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -23,7 +23,7 @@
     class="homepage-search grid-container margin-top-4 margin-bottom-4 desktop:margin-bottom-8 margin-top-10"
     role="region"
     aria-label="Homepage search section"
-    data-categories="<%= ERB::Util.html_escape(@category_names_by_popularity.to_json) %>"
+    data-categories="<%= @category_names_by_popularity %>"
   >
     <form id="dm-homepage-search-form" class="usa-search margin-bottom-2" role="search">
       <label class="usa-sr-only" for="dm-homepage-search-form">Homepage search</label>


### PR DESCRIPTION
### JIRA issue link
[DM-4435](https://agile6.atlassian.net/browse/DM-4435)

## Description - what does this code do?
- Updates encoding to ensure categories with ampersands (e.g. `Obstetrics & Gynecology`, `Nutrition & Food`) both 
  - render correctly in the dropdown
  - are handed off to search

## Testing done - how did you test it/steps on how can another person can test it 
### Before
1. If you're testing in local dev, log in as an admin. 
1. In `feature/homepage-refresh`, search for `Obstetrics` or `Nutrition`.
1. Categories with ampersands should render with `u\2006`
1. Select `Nutrition \u2006 Food` and submit search
1. No search results should be returned
1. Reset the filters on /search 
1. Select Nutrition & Food from the filters and Update results
1. You should get 8 results back

### After
1. In `feature/homepage-refresh`, search for `Obstetrics` or `Nutrition`.
1. Categories with ampersands should render the character correctly
1. Select `Nutrition & Food` and submit search
1. You should get 8 results back

## Screenshots, Gifs, Videos from application (if applicable)
### Before
<img width="434" alt="Screenshot 2024-02-08 at 11 10 59 AM" src="https://github.com/department-of-veterans-affairs/diffusion-marketplace/assets/5402927/25ba9a9d-faa1-4c61-893c-074d5fbad439">

### After
<img width="271" alt="Screenshot 2024-02-13 at 10 13 28 AM" src="https://github.com/department-of-veterans-affairs/diffusion-marketplace/assets/5402927/6e759481-2818-44c5-b43a-55774d360887">
