### PR TITLE
Add innovations to homepage search dropdown

### DIFF
--- a/app/assets/javascripts/search.es6
+++ b/app/assets/javascripts/search.es6
@@ -79,7 +79,7 @@ function updateDropdown(categories, innovations) {
     });
 
     innovations.forEach(function(innovation) {
-        let link = $('<a></a>').attr('href', `/innovations/${innovationLinks[innovation]}` ).text(innovation);
+        let link = $('<a></a>').attr('href', `/innovations/${encodeURIComponent(innovationLinks[innovation])}` ).text(innovation);
         let listItem = $('<li></li>').addClass('search-result padding-bottom-1').append(link);
 
         innovationList.append(listItem);

--- a/app/assets/javascripts/search.es6
+++ b/app/assets/javascripts/search.es6
@@ -73,14 +73,14 @@ function updateDropdown(categories, innovations) {
 
     categories.forEach(function(category) {
         let link = $('<a></a>').attr('href', `/search?category=${encodeURIComponent(category)}`).text(category);
-        let listItem = $('<li></li>').addClass('search-result padding-bottom-1').append(link);
+        let listItem = $('<li></li>').addClass('search-result').append(link);
 
         categoryList.append(listItem);
     });
 
     innovations.forEach(function(innovation) {
         let link = $('<a></a>').attr('href', `/innovations/${encodeURIComponent(innovationLinks[innovation])}` ).text(innovation);
-        let listItem = $('<li></li>').addClass('search-result padding-bottom-1').append(link);
+        let listItem = $('<li></li>').addClass('search-result').append(link);
 
         innovationList.append(listItem);
     });

--- a/app/assets/javascripts/search.es6
+++ b/app/assets/javascripts/search.es6
@@ -66,6 +66,7 @@ function setupSearchDropdown(formId) {
 }
 
 function updateDropdown(categories, innovations) {
+    const innovationLinks = JSON.parse($('.homepage-search').attr('data-innovation-links'));
     let categoryList = $('#category-list');
     let innovationList = $('#practice-list');
     $('li').remove('.search-result');
@@ -78,7 +79,7 @@ function updateDropdown(categories, innovations) {
     });
 
     innovations.forEach(function(innovation) {
-        let link = $('<a></a>').attr('href', `/innovations/`).text(innovation);
+        let link = $('<a></a>').attr('href', `/innovations/${innovationLinks[innovation]}` ).text(innovation);
         let listItem = $('<li></li>').addClass('search-result padding-bottom-1').append(link);
 
         innovationList.append(listItem);

--- a/app/assets/javascripts/search.es6
+++ b/app/assets/javascripts/search.es6
@@ -71,14 +71,14 @@ function updateDropdown(categories, innovations) {
     $('li').remove('.search-result');
 
     categories.forEach(function(category) {
-        let link = $('<a></a>').attr('href', `/search?category=${encodeURIComponent(category)}`).text(category).addClass('public-sans');
+        let link = $('<a></a>').attr('href', `/search?category=${encodeURIComponent(category)}`).text(category);
         let listItem = $('<li></li>').addClass('search-result padding-bottom-1').append(link);
 
         categoryList.append(listItem);
     });
 
     innovations.forEach(function(innovation) {
-        let link = $('<a></a>').attr('href', `/innovations/`).text(innovation).addClass('public-sans');
+        let link = $('<a></a>').attr('href', `/innovations/`).text(innovation);
         let listItem = $('<li></li>').addClass('search-result padding-bottom-1').append(link);
 
         innovationList.append(listItem);

--- a/app/assets/javascripts/search.es6
+++ b/app/assets/javascripts/search.es6
@@ -19,6 +19,10 @@ function setupSearchDropdown(formId) {
     const allCategories = allCategoriesString ? allCategoriesString.match(/[^",\[\]]+/g) : [];
     const mostPopularCategories = allCategories ? allCategories.slice(0, 3) : [];
 
+    const allInnovationsString = $('.homepage-search').attr('data-innovations');
+    const allInnovations = allInnovationsString ? allInnovationsString.match(/[^",\[\]]+/g) : [];
+    const mostRecentInnovations = allInnovations ? allInnovations.slice(0, 3) : [];
+
     searchInput.focus(function() {
         dropdown.show();
         searchInput.attr('aria-expanded', 'true');
@@ -28,12 +32,14 @@ function setupSearchDropdown(formId) {
         let searchTerm = searchInput.val().toLowerCase();
         let filteredCategories = searchTerm ? allCategories.filter(category =>
             category.toLowerCase().includes(searchTerm)).slice(0,3) : mostPopularCategories;
-        updateDropdown(filteredCategories);
+        let filteredInnovations = searchTerm ? allInnovations.filter(innovation =>
+            innovation.toLowerCase().includes(searchTerm)).slice(0,3) : mostRecentInnovations;
+        updateDropdown(filteredCategories, filteredInnovations);
     });
 
     $(document).keydown(function(e) {
         if (searchInput.attr('aria-expanded') === 'true') {
-            const items = $('#search-dropdown .category-item a, #search-dropdown .browse-all-link');
+            const items = $('#search-dropdown .search-result a, #search-dropdown .browse-all-link');
             const focusedElement = document.activeElement;
             const focusedIndex = items.index(focusedElement);
 
@@ -59,16 +65,25 @@ function setupSearchDropdown(formId) {
     $(document).on('focusin', hideDropdownOutsideClickOrFocus);
 }
 
-function updateDropdown(categories) {
+function updateDropdown(categories, innovations) {
     let categoryList = $('#category-list');
-    categoryList.empty();
+    let innovationList = $('#practice-list');
+    $('li').remove('.search-result');
 
     categories.forEach(function(category) {
         let link = $('<a></a>').attr('href', `/search?category=${encodeURIComponent(category)}`).text(category).addClass('public-sans');
-        let listItem = $('<li></li>').addClass('category-item padding-bottom-1').append(link);
+        let listItem = $('<li></li>').addClass('search-result padding-bottom-1').append(link);
 
         categoryList.append(listItem);
     });
+
+    innovations.forEach(function(innovation) {
+        let link = $('<a></a>').attr('href', `/innovations/`).text(innovation).addClass('public-sans');
+        let listItem = $('<li></li>').addClass('search-result padding-bottom-1').append(link);
+
+        innovationList.append(listItem);
+    });
+
 }
 
 addEventListener('turbolinks:load', function () {

--- a/app/assets/stylesheets/dm/pages/_home.scss
+++ b/app/assets/stylesheets/dm/pages/_home.scss
@@ -48,7 +48,20 @@
       z-index: 2000;
     }
 
-    ul:not(:last-child) {
+    .browse-all-link {
+        color: color($theme-color-base-ink);
+        @include u-text-decoration('underline');
+
+        &:hover, &:focus {
+          color: color('primary-dark');
+        }
+
+        &:active {
+          color: color('primary-vivid');
+        }
+    }
+
+    .result-section:not(:last-child) {
       padding-bottom: 1rem;
       border-bottom: 1px solid black;
     }
@@ -71,19 +84,6 @@
 
         &:visited {
           color: color($theme-color-base-ink);
-        }
-      }
-
-      .browse-all-link {
-        color: color($theme-color-base-ink);
-        @include u-text-decoration('underline');
-
-        &:hover, &:focus {
-          color: color('primary-dark');
-        }
-
-        &:active {
-          color: color('primary-vivid');
         }
       }
     }

--- a/app/assets/stylesheets/dm/pages/_home.scss
+++ b/app/assets/stylesheets/dm/pages/_home.scss
@@ -46,19 +46,11 @@
       @include u-border('gray-30');
       @include u-position('absolute');
       z-index: 2000;
+    }
 
-      .browse-all-link {
-        color: color($theme-color-base-ink);
-        @include u-text-decoration('underline');
-
-        &:hover, &:focus {
-          color: color('primary-dark');
-        }
-
-        &:active {
-          color: color('primary-vivid');
-        }
-      }
+    ul:not(:last-child) {
+      padding-bottom: 1rem;
+      border-bottom: 1px solid black;
     }
 
     #category-list, #practice-list {
@@ -79,6 +71,19 @@
 
         &:visited {
           color: color($theme-color-base-ink);
+        }
+      }
+
+      .browse-all-link {
+        color: color($theme-color-base-ink);
+        @include u-text-decoration('underline');
+
+        &:hover, &:focus {
+          color: color('primary-dark');
+        }
+
+        &:active {
+          color: color('primary-vivid');
         }
       }
     }

--- a/app/assets/stylesheets/dm/pages/_home.scss
+++ b/app/assets/stylesheets/dm/pages/_home.scss
@@ -65,6 +65,11 @@
       a {
         text-decoration: none;
         color: color($theme-color-base-ink);
+        // truncation
+        display: block;
+        text-overflow: ellipsis;
+        overflow: hidden;
+        white-space: nowrap;
 
 
         &:hover, &:active, &:focus {

--- a/app/assets/stylesheets/dm/pages/_home.scss
+++ b/app/assets/stylesheets/dm/pages/_home.scss
@@ -70,6 +70,7 @@
       a {
         text-decoration: none;
         color: color($theme-color-base-ink);
+        padding-bottom: 0.5rem; // == padding-bottom-1
         // truncation
         display: block;
         text-overflow: ellipsis;

--- a/app/assets/stylesheets/dm/pages/_home.scss
+++ b/app/assets/stylesheets/dm/pages/_home.scss
@@ -61,7 +61,7 @@
       }
     }
 
-    #category-list {
+    #category-list, #practice-list {
       a {
         text-decoration: none;
         color: color($theme-color-base-ink);
@@ -76,7 +76,7 @@
           color: color($theme-color-base-ink);
         }
       }
-    };
+    }
   }
 
   .featured-innovation-content-container {

--- a/app/assets/stylesheets/dm/pages/_home.scss
+++ b/app/assets/stylesheets/dm/pages/_home.scss
@@ -41,7 +41,7 @@
       @include transition-btn-colors;
     }
 
-    .search-dropdown {
+    #search-dropdown {
       top: 100%; /* Position below the input */
       @include u-border('gray-30');
       @include u-position('absolute');

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -7,6 +7,7 @@ class HomeController < ApplicationController
     @highlighted_pr = Practice.where(highlight: true, published: true, enabled: true, approved: true).first
     @category_names_by_popularity = get_category_names_by_popularity
     @featured_topic = Topic.find_by(featured: true)
+    @practice_names = get_practice_names
   end
 
   def diffusion_map
@@ -74,6 +75,22 @@ class HomeController < ApplicationController
   end
 
   private
+
+  def get_practice_names
+    if current_user
+      all_current_practices
+    else
+      all_public_practices
+    end
+  end
+
+  def all_current_practices
+    Practice.where(published: true, retired: false).pluck("name")
+  end
+
+  def all_public_practices
+    Practice.where(published: true, is_public: true, retired: false).pluck("name")
+  end
 
   def get_diffusion_histories(is_public_practice)
     DiffusionHistory.get_with_practices(is_public_practice).order(Arel.sql("lower(practices.name)"))

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -7,8 +7,8 @@ class HomeController < ApplicationController
     @highlighted_pr = Practice.where(highlight: true, published: true, enabled: true, approved: true).first
     @category_names_by_popularity = get_category_names_by_popularity
     @featured_topic = Topic.find_by(featured: true)
-    @practice_names = get_practice_names
     @practice_names_and_slugs = practice_names_and_slugs_hash
+    @practice_names = @practice_names_and_slugs.keys
   end
 
   def diffusion_map
@@ -77,22 +77,14 @@ class HomeController < ApplicationController
 
   private
 
-  def get_practice_names
-    if current_user
-      all_current_practices.pluck("name")
-    else
-      all_public_practices.pluck("name")
-    end
-  end
-
   def practice_names_and_slugs_hash
-    practices_hash = {}
+    practices_and_slugs = {}
     if current_user
-      all_current_practices.pluck("name", "slug").map { |name, slug| practices_hash[name] = slug }
+      all_current_practices.pluck("name", "slug").map { |name, slug| practices_and_slugs[name] = slug }
     else
-      all_public_practices.pluck("name", "slug").map { |name, slug| practices_hash[name] = slug }
+      all_public_practices.pluck("name", "slug").map { |name, slug| practices_and_slugs[name] = slug }
     end
-    return practices_hash
+    return practices_and_slugs
   end
 
   def all_current_practices

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -78,21 +78,14 @@ class HomeController < ApplicationController
   private
 
   def practice_names_and_slugs_hash
-    practices_and_slugs = {}
-    if current_user
-      all_current_practices.pluck("name", "slug").map { |name, slug| practices_and_slugs[name] = slug }
-    else
-      all_public_practices.pluck("name", "slug").map { |name, slug| practices_and_slugs[name] = slug }
-    end
-    return practices_and_slugs
+    dropdown_practices.pluck("name", "slug").to_h
   end
 
-  def all_current_practices
-    Practice.where(published: true, retired: false).order("created_at DESC")
-  end
-
-  def all_public_practices
-    Practice.where(published: true, is_public: true, retired: false).order("created_at DESC")
+  def dropdown_practices
+    scope = Practice.where(published: true, retired: false)
+    scope = scope.where(is_public: true) if !current_user
+    scope = scope.order("created_at DESC")
+    scope
   end
 
   def get_diffusion_histories(is_public_practice)

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -8,6 +8,7 @@ class HomeController < ApplicationController
     @category_names_by_popularity = get_category_names_by_popularity
     @featured_topic = Topic.find_by(featured: true)
     @practice_names = get_practice_names
+    @practice_names_and_slugs = practice_names_and_slugs_hash
   end
 
   def diffusion_map
@@ -78,18 +79,28 @@ class HomeController < ApplicationController
 
   def get_practice_names
     if current_user
-      all_current_practices
+      all_current_practices.pluck("name")
     else
-      all_public_practices
+      all_public_practices.pluck("name")
     end
   end
 
+  def practice_names_and_slugs_hash
+    practices_hash = {}
+    if current_user
+      all_current_practices.pluck("name", "slug").map { |name, slug| practices_hash[name] = slug }
+    else
+      all_public_practices.pluck("name", "slug").map { |name, slug| practices_hash[name] = slug }
+    end
+    return practices_hash
+  end
+
   def all_current_practices
-    Practice.where(published: true, retired: false).order("created_at DESC").pluck("name")
+    Practice.where(published: true, retired: false).order("created_at DESC")
   end
 
   def all_public_practices
-    Practice.where(published: true, is_public: true, retired: false).order("created_at DESC").pluck("name")
+    Practice.where(published: true, is_public: true, retired: false).order("created_at DESC")
   end
 
   def get_diffusion_histories(is_public_practice)

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -85,11 +85,11 @@ class HomeController < ApplicationController
   end
 
   def all_current_practices
-    Practice.where(published: true, retired: false).pluck("name")
+    Practice.where(published: true, retired: false).order("created_at DESC").pluck("name")
   end
 
   def all_public_practices
-    Practice.where(published: true, is_public: true, retired: false).pluck("name")
+    Practice.where(published: true, is_public: true, retired: false).order("created_at DESC").pluck("name")
   end
 
   def get_diffusion_histories(is_public_practice)

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -44,7 +44,7 @@
           style="display: none;"
         >
           <div class="dropdown-content margin-4">
-            <span class="category-header usa-prose-h3 text-bold" aria-label="Categories">Categories</span>
+            <h3 class="search-header usa-prose-h3 margin-bottom-0" aria-label="Categories">Categories</h3>
             <ul id="category-list" class="usa-list usa-list--unstyled padding-top-1">
               <% @category_names_by_popularity[0..2].each do |category_name| %>
                 <li class="category-item padding-bottom-1">
@@ -53,6 +53,15 @@
               <% end %>
             </ul>
             <a class="browse-all-link public-sans text-bold padding-top-1" href="<%= search_path %>">Browse all categories</a>
+            <h3 class="search-header usa-prose-h3 margin-bottom-0">Innovations</h3>
+            <ul id="practice-list" class="usa-list usa-list--unstyled padding-top-1">
+              <% @practice_names[0..2].each do |practice_name| %>
+                <li class="practice-item padding-bottom-1">
+                  <a class="public-sans" href="#"><%= practice_name %></a>
+                </li>
+              <% end %>
+            </ul>
+            <a class="browse-all-link public-sans text-bold padding-top-1" href="<%= search_path %>">Browse all innovations</a>
           </div>
         </div>
         <button id="dm-homepage-search-button" class="usa-button height-5 margin-right-0" type="submit">

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -44,15 +44,6 @@
           style="display: none;"
         >
           <div class="dropdown-content margin-4">
-            <h3 class="search-header usa-prose-h3 margin-bottom-0" aria-label="Categories">Categories</h3>
-            <ul id="category-list" class="usa-list usa-list--unstyled padding-top-1">
-              <% @category_names_by_popularity[0..2].each do |category_name| %>
-                <li class="category-item padding-bottom-1">
-                  <a class="public-sans" href=<%= "/search?category=#{category_name}" %>><%= category_name %></a>
-                </li>
-              <% end %>
-              <li><a class="browse-all-link public-sans text-bold" href="<%= search_path %>">Browse all categories</a></li>
-            </ul>
             <h3 class="search-header usa-prose-h3 margin-bottom-0">Innovations</h3>
             <ul id="practice-list" class="usa-list usa-list--unstyled padding-top-1">
               <% @practice_names[0..2].each do |practice_name| %>
@@ -61,6 +52,15 @@
                 </li>
               <% end %>
               <li><a class="browse-all-link public-sans text-bold" href="<%= search_path %>">Browse all innovations</a></li>
+            </ul>
+            <h3 class="search-header usa-prose-h3 margin-bottom-0" aria-label="Categories">Categories</h3>
+            <ul id="category-list" class="usa-list usa-list--unstyled padding-top-1">
+              <% @category_names_by_popularity[0..2].each do |category_name| %>
+                <li class="category-item padding-bottom-1">
+                  <a class="public-sans" href=<%= "/search?category=#{category_name}" %>><%= category_name %></a>
+                </li>
+              <% end %>
+              <li><a class="browse-all-link public-sans text-bold" href="<%= search_path %>">Browse all categories</a></li>
             </ul>
           </div>
         </div>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -51,8 +51,8 @@
                   <a class="public-sans" href=<%= "/search?category=#{category_name}" %>><%= category_name %></a>
                 </li>
               <% end %>
+              <li><a class="browse-all-link public-sans text-bold" href="<%= search_path %>">Browse all categories</a></li>
             </ul>
-            <a class="browse-all-link public-sans text-bold padding-top-1" href="<%= search_path %>">Browse all categories</a>
             <h3 class="search-header usa-prose-h3 margin-bottom-0">Innovations</h3>
             <ul id="practice-list" class="usa-list usa-list--unstyled padding-top-1">
               <% @practice_names[0..2].each do |practice_name| %>
@@ -60,8 +60,8 @@
                   <a class="public-sans" href="#"><%= practice_name %></a>
                 </li>
               <% end %>
+              <li><a class="browse-all-link public-sans text-bold" href="<%= search_path %>">Browse all innovations</a></li>
             </ul>
-            <a class="browse-all-link public-sans text-bold padding-top-1" href="<%= search_path %>">Browse all innovations</a>
           </div>
         </div>
         <button id="dm-homepage-search-button" class="usa-button height-5 margin-right-0" type="submit">

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -48,7 +48,7 @@
               <h3 class="search-header usa-prose-h3 margin-bottom-0">Innovations</h3>
               <ul id="practice-list" class="usa-list usa-list--unstyled padding-top-1">
                 <% @practice_names[0..2].each do |practice_name| %>
-                  <li class="search-result padding-bottom-1">
+                  <li class="search-result">
                     <a href="/innovations/<%= @practice_names_and_slugs[practice_name] %>"><%= practice_name %></a>
                   </li>
                 <% end %>
@@ -59,7 +59,7 @@
               <h3 class="search-header usa-prose-h3 margin-bottom-0" aria-label="Categories">Categories</h3>
               <ul id="category-list" class="usa-list usa-list--unstyled padding-top-1">
                 <% @category_names_by_popularity[0..2].each do |category_name| %>
-                  <li class="search-result padding-bottom-1">
+                  <li class="search-result">
                     <a href=<%= "/search?category=#{category_name}" %>><%= category_name %></a>
                   </li>
                 <% end %>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -44,24 +44,28 @@
           style="display: none;"
         >
           <div class="dropdown-content margin-4">
-            <h3 class="search-header usa-prose-h3 margin-bottom-0">Innovations</h3>
-            <ul id="practice-list" class="usa-list usa-list--unstyled padding-top-1">
-              <% @practice_names[0..2].each do |practice_name| %>
-                <li class="practice-item padding-bottom-1">
-                  <a class="public-sans" href="/innovations/<%= @practice_names_and_slugs[practice_name] %>"><%= practice_name %></a>
-                </li>
-              <% end %>
-              <li><a class="browse-all-link public-sans text-bold" href="<%= search_path %>">Browse all innovations</a></li>
-            </ul>
-            <h3 class="search-header usa-prose-h3 margin-bottom-0" aria-label="Categories">Categories</h3>
-            <ul id="category-list" class="usa-list usa-list--unstyled padding-top-1">
-              <% @category_names_by_popularity[0..2].each do |category_name| %>
-                <li class="category-item padding-bottom-1">
-                  <a class="public-sans" href=<%= "/search?category=#{category_name}" %>><%= category_name %></a>
-                </li>
-              <% end %>
-              <li><a class="browse-all-link public-sans text-bold" href="<%= search_path %>">Browse all categories</a></li>
-            </ul>
+            <div class="result-section">
+              <h3 class="search-header usa-prose-h3 margin-bottom-0">Innovations</h3>
+              <ul id="practice-list" class="usa-list usa-list--unstyled padding-top-1">
+                <% @practice_names[0..2].each do |practice_name| %>
+                  <li class="search-result padding-bottom-1">
+                    <a class="public-sans" href="/innovations/<%= @practice_names_and_slugs[practice_name] %>"><%= practice_name %></a>
+                  </li>
+                <% end %>
+              </ul>
+              <a class="browse-all-link public-sans text-bold" href="<%= search_path %>">Browse all innovations</a>
+            </div>
+            <div class="result-section">
+              <h3 class="search-header usa-prose-h3 margin-bottom-0" aria-label="Categories">Categories</h3>
+              <ul id="category-list" class="usa-list usa-list--unstyled padding-top-1">
+                <% @category_names_by_popularity[0..2].each do |category_name| %>
+                  <li class="search-result padding-bottom-1">
+                    <a class="public-sans" href=<%= "/search?category=#{category_name}" %>><%= category_name %></a>
+                  </li>
+                <% end %>
+              </ul>
+              <a class="browse-all-link public-sans text-bold" href="<%= search_path %>">Browse all categories</a>
+            </div>
           </div>
         </div>
         <button id="dm-homepage-search-button" class="usa-button height-5 margin-right-0" type="submit">

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -27,17 +27,16 @@
     data-innovations="<%= @practice_names %>"
     data-innovation-links="<%= @practice_names_and_slugs.to_json %>"
   >
-    <form id="dm-homepage-search-form" class="usa-search margin-bottom-2" role="search">
-      <label class="usa-sr-only" for="dm-homepage-search-form">Homepage search</label>
+    <form id="dm-homepage-search-form" class="usa-search margin-bottom-2" role="search" aria-label="Search innovations and categories">
       <div class="dm-homepage-search-container width-full">
         <input
           class="usa-input height-5"
           id="dm-homepage-search-field"
           type="search"
           name="search"
-          title="Search for innovations"
           autocomplete="off"
-          placeholder="Innovations, categories, partners..."
+          placeholder="Innovations, categories..."
+          aria-labelledby="dm-homepage-search-form"
         >
         <div
           id="search-dropdown"

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -40,7 +40,7 @@
         >
         <div
           id="search-dropdown"
-          class="search-dropdown radius-md bg-white shadow-5 left-0 right-0"
+          class="radius-md bg-white shadow-5 left-0 right-0"
           style="display: none;"
         >
           <div class="dropdown-content margin-4">

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -49,22 +49,22 @@
               <ul id="practice-list" class="usa-list usa-list--unstyled padding-top-1">
                 <% @practice_names[0..2].each do |practice_name| %>
                   <li class="search-result padding-bottom-1">
-                    <a class="public-sans" href="/innovations/<%= @practice_names_and_slugs[practice_name] %>"><%= practice_name %></a>
+                    <a href="/innovations/<%= @practice_names_and_slugs[practice_name] %>"><%= practice_name %></a>
                   </li>
                 <% end %>
               </ul>
-              <a class="browse-all-link public-sans text-bold" href="<%= search_path %>">Browse all innovations</a>
+              <a class="browse-all-link text-bold" href="<%= search_path %>">Browse all innovations</a>
             </div>
             <div class="result-section">
               <h3 class="search-header usa-prose-h3 margin-bottom-0" aria-label="Categories">Categories</h3>
               <ul id="category-list" class="usa-list usa-list--unstyled padding-top-1">
                 <% @category_names_by_popularity[0..2].each do |category_name| %>
                   <li class="search-result padding-bottom-1">
-                    <a class="public-sans" href=<%= "/search?category=#{category_name}" %>><%= category_name %></a>
+                    <a href=<%= "/search?category=#{category_name}" %>><%= category_name %></a>
                   </li>
                 <% end %>
               </ul>
-              <a class="browse-all-link public-sans text-bold" href="<%= search_path %>">Browse all categories</a>
+              <a class="browse-all-link text-bold" href="<%= search_path %>">Browse all categories</a>
             </div>
           </div>
         </div>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -25,6 +25,7 @@
     aria-label="Homepage search section"
     data-categories="<%= @category_names_by_popularity %>"
     data-innovations="<%= @practice_names %>"
+    data-innovation-links="<%= @practice_names_and_slugs.to_json %>"
   >
     <form id="dm-homepage-search-form" class="usa-search margin-bottom-2" role="search">
       <label class="usa-sr-only" for="dm-homepage-search-form">Homepage search</label>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -48,7 +48,7 @@
             <ul id="practice-list" class="usa-list usa-list--unstyled padding-top-1">
               <% @practice_names[0..2].each do |practice_name| %>
                 <li class="practice-item padding-bottom-1">
-                  <a class="public-sans" href="#"><%= practice_name %></a>
+                  <a class="public-sans" href="/innovations/<%= @practice_names_and_slugs[practice_name] %>"><%= practice_name %></a>
                 </li>
               <% end %>
               <li><a class="browse-all-link public-sans text-bold" href="<%= search_path %>">Browse all innovations</a></li>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -24,6 +24,7 @@
     role="region"
     aria-label="Homepage search section"
     data-categories="<%= @category_names_by_popularity %>"
+    data-innovations="<%= @practice_names %>"
   >
     <form id="dm-homepage-search-form" class="usa-search margin-bottom-2" role="search">
       <label class="usa-sr-only" for="dm-homepage-search-form">Homepage search</label>

--- a/app/views/shared/_navbar_search.html.erb
+++ b/app/views/shared/_navbar_search.html.erb
@@ -3,12 +3,9 @@
   search_field_id ||= 'dm-navbar-search-field'
   search_button_id ||= 'dm-navbar-search-button'
 %>
-<form id="<%= search_form_id %>" class="dm-navbar-search-form usa-search usa-search--small<%= ' margin-right-0' if ENV['VAEC_ENV'] === 'true' && session[:user_type] === 'guest' %>" role="search">
-  <label class="usa-sr-only" for="<%= search_form_id %>">
-    practice search
-  </label>
+<form id="<%= search_form_id %>" class="dm-navbar-search-form usa-search usa-search--small<%= ' margin-right-0' if ENV['VAEC_ENV'] === 'true' && session[:user_type] === 'guest' %>" role="search" aria-label="search innovations">
   <div class="dm-navbar-search-container">
-    <input class="usa-input dm-navbar-search-field" id="<%= search_field_id %>" type="search" name="search" title="Search practices">
+    <input class="usa-input dm-navbar-search-field" id="<%= search_field_id %>" type="search" name="search" aria-labelledby="<%= search_form_id %>">
     <button id="<%= search_button_id %>" class="usa-button dm-navbar-search-button" type="submit">
       <span class="usa-sr-only">Search</span>
     </button>

--- a/spec/features/homepage_spec.rb
+++ b/spec/features/homepage_spec.rb
@@ -154,6 +154,12 @@ describe 'Homepage', type: :feature do
           expect(page).to have_link('Browse all categories', href: '/search')
         end
       end
+
+      it 'lets a user navigate results with arrow keys' do
+        page.send_keys :down, :down, :down, :down, :down # navigate to first category
+        page.send_keys :enter # select category
+        expect(page).to have_current_path('/search?category=COVID')
+      end
     end
   end
 end

--- a/spec/features/homepage_spec.rb
+++ b/spec/features/homepage_spec.rb
@@ -27,6 +27,10 @@ describe 'Homepage', type: :feature do
     create(:category_practice, practice: @practice_2, category: @cat_2)
     create(:category_practice, practice: @practice_3, category: @cat_1)
 
+    ampersand_practice = create(:practice, name: 'Coaching & More', slug: 'coaching-and-more', is_public: true, approved: true, published: true, tagline: "HAPPEN tagline", date_initiated: 'Sun, 04 Feb 1992 00:00:00 UTC +00:00', created_at: 'Sun, 04 Feb 1992 00:00:00 UTC +00:00', support_network_email: 'contact-happen@happen.com', user: @user)
+    ampersand_category = create(:category, name: 'Nutrition & Food', parent_category: @parent_cat)
+    create(:category_practice, practice: ampersand_practice, category: ampersand_category)
+
     visit '/'
   end
 
@@ -164,6 +168,12 @@ describe 'Homepage', type: :feature do
       page.send_keys :down, :down, :down, :down, :down # navigate to first category
       page.send_keys :enter # select category
       expect(page).to have_current_path('/search?category=COVID')
+    end
+
+    it 'encodes categories & innovations with ampersands' do
+      fill_in('dm-homepage-search-field', with: '&')
+      expect(page).to have_link('Nutrition & Food', href: '/search?category=Nutrition%20%26%20Food')
+      expect(page).to have_link('Coaching & More', href: '/innovations/coaching-and-more')
     end
   end
 end

--- a/spec/features/homepage_spec.rb
+++ b/spec/features/homepage_spec.rb
@@ -125,8 +125,8 @@ describe 'Homepage', type: :feature do
       end
 
       it 'should navigate to search page with category filter when a category is clicked' do
-        within '#search-dropdown' do
-          first('.category-item').find('a').click
+        within '#category-list' do
+          first('.search-result').find('a').click
         end
         expect(page).to have_current_path('/search?category=COVID')
       end

--- a/spec/features/homepage_spec.rb
+++ b/spec/features/homepage_spec.rb
@@ -10,10 +10,10 @@ describe 'Homepage', type: :feature do
 
     @user = create(:user, :admin, email: 'naofumi.iwatani@va.gov', password: 'Password123', password_confirmation: 'Password123', skip_va_validation: true, confirmed_at: Time.now, accepted_terms: true)
 
-    create(:practice, name: 'Project HAPPEN', slug: 'project-happen', approved: true, published: true, tagline: "HAPPEN tagline", support_network_email: 'contact-happen@happen.com', user: @user)
-    @practice = create(:practice, name: 'The Best Practice Ever!', initiating_facility_type: 'facility', tagline: 'Test tagline', date_initiated: 'Sun, 05 Feb 1992 00:00:00 UTC +00:00', summary: 'This is the best practice ever.', overview_problem: 'overview-problem', published: true, approved: true, user: @user)
-    @practice_2 = create(:practice, name: 'The Second Best Practice Ever!', initiating_facility_type: 'facility', tagline: 'Test tagline', date_initiated: 'Sun, 05 Feb 1992 00:00:00 UTC +00:00', summary: 'This is the best practice ever.', overview_problem: 'overview-problem', published: true, approved: true, user: @user)
-    @practice_3 = create(:practice, name: 'The Third Best Practice Ever!', initiating_facility_type: 'facility', tagline: 'Test tagline', date_initiated: 'Sun, 05 Feb 1992 00:00:00 UTC +00:00', summary: 'This is the best practice ever.', overview_problem: 'overview-problem', published: true, approved: true, user: @user)
+    create(:practice, name: 'Project HAPPEN', slug: 'project-happen', approved: true, published: true, tagline: "HAPPEN tagline", date_initiated: 'Sun, 04 Feb 1992 00:00:00 UTC +00:00', created_at: 'Sun, 04 Feb 1992 00:00:00 UTC +00:00', support_network_email: 'contact-happen@happen.com', user: @user)
+    @practice = create(:practice, name: 'The Best Practice Ever!', initiating_facility_type: 'facility', tagline: 'Test tagline', date_initiated: 'Sun, 05 Feb 1992 00:00:00 UTC +00:00', created_at: 'Sun, 05 Feb 1992 00:00:00 UTC +00:00', summary: 'This is the best practice ever.', overview_problem: 'overview-problem', is_public: true, published: true, approved: true, user: @user)
+    @practice_2 = create(:practice, name: 'The Second Best Practice Ever!', initiating_facility_type: 'facility', tagline: 'Test tagline', date_initiated: 'Sun, 06 Feb 1992 00:00:00 UTC +00:00', created_at: 'Sun, 06 Feb 1992 00:00:00 UTC +00:00', summary: 'This is the best practice ever.', overview_problem: 'overview-problem', is_public: true, published: true, approved: true, user: @user)
+    @practice_3 = create(:practice, name: 'The Third Best Practice Ever!', initiating_facility_type: 'facility', tagline: 'Test tagline', date_initiated: 'Sun, 07 Feb 1992 00:00:00 UTC +00:00', created_at: 'Sun, 07 Feb 1992 00:00:00 UTC +00:00', summary: 'This is the best practice ever.', overview_problem: 'overview-problem', is_public: true, published: true, approved: true, user: @user)
 
     create(:practice_origin_facility, practice: @practice, facility_type: 0, va_facility_id: 1)
 
@@ -113,14 +113,31 @@ describe 'Homepage', type: :feature do
         find('#dm-homepage-search-field').click
       end
 
-      it 'should display the dropdown when the search input is focused' do
+      it 'displays the dropdown when the search input is focused' do
         expect(page).to have_selector('#search-dropdown', visible: :visible)
       end
 
+      it 'lists most recently created innovations' do
+        within '#practice-list' do
+          expect(page).to have_content('The Best Practice Ever!')
+          expect(page).to have_content('The Second Best Practice Ever!')
+          expect(page).to have_content('The Third Best Practice Ever!')
+
+          expect(page).not_to have_content('Project HAPPEN') # oldest practice
+        end
+      end
+
       it 'should list popular categories in the dropdown initially' do
-        within '#search-dropdown' do
+        within '#category-list' do
           expect(page).to have_content('COVID')
           expect(page).to have_content('Telehealth')
+        end
+      end
+
+      it 'lets a user search for innovations' do
+        fill_in('dm-homepage-search-field', with: 'HAPPEN')
+        within '#search-dropdown' do
+          expect(page).to have_link('Project HAPPEN', href: '/innovations/project-happen')
         end
       end
 
@@ -131,11 +148,11 @@ describe 'Homepage', type: :feature do
         expect(page).to have_current_path('/search?category=COVID')
       end
 
-      it 'should have a link to the search page' do
+      it 'links to the search page' do
         within '#search-dropdown' do
-          click_link('Browse all categories')
+          expect(page).to have_link('Browse all innovations', href: '/search')
+          expect(page).to have_link('Browse all categories', href: '/search')
         end
-        expect(page).to have_current_path('/search')
       end
     end
   end


### PR DESCRIPTION
### JIRA issue link
[DM-4431](https://agile6.atlassian.net/browse/DM-4431)

## Description - what does this code do?
- Adds Innovations to search dropdown
- Only shows public innovation to public users
- Cleans up markup and CSS to make it reusable for additional dropdown sections
- Adds responsive truncation to long result names
- Updates placeholder text [per team feedback](https://agile6.atlassian.net/browse/DM-4431?focusedCommentId=11915)
- Backfills some tests for #786 #779

## Testing done - how did you test it/steps on how can another person can test it 
In local dev:
1. Go to homepage and confirm you only see public innovations
2. Sign in and then return to the homepage
3. You should see 3 innovations, ordered by their `created_at` date
4. Start typing a string like `service`. As you type you should see both Innovations and Categories updating
5. Click on an innovation and confirm that it takes you to the innovation show page

## Screenshots, Gifs, Videos from application (if applicable)
### Public user (local dev)
![Screenshot 2024-02-20 at 4 02 33 PM](https://github.com/department-of-veterans-affairs/diffusion-marketplace/assets/5402927/b107e45c-8996-4bac-8415-d480dcf13db0)

### Private user (local dev)
![Screenshot 2024-02-20 at 4 02 41 PM](https://github.com/department-of-veterans-affairs/diffusion-marketplace/assets/5402927/8afdf833-d753-46c8-b343-1ac86a0c680d)

## Link to mock-ups/mock ups (image file if you have it) (if applicable)
https://www.figma.com/file/D16fyBygVx88HpyczTuqXs/Diffusion-Marketplace-(2024)%2B?type=design&node-id=3%3A5426&mode=design&t=P8YnvwIpLSCrNRXh-1
