### PR TITLE
Dm 4402 fix innovation cc email bug

### DIFF
--- a/app/assets/javascripts/practice_editor_utilities.es6
+++ b/app/assets/javascripts/practice_editor_utilities.es6
@@ -452,3 +452,8 @@ function displayAttachmentForm(sArea, sType) {
     $(`#display_${sArea}_form div[id*="_form"]`).hide();
     $(`#display_${sArea}_form div[id="${sArea}_${sType}_form"]`).show();
 }
+
+$(document).on('change', '.pe-address-input', function() {
+    var isEmpty = !$(this).val();
+    $(this).closest('li.fields').find('input[name*="[_destroy]"]').val(isEmpty ? '1' : '0');
+});

--- a/spec/features/practice_editor/about_spec.rb
+++ b/spec/features/practice_editor/about_spec.rb
@@ -206,7 +206,7 @@ describe 'Practice editor', type: :feature do
             expect(email_message).to eq('Please fill out this field.')
         end
 
-        it 'should allow the user to update the email data on the page' do
+        it 'should allow the user to update the email data on the page', js: true do
             # create the main email address
             fill_in_main_email_field
             save_button.click
@@ -261,17 +261,9 @@ describe 'Practice editor', type: :feature do
             end
 
             # delete "second" cc email
-            expect(page).to have_field(@email_field_name, with: 'second_test@test.com')
-            input_field_id = first_cc_email_field_input[:id]
-            find('.add-practice-email-link').click
-            within(first_cc_email_field) do
-                click_link('Delete entry')
-                expect(page).to_not have_selector("##{input_field_id}")
-            end
+            first_cc_email_field_input.set('')
             save_button.click
-            within(:css, '.practice-editor-contact-ul') do
-                expect(page).to_not have_selector("##{input_field_id}")
-            end
+            expect(first_cc_email_field_input.value).to eq('')
         end
     end
 end


### PR DESCRIPTION
### JIRA issue link
https://agile6.atlassian.net/browse/DM-4402

## Description - what does this code do?
* adds jquery / js to allow submission of empty innovation cc email value, recognizes empty value specifically for `pe-address-input` class and utilizes `_destroy` param to let backend know to destroy the record

## Testing done - how did you test it/steps on how can another person can test it 
1. Visit the `edit/about` page for an innovation
2. Make sure there is an email address saved for the "Copied (cc’ed) email address" field, if none, add one and save by clicking the  green `Save and update` button at the top right of the page
3. Clear the address from the "Copied (cc’ed) email address" field, save the page
4. Verify the field is now empty.

## Screenshots, Gifs, Videos from application (if applicable)


## Link to mock-ups/mock ups (image file if you have it) (if applicable)


## Acceptance criteria
- [ ]

## Definition of done
- [x] Unit tests written (if applicable)
- [x] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating JIRA issue
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs