### PR TITLE
DM-4439: Clean up PageBuilder components' required fields

### DIFF
--- a/app/admin/pages.rb
+++ b/app/admin/pages.rb
@@ -236,6 +236,7 @@ ActiveAdmin.register Page do
     f.inputs "Page Components" do
       render partial: 'page_components_form', locals: {f: f, page_components: :page_components}
     end
+    para 'All fields marked with an * are required'
     f.actions # adds the 'Submit' and 'Cancel' buttons
   end
 

--- a/app/assets/stylesheets/active_admin.scss
+++ b/app/assets/stylesheets/active_admin.scss
@@ -114,6 +114,14 @@
     padding-top: 0;
   }
 
+  fieldset label {
+    font-size: 1rem;
+  }
+
+  .page_components .required > label::after {
+      content: ' *';
+  }
+
   .max-width-15 {
     max-width: 15rem;
   }

--- a/app/assets/stylesheets/active_admin.scss
+++ b/app/assets/stylesheets/active_admin.scss
@@ -122,6 +122,13 @@
       content: ' *';
   }
 
+  .page_components .form-header {
+    font-size: 1rem;
+    font-weight: bold;
+    color: #8494a8;
+    text-transform: uppercase;
+  }
+
   .max-width-15 {
     max-width: 15rem;
   }

--- a/app/views/active_admin/resource/_page_accordion_component_form.html.arb
+++ b/app/views/active_admin/resource/_page_accordion_component_form.html.arb
@@ -25,7 +25,7 @@ html = Arbre::Context.new do
         # Title
         li class: 'string input optional stringish', id: "page_page_components_attributes_#{placeholder}_component_attributes_title_input" do
           label 'Title', for: "page_page_components_attributes_accordion_#{placeholder}_component_attributes_text", class: 'label'
-          input value: component&.title || nil, type: 'text', required: 'required',
+          input value: component&.title || nil, type: 'text',
                 id: "page_page_components_attributes_#{placeholder}_component_attributes_title",
                 name: "page[page_components_attributes][#{placeholder}][component_attributes][title]"
           para 'Section header styled as secondary heading/"H2"', class: 'inline-hints'

--- a/app/views/active_admin/resource/_page_event_component_form.html.arb
+++ b/app/views/active_admin/resource/_page_event_component_form.html.arb
@@ -25,7 +25,7 @@ html = Arbre::Context.new do
       ol do
         li class: 'string input optional stringish', id: "page_page_components_attributes_#{placeholder}_component_attributes_title_input" do
           label 'Title', for: "page_page_components_attributes_event_#{placeholder}_component_attributes_title", class: 'label'
-          input value: component&.title || nil, type: 'text', required: 'required',
+          input value: component&.title || nil,
                 id: "page_page_components_attributes_#{placeholder}_component_attributes_title",
                 name: "page[page_components_attributes][#{placeholder}][component_attributes][title]"
           para 'Event title styled as an H3', class: 'inline-hints'
@@ -33,7 +33,7 @@ html = Arbre::Context.new do
 
         li class: 'string input optional stringish', id: "page_page_components_attributes_#{placeholder}_component_attributes_url_input" do
           label 'URL', for: "page_page_components_attributes_event_#{placeholder}_component_attributes_url", class: 'label'
-          input value: component&.url || nil, type: 'text', required: 'required',
+          input value: component&.url || nil, type: 'text',
                 id: "page_page_components_attributes_#{placeholder}_component_attributes_url",
                 name: "page[page_components_attributes][#{placeholder}][component_attributes][url]"
           para 'URL used for event title link, e.g. https://va.gov', class: 'inline-hints'
@@ -41,7 +41,7 @@ html = Arbre::Context.new do
 
         li class: 'string input optional stringish', id: "page_page_components_attributes_#{placeholder}_component_attributes_presented_by_input" do
           label 'Presented by', for: "page_page_components_attributes_event_#{placeholder}_component_attributes_presented_by", class: 'label'
-          input value: component&.presented_by || nil, type: 'text', required: 'required',
+          input value: component&.presented_by || nil, type: 'text',
                 id: "page_page_components_attributes_#{placeholder}_component_attributes_presented_by",
                 name: "page[page_components_attributes][#{placeholder}][component_attributes][presented_by]"
           para 'Sponsoring organization, e.g. VHA Innovation Network', class: 'inline-hints'
@@ -49,7 +49,7 @@ html = Arbre::Context.new do
 
         li class: 'date input optional', id: "page_page_components_attributes_#{placeholder}_component_attributes_start_date_input" do
           label 'Start date', for: "page_page_components_attributes_event_#{placeholder}_component_attributes_start_date", class: 'label'
-          input value: component&.start_date || nil, type: 'date', required: 'required',
+          input value: component&.start_date || nil, type: 'date',
                 id: "page_page_components_attributes_#{placeholder}_component_attributes_start_date",
                 name: "page[page_components_attributes][#{placeholder}][component_attributes][start_date]"
           para '', class: 'inline-hints'
@@ -57,7 +57,7 @@ html = Arbre::Context.new do
 
         li class: 'date input optional', id: "page_page_components_attributes_#{placeholder}_component_attributes_end_date_input" do
           label 'End date', for: "page_page_components_attributes_event_#{placeholder}_component_attributes_end_date", class: 'label'
-          input value: component&.end_date || nil, type: 'date', required: 'required',
+          input value: component&.end_date || nil, type: 'date',
                 id: "page_page_components_attributes_#{placeholder}_component_attributes_end_date",
                 name: "page[page_components_attributes][#{placeholder}][component_attributes][end_date]"
           para 'Leave blank if this is a one day event', class: 'inline-hints'
@@ -65,7 +65,7 @@ html = Arbre::Context.new do
 
         li class: 'string input optional stringish', id: "page_page_components_attributes_#{placeholder}_component_attributes_location_input" do
           label 'Location', for: "page_page_components_attributes_event_#{placeholder}_component_attributes_location", class: 'label'
-          input value: component&.location || nil, type: 'text', required: 'required',
+          input value: component&.location || nil, type: 'text',
                 id: "page_page_components_attributes_#{placeholder}_component_attributes_location",
                 name: "page[page_components_attributes][#{placeholder}][component_attributes][location]"
           para 'e.g. Virtual and Washington DC in-person', class: 'inline-hints'

--- a/app/views/active_admin/resource/_page_header2_component_form.html.arb
+++ b/app/views/active_admin/resource/_page_header2_component_form.html.arb
@@ -16,21 +16,21 @@ html = Arbre::Context.new do
 
         li class: 'string input optional stringish', id: "page_page_components_attributes_#{placeholder}_component_attributes_subtopic_title_input" do
           label 'Subtopic title', for: "page_page_components_attributes_#{placeholder}_component_attributes_text", class: 'label'
-          input value: component&.subtopic_title || nil, type: 'text', required: 'required',
+          input value: component&.subtopic_title || nil, type: 'text',
                 id: "page_page_components_attributes_#{placeholder}_component_attributes_subtopic_title",
                 name: "page[page_components_attributes][#{placeholder}][component_attributes][subtopic_title]"
           para 'Section header styled as secondary heading/"H2"', class: 'inline-hints'
 
           li class: 'string input optional stringish', id: "page_page_components_attributes_#{placeholder}_component_attributes_subtopic_description_input" do
             label 'Subtopic description', for: "page_page_components_attributes_#{placeholder}_component_attributes_text", class: 'label'
-            input value: component&.subtopic_description || nil, type: 'text', required: 'required',
+            input value: component&.subtopic_description || nil, type: 'text',
                   id: "page_page_components_attributes_#{placeholder}_component_attributes_subtopic_description",
                   name: "page[page_components_attributes][#{placeholder}][component_attributes][subtopic_description]"
           end
 
           li class: 'string input optional stringish', id: "page_page_components_attributes_#{placeholder}_component_attributes_url_input" do
           label 'URL', for: "page_page_components_attributes_#{placeholder}_component_attributes_text", class: 'label'
-          input value: component&.url || nil, type: 'text', required: 'required',
+          input value: component&.url || nil, type: 'text',
                 id: "page_page_components_attributes_#{placeholder}_component_attributes_url",
                 name: "page[page_components_attributes][#{placeholder}][component_attributes][url]"
           para 'Optional. Enter a URL suffix to any internal page of the marketplace (Ex: "/innovations/vione" or a complete external URL (Ex.  https://www.va.gov/) that you would like the heading to link to', class: 'inline-hints'

--- a/app/views/active_admin/resource/_page_header3_component_form.html.arb
+++ b/app/views/active_admin/resource/_page_header3_component_form.html.arb
@@ -16,14 +16,14 @@ html = Arbre::Context.new do
 
         li class: 'string input optional stringish', id: "page_page_components_attributes_#{placeholder}_component_attributes_title_input" do
           label 'Title', for: "page_page_components_attributes_#{placeholder}_component_attributes_title", class: 'label'
-          input value: component&.title || nil, type: 'text', required: 'required',
+          input value: component&.title || nil, type: 'text',
                 id: "page_page_components_attributes_#{placeholder}_component_attributes_title",
                 name: "page[page_components_attributes][#{placeholder}][component_attributes][title]"
           para 'Section header styled as secondary heading/"H3"', class: 'inline-hints'
 
           li class: 'string input optional stringish', id: "page_page_components_attributes_#{placeholder}_component_attributes_description_input" do
             label 'Description', for: "page_page_components_attributes_#{placeholder}_component_attributes_description", class: 'label'
-            input value: component&.description || nil, type: 'text', required: 'required',
+            input value: component&.description || nil, type: 'text',
                   id: "page_page_components_attributes_#{placeholder}_component_attributes_description",
                   name: "page[page_components_attributes][#{placeholder}][component_attributes][description]"
           end
@@ -40,7 +40,7 @@ html = Arbre::Context.new do
 
           li class: 'string input optional stringish', id: "page_page_components_attributes_#{placeholder}_component_attributes_url_input" do
           label 'URL', for: "page_page_components_attributes_#{placeholder}_component_attributes_text", class: 'label'
-          input value: component&.url || nil, type: 'text', required: 'required',
+          input value: component&.url || nil, type: 'text',
                 id: "page_page_components_attributes_#{placeholder}_component_attributes_url",
                 name: "page[page_components_attributes][#{placeholder}][component_attributes][url]"
           para 'Optional. Enter a URL suffix to any internal page of the marketplace (Ex: "/innovations/vione" or a complete external URL (Ex.  https://www.va.gov/) that you would like the heading to link to', class: 'inline-hints'

--- a/app/views/active_admin/resource/_page_image_component_form.html.arb
+++ b/app/views/active_admin/resource/_page_image_component_form.html.arb
@@ -18,9 +18,10 @@ html = Arbre::Context.new do
 
         a 'Move to Top', href: '#', class: 'move-to-top float-right', id: component&.page_component&.id
 
-        li class: 'select input optional', id: "page_page_components_attributes_#{placeholder}_component_attributes_alignment_input" do
+        li class: 'select input required', id: "page_page_components_attributes_#{placeholder}_component_attributes_alignment_input" do
           label 'Alignment', for: "page_page_components_attributes_#{placeholder}_component_attributes_alignment", class: 'label'
           select value: component&.alignment || 'center',
+                required: 'required',
                 id: "page_page_components_attributes_#{placeholder}_component_attributes_alignment",
                 name: "page[page_components_attributes][#{placeholder}][component_attributes][alignment]" do
             option ''
@@ -43,7 +44,7 @@ html = Arbre::Context.new do
                 name: "page[page_components_attributes][#{placeholder}][component_attributes][alt_text]"
           para 'Alternate text that gets rendered in case the image cannot load.', class: 'inline-hints'
         end
-        li class: 'url input required stringish', id: "page_page_components_attributes_#{placeholder}_component_attributes_url_input" do
+        li class: 'url input optional stringish', id: "page_page_components_attributes_#{placeholder}_component_attributes_url_input" do
           label 'Url', for: "page_page_components_attributes_#{placeholder}_component_attributes_url", class: 'label'
           input value: component&.url || nil, type: 'text',
                 id: "page_page_components_attributes_#{placeholder}_component_attributes_url",

--- a/app/views/active_admin/resource/_page_map_component_form.html.arb
+++ b/app/views/active_admin/resource/_page_map_component_form.html.arb
@@ -14,17 +14,17 @@ html = Arbre::Context.new do
 
         a 'Move to Top', href: '#', class: 'move-to-top float-right', id: component&.page_component&.id
 
-        li class: 'url input required stringish', id: "page_page_components_attributes_#{placeholder}_component_attributes_title_input" do
+        li class: 'url input optional stringish', id: "page_page_components_attributes_#{placeholder}_component_attributes_title_input" do
           label 'Title', for: "page_page_components_attributes_#{placeholder}_component_attributes_title", class: 'label'
-          input value: component&.title || nil, type: 'text', required: 'required',
+          input value: component&.title || nil, type: 'text',
                 id: "page_page_components_attributes_#{placeholder}_component_attributes_title",
                 name: "page[page_components_attributes][#{placeholder}][component_attributes][title]"
           para 'Enter a title for the map.', class: 'inline-hints'
         end
 
-        li class: 'url input required stringish', id: "page_page_components_attributes_#{placeholder}_component_attributes_map_info_window_text_input" do
+        li class: 'url input optional stringish', id: "page_page_components_attributes_#{placeholder}_component_attributes_map_info_window_text_input" do
           label 'Map Info Window Text', for: "page_page_components_attributes_#{placeholder}_component_attributes_map_info_window_text", class: 'label'
-          input value: component&.map_info_window_text || nil, type: 'text', required: 'required',
+          input value: component&.map_info_window_text || nil, type: 'text',
                 id: "page_page_components_attributes_#{placeholder}_component_attributes_map_info_window_text",
                 name: "page[page_components_attributes][#{placeholder}][component_attributes][map_info_window_text]"
           para 'Enter text or acronym to display in the maps info window.', class: 'inline-hints'
@@ -57,7 +57,7 @@ html = Arbre::Context.new do
 
         li class: 'select input optional', id: "page_page_components_attributes_#{placeholder}_practices_attributes_input" do
           label 'Innovation List', for: "page_page_components_attributes_#{placeholder}_component_attributes_map", class: 'label'
-          select required: 'required', multiple: 'multiple', size: '20',
+          select multiple: 'multiple', size: '20',
                  id: "page_page_components_attributes_#{placeholder}_component_attributes_map",
                  name: "page[page_components_attributes][#{placeholder}][component_attributes][practices][]" do
             Practice.order(name: :asc).each do |p|

--- a/app/views/active_admin/resource/_page_map_component_form.html.arb
+++ b/app/views/active_admin/resource/_page_map_component_form.html.arb
@@ -31,10 +31,11 @@ html = Arbre::Context.new do
         end
 
         # Description text alignment
-        li class: 'select input description-text-alignment-container',
+        li class: 'select input required description-text-alignment-container',
            id: "page_page_components_attributes_#{placeholder}_component_attributes_description_text_alignment_input" do
           label 'Text alignment', for: "page_page_components_attributes_#{placeholder}_component_attributes_description_text_alignment", class: 'label'
           select value: component&.description_text_alignment || nil,
+                 required: 'required',
                  id: "page_page_components_attributes_#{placeholder}_component_attributes_description_text_alignment",
                  name: "page[page_components_attributes][#{placeholder}][component_attributes][description_text_alignment]" do
             option 'Bottom', selected: component&.description_text_alignment === 'Bottom' || component&.description_text_alignment.blank?
@@ -46,7 +47,7 @@ html = Arbre::Context.new do
         end
 
         # Map description
-        li class: 'url input required stringish', id: "page_page_components_attributes_#{placeholder}_component_attributes_description_input" do
+        li class: 'url input optional stringish', id: "page_page_components_attributes_#{placeholder}_component_attributes_description_input" do
           label 'Description', for: "page_page_components_attributes_#{placeholder}_component_attributes_description", class: 'label'
 
           textarea component&.description, id: "page_page_components_attributes_#{placeholder}_component_attributes_description", name: "page[page_components_attributes][#{placeholder}][component_attributes][description]", class: 'tinymce', rows:'18' do

--- a/app/views/active_admin/resource/_page_map_component_form.html.arb
+++ b/app/views/active_admin/resource/_page_map_component_form.html.arb
@@ -67,6 +67,8 @@ html = Arbre::Context.new do
           para 'Select which Innovations adoptions are displayed on the map.  Hold down the CTRL key and click on Innovation names to add to the list.', class: 'inline-hints'
         end
 
+        span 'Map Markers:', class: 'form-header'
+
         li class: 'checkbox input optional', id: "page_page_components_attributes_#{placeholder}_component_attributes_display_successful_adoptions_input" do
           if component
             input type: 'hidden', value: '0', name: "page[page_components_attributes][#{placeholder}][component_attributes][display_successful_adoptions]"

--- a/app/views/active_admin/resource/_page_news_component_form.html.arb
+++ b/app/views/active_admin/resource/_page_news_component_form.html.arb
@@ -25,7 +25,7 @@ html = Arbre::Context.new do
       ol do
         li class: 'string input optional stringish', id: "page_page_components_attributes_#{placeholder}_component_attributes_title_input" do
           label 'Title', for: "page_page_components_attributes_news_#{placeholder}_component_attributes_text", class: 'label'
-          input value: component&.title || nil, type: 'text', required: 'required',
+          input value: component&.title || nil, type: 'text',
                 id: "page_page_components_attributes_#{placeholder}_component_attributes_title",
                 name: "page[page_components_attributes][#{placeholder}][component_attributes][title]"
           para 'News item title styled as an /"H3"', class: 'inline-hints'
@@ -33,7 +33,7 @@ html = Arbre::Context.new do
 
         li class: 'string input optional stringish', id: "page_page_components_attributes_#{placeholder}_component_attributes_url_input" do
           label 'URL', for: "page_page_components_attributes_news_#{placeholder}_component_attributes_text", class: 'label'
-          input value: component&.url || nil, type: 'text', required: 'required',
+          input value: component&.url || nil, type: 'text',
                 id: "page_page_components_attributes_#{placeholder}_component_attributes_url",
                 name: "page[page_components_attributes][#{placeholder}][component_attributes][url]"
           para 'Link to news item hosted elsewhere, e.g. https://va.gov', class: 'inline-hints'
@@ -41,7 +41,7 @@ html = Arbre::Context.new do
 
         li class: 'date input optional', id: "page_page_components_attributes_#{placeholder}_component_attributes_published_date_input" do
           label 'Publication date', for: "page_page_components_attributes_news_#{placeholder}_component_attributes_published_date", class: 'label'
-          input value: component&.published_date || nil, type: 'date', required: 'required',
+          input value: component&.published_date || nil, type: 'date',
                 id: "page_page_components_attributes_#{placeholder}_component_attributes_published_date",
                 name: "page[page_components_attributes][#{placeholder}][component_attributes][published_date]"
           para 'Original publication date', class: 'inline-hints'
@@ -49,7 +49,7 @@ html = Arbre::Context.new do
 
         li class: 'string input optional stringish', id: "page_page_components_attributes_#{placeholder}_component_attributes_authors_input" do
           label 'Author(s)', for: "page_page_components_attributes_news_#{placeholder}_component_attributes_text", class: 'label'
-          input value: component&.authors || nil, type: 'text', required: 'required',
+          input value: component&.authors || nil, type: 'text',
                 id: "page_page_components_attributes_#{placeholder}_component_attributes_authors",
                 name: "page[page_components_attributes][#{placeholder}][component_attributes][authors]"
           para 'Enter with appropriate punctuation. e.g. "John, Joan, and Jill', class: 'inline-hints'

--- a/app/views/active_admin/resource/_page_one_to_one_image_component_form.html.arb
+++ b/app/views/active_admin/resource/_page_one_to_one_image_component_form.html.arb
@@ -62,6 +62,7 @@ html = Arbre::Context.new do
         li class: 'select input required text-alignment-container', id: "page_page_components_attributes_#{placeholder}_component_attributes_text_alignment_input" do
           label 'Text alignment', for: "page_page_components_attributes_#{placeholder}_component_attributes_text_alignment", class: 'label'
           select value: component&.text_alignment || nil,
+            required: 'required',
             id: "page_page_components_attributes_#{placeholder}_component_attributes_text_alignment",
             name: "page[page_components_attributes][#{placeholder}][component_attributes][text_alignment]" do
             option 'Left', selected: component&.text_alignment === 'Left' || component&.text_alignment.blank?

--- a/app/views/active_admin/resource/_page_practice_list_component_form.html.arb
+++ b/app/views/active_admin/resource/_page_practice_list_component_form.html.arb
@@ -16,7 +16,7 @@ html = Arbre::Context.new do
 
         li class: 'select input optional', id: "page_page_components_attributes_#{placeholder}_practices_attributes_input" do
           label 'Practice List', for: "page_page_components_attributes_#{placeholder}_component_attributes_practice_list", class: 'label'
-          select required: 'required', multiple: 'multiple', size: '20',
+          select multiple: 'multiple', size: '20',
                 id: "page_page_components_attributes_#{placeholder}_component_attributes_practice_list",
                 name: "page[page_components_attributes][#{placeholder}][component_attributes][practices][]" do
             Practice.order(name: :asc).each do |p|

--- a/app/views/active_admin/resource/_page_subpage_hyperlink_component_form.html.arb
+++ b/app/views/active_admin/resource/_page_subpage_hyperlink_component_form.html.arb
@@ -14,16 +14,16 @@ html = Arbre::Context.new do
 
         a 'Move to Top', href: '#', class: 'move-to-top float-right', id: component&.page_component&.id
 
-        li class: 'url input required stringish', id: "page_page_components_attributes_#{placeholder}_component_attributes_url_input" do
+        li class: 'url input optional stringish', id: "page_page_components_attributes_#{placeholder}_component_attributes_url_input" do
           label 'Subpage URL suffix', for: "page_page_components_attributes_#{placeholder}_component_attributes_url", class: 'label'
-          input value: component&.url || nil, type: 'text', required: 'required',
+          input value: component&.url || nil, type: 'text',
                 id: "page_page_components_attributes_#{placeholder}_component_attributes_url",
                 name: "page[page_components_attributes][#{placeholder}][component_attributes][url]"
           para 'Enter a brief and descriptive URL suffix to any internal page of the marketplace (Ex: "/innovations/vione", "/partners", "/covid-19/telehealth"', class: 'inline-hints'
         end
 
-        li class: 'string input required stringish', id: "page_page_components_attributes_#{placeholder}_component_attributes_title_input" do
-          input value: component&.title || nil, type: 'text', required: 'required',
+        li class: 'string input optional stringish', id: "page_page_components_attributes_#{placeholder}_component_attributes_title_input" do
+          input value: component&.title || nil, type: 'text',
                 id: "page_page_components_attributes_#{placeholder}_component_attributes_title",
                 name: "page[page_components_attributes][#{placeholder}][component_attributes][title]"
           label 'Subpage title', for: "page_page_components_attributes_#{placeholder}_component_attributes_title"

--- a/app/views/active_admin/resource/_page_triple_paragraph_component_form.html.arb
+++ b/app/views/active_admin/resource/_page_triple_paragraph_component_form.html.arb
@@ -35,7 +35,7 @@ html = Arbre::Context.new do
                 class: 'toggle-has-background-color-styling'
         end
 
-        li class: 'string input optional stringish', id: "page_page_components_attributes_#{placeholder}_component_attributes_title1_input" do
+        li class: 'string input required stringish', id: "page_page_components_attributes_#{placeholder}_component_attributes_title1_input" do
           label 'Title 1', for: "page_page_components_attributes_news_#{placeholder}_component_attributes_title1", class: 'label'
           input value: component&.title1 || nil, type: 'text', required: 'required',
                 id: "page_page_components_attributes_#{placeholder}_component_attributes_title1",
@@ -43,16 +43,16 @@ html = Arbre::Context.new do
           para 'Title for first paragraph styled as an /"H3"', class: 'inline-hints'
         end
 				
-				li class: 'string input optional stringish', id: "page_page_components_attributes_news_#{placeholder}_component_attributes_text1_input" do
+				li class: 'string input required stringish', id: "page_page_components_attributes_news_#{placeholder}_component_attributes_text1_input" do
 					label 'Body 1', for: "page_page_components_attributes_news_#{placeholder}_component_attributes_text1", class: 'label'
 
-					textarea component&.text1, id: "page_page_components_attributes_news_#{placeholder}_component_attributes_text1", name: "page[page_components_attributes][#{placeholder}][component_attributes][text1]", class: 'tinymce', rows: 18 do
+					textarea component&.text1, id: "page_page_components_attributes_news_#{placeholder}_component_attributes_text1", name: "page[page_components_attributes][#{placeholder}][component_attributes][text1]", class: 'tinymce', required: 'required', rows: 18 do
 						component&.send(:text1).try :html_safe
 					end
 					para 'Text body for first paragraph', class: 'inline-hints'
 				end
 
-				li class: 'string input optional stringish', id: "page_page_components_attributes_#{placeholder}_component_attributes_title2_input" do
+				li class: 'string input required stringish', id: "page_page_components_attributes_#{placeholder}_component_attributes_title2_input" do
           label 'Title 2', for: "page_page_components_attributes_news_#{placeholder}_component_attributes_title2", class: 'label'
           input value: component&.title2 || nil, type: 'text', required: 'required',
                 id: "page_page_components_attributes_#{placeholder}_component_attributes_title2",
@@ -60,16 +60,16 @@ html = Arbre::Context.new do
           para 'Title for second paragraph styled as an /"H3"', class: 'inline-hints'
         end
 				
-				li class: 'string input optional stringish', id: "page_page_components_attributes_news_#{placeholder}_component_attributes_text2_input" do
+				li class: 'string input required stringish', id: "page_page_components_attributes_news_#{placeholder}_component_attributes_text2_input" do
 					label 'Body 2', for: "page_page_components_attributes_news_#{placeholder}_component_attributes_text2", class: 'label'
 
-					textarea component&.text2, id: "page_page_components_attributes_news_#{placeholder}_component_attributes_text2", name: "page[page_components_attributes][#{placeholder}][component_attributes][text2]", class: 'tinymce', rows: 18 do
+					textarea component&.text2, id: "page_page_components_attributes_news_#{placeholder}_component_attributes_text2", name: "page[page_components_attributes][#{placeholder}][component_attributes][text2]", class: 'tinymce', required: 'required', rows: 18 do
 						component&.send(:text2).try :html_safe
 					end
 					para 'Text body for second paragraph', class: 'inline-hints'
 				end
 
-				li class: 'string input optional stringish', id: "page_page_components_attributes_#{placeholder}_component_attributes_title3_input" do
+				li class: 'string input required stringish', id: "page_page_components_attributes_#{placeholder}_component_attributes_title3_input" do
           label 'Title 3', for: "page_page_components_attributes_news_#{placeholder}_component_attributes_title3", class: 'label'
           input value: component&.title3 || nil, type: 'text', required: 'required',
                 id: "page_page_components_attributes_#{placeholder}_component_attributes_title3",
@@ -77,10 +77,10 @@ html = Arbre::Context.new do
           para 'Title for third paragraph styled as an /"H3"', class: 'inline-hints'
         end
 				
-				li class: 'string input optional stringish', id: "page_page_components_attributes_news_#{placeholder}_component_attributes_text3_input" do
+				li class: 'string input required stringish', id: "page_page_components_attributes_news_#{placeholder}_component_attributes_text3_input" do
 					label 'Body 3', for: "page_page_components_attributes_news_#{placeholder}_component_attributes_text3", class: 'label'
 
-					textarea component&.text3, id: "page_page_components_attributes_news_#{placeholder}_component_attributes_text3", name: "page[page_components_attributes][#{placeholder}][component_attributes][text3]", class: 'tinymce', rows: 18 do
+					textarea component&.text3, id: "page_page_components_attributes_news_#{placeholder}_component_attributes_text3", name: "page[page_components_attributes][#{placeholder}][component_attributes][text3]", class: 'tinymce', required: 'required', rows: 18 do
 						component&.send(:text3).try :html_safe
 					end
 					para 'Text body for third paragraph', class: 'inline-hints'

--- a/app/views/active_admin/resource/_page_two_to_one_image_component_form.html.arb
+++ b/app/views/active_admin/resource/_page_two_to_one_image_component_form.html.arb
@@ -62,6 +62,7 @@ html = Arbre::Context.new do
         li class: 'select input required text-alignment-container', id: "page_page_components_attributes_#{placeholder}_component_attributes_text_alignment_input" do
           label 'Text alignment', for: "page_page_components_attributes_#{placeholder}_component_attributes_text_alignment", class: 'label'
           select value: component&.text_alignment || nil,
+            required: 'required',
             id: "page_page_components_attributes_#{placeholder}_component_attributes_text_alignment",
             name: "page[page_components_attributes][#{placeholder}][component_attributes][text_alignment]" do
             option 'Left', selected: component&.text_alignment === 'Left' || component&.text_alignment.blank?

--- a/app/views/active_admin/resource/_page_you_tube_player_component_form.html.arb
+++ b/app/views/active_admin/resource/_page_you_tube_player_component_form.html.arb
@@ -14,9 +14,9 @@ html = Arbre::Context.new do
 
         a 'Move to Top', href: '#', class: 'move-to-top float-right', id: component&.page_component&.id
 
-        li class: 'string input required stringish', id: "page_page_components_attributes_#{placeholder}_component_attributes_url_input" do
+        li class: 'string input optional stringish', id: "page_page_components_attributes_#{placeholder}_component_attributes_url_input" do
           label 'YouTube URL', for: "page_page_components_attributes_#{placeholder}_component_attributes_url", class: 'label'
-          input value: component&.url || nil, type: 'url', required: 'required',
+          input value: component&.url || nil, type: 'url',
                 id: "page_page_components_attributes_#{placeholder}_component_attributes_url",
                 name: "page[page_components_attributes][#{placeholder}][component_attributes][url]"
           para 'Enter the full YouTube URL.', class: 'inline-hints'


### PR DESCRIPTION
### JIRA issue link
[DM-4439](https://agile6.atlassian.net/browse/DM-4439)

## Description - what does this code do?
- Adds styling to `required` CSS class so that an asterisk is added automatically
  - Increase label text size so that asterisks are actually legible
- Add an explainer for required fields near the submit button
- Adds `required = required` to fields that were missing it and vice versa, removes `required=required` copy pasta from optional fields

## Testing done - how did you test it/steps on how can another person can test it 
Review the fields documentation in [DM-4439](https://agile6.atlassian.net/browse/DM-4439). Confirm that it matches.
