### PR TITLE
Dm 4317 obscure imagemagick error details

### DIFF
--- a/app/admin/topics.rb
+++ b/app/admin/topics.rb
@@ -95,10 +95,10 @@ ActiveAdmin.register Topic do
     end
 
     def update(_options={}, &block)
-    update! do |success, failure|
-      yield(success, failure) if block
+      update! do |success, failure|
+        yield(success, failure) if block
 
-      resource.errors.messages.each do |k,v|
+        resource.errors.messages.each do |k,v|
           if v.include?("Paperclip::Errors::NotIdentifiedByImageMagickError")
             resource.errors.messages[k] = "There was an issue with uploading your image file."
           end

--- a/app/admin/topics.rb
+++ b/app/admin/topics.rb
@@ -73,4 +73,39 @@ ActiveAdmin.register Topic do
       end
     f.actions
   end
+
+  # The following controller overrides is a brute force way of catching
+  # Paperclip::Errors::NotIdentifiedByImageMagickError's, which were being displayed to the
+  # user when submitting a corrupted image file, that our recent WASA report took issue with.
+  # The intention is to obscure the error while preserving active_admin's built-in error handling
+  # for anything other than a paperclip error.
+  controller do
+    def create(_options={}, &block)
+      create! do |success, failure|
+        yield(success, failure) if block
+
+        resource.errors.messages.each do |k,v|
+          if v.include?("Paperclip::Errors::NotIdentifiedByImageMagickError")
+            resource.errors.messages[k] = "There was an issue with uploading your image file."
+          end
+        end
+
+        failure.html { render :new }
+      end
+    end
+
+    def update(_options={}, &block)
+    update! do |success, failure|
+      yield(success, failure) if block
+
+      resource.errors.messages.each do |k,v|
+          if v.include?("Paperclip::Errors::NotIdentifiedByImageMagickError")
+            resource.errors.messages[k] = "There was an issue with uploading your image file."
+          end
+        end
+
+        failure.html { render :edit }
+      end
+    end
+  end
 end

--- a/app/controllers/practices_controller.rb
+++ b/app/controllers/practices_controller.rb
@@ -1,4 +1,4 @@
-class PracticesController < ApplicationController
+class PracticesController < ApplicationController # rubocop:disable Metrics/ClassLength
   include CropperUtils, PracticesHelper, PracticeEditorUtils, EditorSessionUtils, PracticeEditorSessionsHelper, PracticeUtils, ThreeColumnDataHelper, UsersHelper
   prepend_before_action :skip_timeout, only: [:session_time_remaining]
   before_action :set_practice, only: [:show, :edit, :update, :destroy, :highlight, :un_highlight, :feature,
@@ -169,7 +169,11 @@ class PracticesController < ApplicationController
           flash[:error] = "Your editing session for #{@practice.name} has ended. Your edits have not been saved and you have been returned to the Metrics page."
           format.html { redirect_to practice_metrics_path(@practice) }
         else
-          flash[:error] = "There was an #{@practice.errors.messages}. The innovation was not saved."
+          if @practice.errors.messages.values.flatten.any? {|v| v.include?('Paperclip::Errors'||'ImageMagick')}
+            flash[:error] = "Image processing failed. Please ensure the file is a valid image."
+          else
+            flash[:error] = "There was an #{@practice.errors.messages}. The innovation was not saved."
+          end
           # if the request was sent via the publication modal, redirect the user to the practice's show page
           if is_request_from_publish_modal
             format.html { redirect_to practice_path(@practice) }

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -1,7 +1,12 @@
 class Topic < ApplicationRecord
   has_attached_file :attachment, styles: {thumb: '768x432>'} # TODO: modify thumb size
   validates :title, :description, :url, :cta_text, presence: true
-  validates_attachment_content_type :attachment, content_type: /\Aimage\/.*\z/
+  validates_attachment :attachment,
+                       presence: { message: "can't be blank" },
+                       content_type: {
+                         content_type: %w[image/jpg image/jpeg image/png],
+                         message: "must be one of the following types: jpg, jpeg, or png"
+                       }
   validates_with InternalUrlValidator, on: [:create, :update], if: Proc.new { |topic| topic.url.present? && topic.url.chars.first === '/' }
   validates_with ExternalUrlValidator, on: [:create, :update], if: Proc.new { |topic| topic.url.present? && topic.url.chars.first != '/' }
 

--- a/spec/assets/invalid.jpeg.svg
+++ b/spec/assets/invalid.jpeg.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 96 105">
+  <g fill="#97C024" stroke="#97C024" stroke-linejoin="round" stroke-linecap="round">
+    <path d="M14,40v24M81,40v24M38,68v24M57,68v24M28,42v31h39v-31z" stroke-width="12"/>
+    <path d="M32,5l5,10M64,5l-6,10 " stroke-width="2"/>
+  </g>
+  <path d="M22,35h51v10h-51zM22,33c0-31,51-31,51,0" fill="#97C024"/>
+  <g fill="#FFF">
+    <circle cx="36" cy="22" r="2"/>
+    <circle cx="59" cy="22" r="2"/>
+  </g>
+</svg>

--- a/spec/features/admin/admin_topics_spec.rb
+++ b/spec/features/admin/admin_topics_spec.rb
@@ -8,6 +8,7 @@ describe 'Admin Topics Tab', type: :feature do
     @img_path_1 = "#{Rails.root}/spec/assets/acceptable_img.jpg"
     @img_path_2 = "#{Rails.root}/spec/assets/charmander.png"
     @img_path_3 = "#{Rails.root}/spec/assets/SpongeBob.png"
+    @img_path_4 = "#{Rails.root}/spec/assets/invalid.jpeg.svg"
     Topic.create(title: "Mock topic one", description: "Description for mock topic 1", url: '/diffusion-map', cta_text: "Click here for diffusion map", attachment: File.new(@img_path_1))
     Topic.create(title: "Mock topic two", description: "Description for mock topic 2", url: 'https://www.va.gov', cta_text: "Click here for Veterans Affairs website", attachment: File.new(@img_path_2), featured: true)
     login_as(@admin, scope: :user, run_callbacks: false)
@@ -83,5 +84,15 @@ describe 'Admin Topics Tab', type: :feature do
     expect(page).to have_content('Topic was successfully destroyed.')
     visit '/'
     expect(page).to have_no_content('FEATURED TOPIC')
+  end
+
+  it 'disallows an invalid attachment type and displays error message' do
+    visit '/admin'
+    click_link 'Topics'
+    find_all('.edit_link').first.click
+    fill_in('Title', with: 'Mock updated topic two')
+    find('#topic_attachment').attach_file(@img_path_4)
+    click_button('Update Topic')
+    expect(page).to have_content("must be one of the following types: jpg, jpeg, or png")
   end
 end


### PR DESCRIPTION
### JIRA issue link
https://agile6.atlassian.net/browse/DM-4371

## Description - what does this code do?

Edits controller logic for `practices` and `topics` in order to intercept `Paperclip::Errors::NotIdentifiedByImageMagickError` errors and replace with a generic message that does not implicate specific components of our tech stack as per WASA scan warning (see jira ticket)

## Testing done - how did you test it/steps on how can another person can test it 

Note: if you cannot recreate `ImageMagick` errors locally with a corrupted image file this branch needs to be deployed DEV to test.
1. As admin, edit an existing topic, try and add a corrupted image file, verify the form reloads with error message "There was an issue with uploading your image file under the image input field (screenshot 1).
2. Verify that you can load a non-corrupted file as expected.
3. Try and create a new `Topic` with a corrupted image file, verify the form refreshes with the same error message.
4. Edit an existing practice and attempt to upload a corrupted image file, such as under the `edit/overview` page where an image can be uploaded as a "Problem Attachment", note: you have to click "Add Image" after inputting the file and required text fields before clicking "Save and Update".
5. Verify the form page refreshes with error message "Image processing failed. Please ensure the file is a valid image." at the top (screenshot 2)
6. Verify a non-corrupted image file works.

## Screenshots, Gifs, Videos from application (if applicable)
![Screenshot (23)](https://github.com/department-of-veterans-affairs/diffusion-marketplace/assets/65036872/82abef84-4c72-42c5-93cb-4f9175fc6717)
![Screenshot (22)](https://github.com/department-of-veterans-affairs/diffusion-marketplace/assets/65036872/cca6da04-7671-4e9e-8c58-2f29cd100ce7)

## Link to mock-ups/mock ups (image file if you have it) (if applicable)


## Acceptance criteria
- [ ]

## Definition of done
- [x] Unit tests written (if applicable)
- [x] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating JIRA issue
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs