### PR TITLE
Add confirmation email to batch email

### DIFF
--- a/app/mailers/practice_editor_mailer.rb
+++ b/app/mailers/practice_editor_mailer.rb
@@ -1,6 +1,7 @@
 class PracticeEditorMailer < ApplicationMailer
   default from: ENV['DO_NOT_REPLY_MAILER_SENDER'] || 'do_not_reply@va.gov'
   layout 'mailer'
+  MAILER_RETURN = "marketplace@va.gov"
 
   def invite_to_edit_practice_email(practice, user)
     practice_user_editor_text = "You have been added to the list of practice editors for the #{practice.name} Diffusion Marketplace Page!"
@@ -32,6 +33,7 @@ class PracticeEditorMailer < ApplicationMailer
     @filters = mailer_args[:filters]
     @practice_names = mailer_args[:practice_names]
     subject = (@practice_names.empty? ? "Failure: Diffusion Marketplace Innovation Batch Emails Not Sent" : "Confirmation: Diffusion Marketplace Innovation Batch Emails Sent")
-    mail(to: mailer_args[:sender_email_address], subject: subject)
+    recipients = [mailer_args[:sender_email_address], MAILER_RETURN]
+    mail(to: recipients, subject: subject)
   end
 end

--- a/app/mailers/practice_editor_mailer.rb
+++ b/app/mailers/practice_editor_mailer.rb
@@ -25,4 +25,13 @@ class PracticeEditorMailer < ApplicationMailer
 
     mail(to: user_info[:email], subject: @subject)
   end
+
+  def send_batch_email_confirmation(mailer_args)
+    @message_subject = mailer_args[:subject]
+    @message = mailer_args[:message]
+    @filters = mailer_args[:filters]
+    @practice_names = mailer_args[:practice_names]
+    subject = (@practice_names.empty? ? "Failure: Diffusion Marketplace Innovation Batch Emails Not Sent" : "Confirmation: Diffusion Marketplace Innovation Batch Emails Sent")
+    mail(to: mailer_args[:sender_email_address], subject: subject)
+  end
 end

--- a/app/services/practice_mailer_service.rb
+++ b/app/services/practice_mailer_service.rb
@@ -16,7 +16,7 @@ class PracticeMailerService
     user_practices_data = collect_users_and_their_practices_info
     send_emails(user_practices_data)
     update_last_email_date_for_practices
-    send_confirmation_email
+    send_confirmation_emails
   end
 
   private
@@ -62,7 +62,7 @@ class PracticeMailerService
     Practice.where(id: practice_ids_to_update.to_a).update_all(last_email_date: Time.current)
   end
 
-  def send_confirmation_email
+  def send_confirmation_emails
     confirm_email_args = {
       sender_email_address: current_user.email,
       subject: subject,

--- a/app/views/practice_editor_mailer/send_batch_email_confirmation.html.erb
+++ b/app/views/practice_editor_mailer/send_batch_email_confirmation.html.erb
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta content='text/html; charset=UTF-8' http-equiv='Content-Type' />
+  </head>
+  <body>
+    <h3>The following message has been sent to the editors and owners of <%= @filters.empty? ? "all" : "selected" %> Innovations via the Diffusion Marketplace's batch emailer admin tool:</h3>
+    <p>Hello Innovation Editor, </p>
+    <p>
+      <%= @message.html_safe %>
+    </p>
+    <p>Visit your Innovation(s) at the following link(s) and click "Edit" to begin editing. Please note that only one person can edit the innovation at a time.</p>
+    <ul>
+          <li><a href="#">Sample Innovation Link</a></li>
+        </ul>
+    <p>
+      If you have any questions, issues, or feedback to share with us please send an email to <%= mail_to 'Marketplace@VA.gov ', 'Marketplace@VA.gov ' %>
+    </p>
+
+    <% if @practice_names.empty? %>
+      <h3>You attempted to send the above message to filtered Innovation owners and editors but the applied filters returned no Innovation results.</h3>
+    <% else %>
+      <h3>The above message has been sent to the editors and owners of <%= @filters.empty? ? "all published Innovations." : "the following Innovations:" %> </h3>
+    <% end %>
+    <% unless @filters.empty? %>
+      <ul>
+        <% @practice_names.each do |practice| %>
+          <li>
+            <%= practice %>
+          </li>
+        <% end %>
+      </ul>
+
+      <h3>The following @filters were applied to scope the message recipients:</h3>
+      <ul>
+        <% @filters.each do |k, v| %>
+          <li>
+            <% unless v.empty? %>
+              <%= k.to_s + ": " + v %>
+            <% end %>
+          </li>
+        <% end %>
+      </ul>
+    <% end %>
+  </body>
+  <footer>
+    <%= image_tag('dm-footer-logo.png', alt: "Diffusion Marketplace Logo", host: "https://marketplace.va.gov") %>
+  </footer>
+</html>

--- a/spec/features/admin/email_selected_practices_editors_spec.rb
+++ b/spec/features/admin/email_selected_practices_editors_spec.rb
@@ -2,11 +2,12 @@ require 'rails_helper'
 
 describe 'Admin email all editors button', type: :feature do
   let(:admin) { create(:user, :admin) }
-  let!(:users) { create_list(:user, 3) }
+  let(:user) { create(:user) }
+  let!(:editors) { create_list(:user, 3) }
   let!(:recently_updated_practice) do
     create(
       :practice,
-      user: admin,
+      user: user,
       published: true,
       updated_at: 1.day.ago,
       last_email_date: 2.days.ago
@@ -16,7 +17,7 @@ describe 'Admin email all editors button', type: :feature do
   let!(:older_practice) do
     create(
       :practice,
-      user: admin,
+      user: user,
       published: true,
       updated_at: 10.days.ago,
       last_email_date: 11.days.ago
@@ -26,7 +27,7 @@ describe 'Admin email all editors button', type: :feature do
   let!(:unemailed_practice) do
     create(
       :practice,
-      user: admin,
+      user: user,
       published: true,
       updated_at: 5.days.ago,
       last_email_date: nil
@@ -36,7 +37,7 @@ describe 'Admin email all editors button', type: :feature do
   let!(:unpublished_practice) do
     create(
       :practice,
-      user: admin,
+      user: user,
       published: false,
       updated_at: 3.days.ago,
       last_email_date: 4.days.ago
@@ -49,24 +50,22 @@ describe 'Admin email all editors button', type: :feature do
     visit admin_practices_path
 
     [recently_updated_practice, older_practice, unemailed_practice].each do |practice|
-      create(:practice_editor, user: users.first, practice: practice)
+      create(:practice_editor, user: editors.first, practice: practice)
     end
 
     page.driver.browser.manage.window.resize_to(1920, 1080)
   end
 
   it 'sends an email to all editors of unfiltered and published practices' do
-    create(:practice_editor, user: users.second, practice: recently_updated_practice)
-    2.times do
-      create(:practice_editor, user: admin, practice: recently_updated_practice)
-    end
+    create(:practice_editor, user: editors.second, practice: recently_updated_practice)
+    create(:practice_editor, user: user, practice: recently_updated_practice)
 
     filter_practices_and_send_email
 
     emails = ActionMailer::Base.deliveries
-    expect(emails.count).to eq 3
+    expect(emails.count).to eq 4
 
-    email = emails.find { |e| e.to.include?(users.first.email) }
+    email = emails.find { |e| e.to.include?(editors.first.email) }
     expect(email.subject).to eq 'Important Update'
 
     expect(email.body.encoded).to include older_practice.name
@@ -74,7 +73,7 @@ describe 'Admin email all editors button', type: :feature do
     expect(email.body.encoded).to include recently_updated_practice.name
     expect(email.body.encoded).not_to include unpublished_practice.name
 
-    email2 = emails.find { |e| e.to.include?(users.second.email) }
+    email2 = emails.find { |e| e.to.include?(editors.second.email) }
     expect(email2.subject).to eq 'Important Update'
 
     expect(email2.body.encoded).to include recently_updated_practice.name
@@ -82,23 +81,31 @@ describe 'Admin email all editors button', type: :feature do
     expect(email2.body.encoded).not_to include unemailed_practice.name
     expect(email2.body.encoded).not_to include unpublished_practice.name
 
+    user_email = emails.find { |e| e.to.include?(user.email) }
+    expect(user_email.subject).to eq 'Important Update'
+
+    expect(user_email.body.encoded).to include older_practice.name
+    expect(user_email.body.encoded).to include unemailed_practice.name
+    expect(user_email.body.encoded).to include recently_updated_practice.name
+    expect(user_email.body.encoded).not_to include unpublished_practice.name
+
+    expect(user_email.body.encoded.scan(recently_updated_practice.name).length).to eq(1)
+
     admin_email = emails.find { |e| e.to.include?(admin.email) }
-    expect(admin_email.subject).to eq 'Important Update'
-
-    expect(admin_email.body.encoded).to include older_practice.name
-    expect(admin_email.body.encoded).to include unemailed_practice.name
-    expect(admin_email.body.encoded).to include recently_updated_practice.name
+    expect(admin_email.subject).to eq('Confirmation: Diffusion Marketplace Innovation Batch Emails Sent')
+    expect(admin_email.body.encoded).not_to include older_practice.name
+    expect(admin_email.body.encoded).not_to include unemailed_practice.name
+    expect(admin_email.body.encoded).not_to include recently_updated_practice.name
     expect(admin_email.body.encoded).not_to include unpublished_practice.name
-
-    expect(admin_email.body.encoded.scan(recently_updated_practice.name).length).to eq(1)
+    expect(admin_email.body.encoded).to include("The above message has been sent to the editors and owners of all published Innovations")
   end
 
   it 'sends an email to all editors of practices filtered by "Not Updated Since"' do
     filter_practices_and_send_email('practice_batch_email[not_updated_since]', 7.days.ago)
     emails = ActionMailer::Base.deliveries
-    expect(emails.count).to eq 2
+    expect(emails.count).to eq 3
 
-    email = emails.find { |e| e.to.include?(users.first.email) }
+    email = emails.find { |e| e.to.include?(editors.first.email) }
     expect(email.subject).to eq 'Important Update'
 
     expect(email.body.encoded).to include older_practice.name
@@ -106,20 +113,29 @@ describe 'Admin email all editors button', type: :feature do
     expect(email.body.encoded).not_to include recently_updated_practice.name
     expect(email.body.encoded).not_to include unpublished_practice.name
 
+    user_email = emails.find { |e| e.to.include?(user.email) }
+    expect(user_email.body.encoded).to include older_practice.name
+    expect(user_email.body.encoded).not_to include unemailed_practice.name
+    expect(user_email.body.encoded).not_to include recently_updated_practice.name
+    expect(user_email.body.encoded).not_to include unpublished_practice.name
+
     admin_email = emails.find { |e| e.to.include?(admin.email) }
+    expect(admin_email.subject).to eq('Confirmation: Diffusion Marketplace Innovation Batch Emails Sent')
+    expect(admin_email.body.encoded).to include("The above message has been sent to the editors and owners of the following Innovations:")
     expect(admin_email.body.encoded).to include older_practice.name
     expect(admin_email.body.encoded).not_to include unemailed_practice.name
     expect(admin_email.body.encoded).not_to include recently_updated_practice.name
     expect(admin_email.body.encoded).not_to include unpublished_practice.name
+    expect(admin_email.body.encoded).to include("not_updated_since: #{7.days.ago.to_date}")
   end
 
   it 'sends an email to all editors of practices filtered by "Not Emailed Since"' do
     filter_practices_and_send_email('practice_batch_email[not_emailed_since]', 12.days.ago)
 
     emails = ActionMailer::Base.deliveries
-    expect(emails.count).to eq 2
+    expect(emails.count).to eq 3
 
-    email = emails.find { |e| e.to.include?(users.first.email) }
+    email = emails.find { |e| e.to.include?(editors.first.email) }
     expect(email.subject).to eq 'Important Update'
 
     expect(email.body.encoded).to include unemailed_practice.name
@@ -127,11 +143,20 @@ describe 'Admin email all editors button', type: :feature do
     expect(email.body.encoded).not_to include recently_updated_practice.name
     expect(email.body.encoded).not_to include unpublished_practice.name
 
+    user_email = emails.find { |e| e.to.include?(user.email) }
+    expect(user_email.body.encoded).to include unemailed_practice.name
+    expect(user_email.body.encoded).not_to include older_practice.name
+    expect(user_email.body.encoded).not_to include recently_updated_practice.name
+    expect(user_email.body.encoded).not_to include unpublished_practice.name
+
     admin_email = emails.find { |e| e.to.include?(admin.email) }
+    expect(admin_email.subject).to eq('Confirmation: Diffusion Marketplace Innovation Batch Emails Sent')
+    expect(admin_email.body.encoded).to include("The above message has been sent to the editors and owners of the following Innovations:")
     expect(admin_email.body.encoded).to include unemailed_practice.name
     expect(admin_email.body.encoded).not_to include older_practice.name
     expect(admin_email.body.encoded).not_to include recently_updated_practice.name
     expect(admin_email.body.encoded).not_to include unpublished_practice.name
+    expect(admin_email.body.encoded).to include("not_emailed_since: #{12.days.ago.to_date}")
   end
 
   def filter_practices_and_send_email(filter=nil, value=nil)

--- a/spec/services/practice_mailer_service_spec.rb
+++ b/spec/services/practice_mailer_service_spec.rb
@@ -4,19 +4,20 @@ RSpec.describe PracticeMailerService do
   describe '.call' do
     let!(:admin) { create(:user, :admin) }
     let!(:user) { create(:user) }
-    let!(:other_user) { create(:user) }
+    let!(:user2) { create(:user) }
+    let!(:user3) { create(:user) }
     let(:subject_text) { 'Important Update' }
     let(:message_text) { 'Please review the latest changes.' }
 
-    let!(:practice) { create(:practice, user: admin, published: true) }
+    let!(:practice) { create(:practice, user: user3, published: true) }
     let!(:practice_a) { create(:practice, name: "Innovation A", user: user, published: true, updated_at: 2.days.ago, last_email_date: 3.days.ago) }
-    let!(:practice_b) { create(:practice, name: "Innovation B", user: other_user, published: true, updated_at: 4.days.ago, last_email_date: nil) }
+    let!(:practice_b) { create(:practice, name: "Innovation B", user: user2, published: true, updated_at: 4.days.ago, last_email_date: nil) }
     let!(:unpublished_practice) { create(:practice, name: "Innovation C", user: user, published: false, updated_at: 1.day.ago) }
 
     before do
-      create(:practice_editor, user: other_user, practice: practice_a)
+      create(:practice_editor, user: user2, practice: practice_a)
       create(:practice_editor, user: user, practice: practice_b)
-      create(:practice_editor, user: admin, practice: unpublished_practice)
+      create(:practice_editor, user: user3, practice: unpublished_practice)
 
       ActionMailer::Base.deliveries.clear
     end
@@ -31,7 +32,7 @@ RSpec.describe PracticeMailerService do
         filters: filters
       )
       emails = ActionMailer::Base.deliveries
-      expect(emails.count).to eq(3)
+      expect(emails.count).to eq(4)
 
       user_email = emails.find { |e| e.to.include?(user.email) }
       expect(user_email.subject).to eq(subject_text)
@@ -42,22 +43,29 @@ RSpec.describe PracticeMailerService do
       expect(user_email.body.encoded).to include(Rails.application.routes.url_helpers.practice_url(practice_a, Rails.application.config.action_mailer.default_url_options))
       expect(user_email.body.encoded).to include(Rails.application.routes.url_helpers.practice_url(practice_b, Rails.application.config.action_mailer.default_url_options))
 
-      other_user_email = emails.find { |e| e.to.include?(other_user.email) }
-      expect(other_user_email.subject).to eq(subject_text)
-      expect(other_user_email.to).to include(other_user.email)
-      expect(other_user_email.body.encoded).to include(practice_a.name)
-      expect(other_user_email.body.encoded).to include(practice_b.name)
-      expect(other_user_email.body.encoded).not_to include(practice.name)
-      expect(other_user_email.body.encoded).to include(Rails.application.routes.url_helpers.practice_url(practice_a, Rails.application.config.action_mailer.default_url_options))
-      expect(other_user_email.body.encoded).to include(Rails.application.routes.url_helpers.practice_url(practice_b, Rails.application.config.action_mailer.default_url_options))
+      user2_email = emails.find { |e| e.to.include?(user2.email) }
+      expect(user2_email.subject).to eq(subject_text)
+      expect(user2_email.to).to include(user2.email)
+      expect(user2_email.body.encoded).to include(practice_a.name)
+      expect(user2_email.body.encoded).to include(practice_b.name)
+      expect(user2_email.body.encoded).not_to include(practice.name)
+      expect(user2_email.body.encoded).to include(Rails.application.routes.url_helpers.practice_url(practice_a, Rails.application.config.action_mailer.default_url_options))
+      expect(user2_email.body.encoded).to include(Rails.application.routes.url_helpers.practice_url(practice_b, Rails.application.config.action_mailer.default_url_options))
+
+      user3_email = emails.find { |e| e.to.include?(user3.email) }
+      expect(user3_email.subject).to eq(subject_text)
+      expect(user3_email.to).to include(user3.email)
+      expect(user3_email.body.encoded).to include(practice.name)
+      expect(user3_email.body.encoded).not_to include(practice_a.name)
+      expect(user3_email.body.encoded).not_to include(practice_b.name)
+      expect(user3_email.body.encoded).to include(Rails.application.routes.url_helpers.practice_url(practice, Rails.application.config.action_mailer.default_url_options))
 
       admin_email = emails.find { |e| e.to.include?(admin.email) }
-      expect(admin_email.subject).to eq(subject_text)
-      expect(admin_email.to).to include(admin.email)
-      expect(admin_email.body.encoded).to include(practice.name)
+      expect(admin_email.subject).to eq('Confirmation: Diffusion Marketplace Innovation Batch Emails Sent')
+      expect(admin_email.body.encoded).not_to include(practice.name)
       expect(admin_email.body.encoded).not_to include(practice_a.name)
       expect(admin_email.body.encoded).not_to include(practice_b.name)
-      expect(admin_email.body.encoded).to include(Rails.application.routes.url_helpers.practice_url(practice, Rails.application.config.action_mailer.default_url_options))
+      expect(admin_email.body.encoded).to include("The above message has been sent to the editors and owners of all published Innovations")
     end
 
     context 'when applying specific scope filters' do
@@ -72,7 +80,7 @@ RSpec.describe PracticeMailerService do
         )
 
         emails = ActionMailer::Base.deliveries
-        expect(emails.count).to eq(2)
+        expect(emails.count).to eq(3)
 
         user_email = emails.find { |e| e.to.include?(user.email) }
         expect(user_email.subject).to eq(subject_text)
@@ -83,14 +91,22 @@ RSpec.describe PracticeMailerService do
         expect(user_email.body.encoded).not_to include(Rails.application.routes.url_helpers.practice_url(practice_a, Rails.application.config.action_mailer.default_url_options))
         expect(user_email.body.encoded).to include(Rails.application.routes.url_helpers.practice_url(practice_b, Rails.application.config.action_mailer.default_url_options))
 
-        other_user_email = emails.find { |e| e.to.include?(other_user.email) }
-        expect(other_user_email.subject).to eq(subject_text)
-        expect(other_user_email.to).to include(other_user.email)
-        expect(other_user_email.body.encoded).not_to include(practice_a.name)
-        expect(other_user_email.body.encoded).to include(practice_b.name)
-        expect(other_user_email.body.encoded).not_to include(practice.name)
-        expect(other_user_email.body.encoded).not_to include(Rails.application.routes.url_helpers.practice_url(practice_a, Rails.application.config.action_mailer.default_url_options))
-        expect(other_user_email.body.encoded).to include(Rails.application.routes.url_helpers.practice_url(practice_b, Rails.application.config.action_mailer.default_url_options))
+        user2_email = emails.find { |e| e.to.include?(user2.email) }
+        expect(user2_email.subject).to eq(subject_text)
+        expect(user2_email.to).to include(user2.email)
+        expect(user2_email.body.encoded).not_to include(practice_a.name)
+        expect(user2_email.body.encoded).to include(practice_b.name)
+        expect(user2_email.body.encoded).not_to include(practice.name)
+        expect(user2_email.body.encoded).not_to include(Rails.application.routes.url_helpers.practice_url(practice_a, Rails.application.config.action_mailer.default_url_options))
+        expect(user2_email.body.encoded).to include(Rails.application.routes.url_helpers.practice_url(practice_b, Rails.application.config.action_mailer.default_url_options))
+
+        admin_email = emails.find { |e| e.to.include?(admin.email) }
+        expect(admin_email.subject).to eq('Confirmation: Diffusion Marketplace Innovation Batch Emails Sent')
+        expect(admin_email.body.encoded).to include("The above message has been sent to the editors and owners of the following Innovations:")
+        expect(admin_email.body.encoded).to include(practice_b.name)
+        expect(admin_email.body.encoded).not_to include(practice.name)
+        expect(admin_email.body.encoded).not_to include(practice_a.name)
+        expect(admin_email.body.encoded).to include("not_updated_since: #{3.days.ago.to_date}")
       end
     end
 
@@ -103,7 +119,15 @@ RSpec.describe PracticeMailerService do
           current_user: admin,
           filters: filters
         )
-        expect(ActionMailer::Base.deliveries.count).to eq(0)
+        emails = ActionMailer::Base.deliveries
+        expect(emails.count).to eq(1)
+        admin_email = emails.find { |e| e.to.include?(admin.email) }
+        expect(admin_email.subject).to eq('Failure: Diffusion Marketplace Innovation Batch Emails Not Sent')
+        expect(admin_email.body.encoded).to include("You attempted to send the above message to filtered Innovation owners and editors but the applied filters returned no Innovation results.")
+        expect(admin_email.body.encoded).not_to include(practice_b.name)
+        expect(admin_email.body.encoded).not_to include(practice.name)
+        expect(admin_email.body.encoded).not_to include(practice_a.name)
+        expect(admin_email.body.encoded).to include("not_updated_since: #{5.days.ago.to_date}")
       end
     end
   end

--- a/spec/services/practice_mailer_service_spec.rb
+++ b/spec/services/practice_mailer_service_spec.rb
@@ -66,6 +66,13 @@ RSpec.describe PracticeMailerService do
       expect(admin_email.body.encoded).not_to include(practice_a.name)
       expect(admin_email.body.encoded).not_to include(practice_b.name)
       expect(admin_email.body.encoded).to include("The above message has been sent to the editors and owners of all published Innovations")
+
+      super_admin_email = emails.find { |e| e.to.include?("marketplace@va.gov") }
+      expect(super_admin_email.subject).to eq('Confirmation: Diffusion Marketplace Innovation Batch Emails Sent')
+      expect(super_admin_email.body.encoded).not_to include(practice.name)
+      expect(super_admin_email.body.encoded).not_to include(practice_a.name)
+      expect(super_admin_email.body.encoded).not_to include(practice_b.name)
+      expect(super_admin_email.body.encoded).to include("The above message has been sent to the editors and owners of all published Innovations")
     end
 
     context 'when applying specific scope filters' do


### PR DESCRIPTION
### JIRA issue link


## Description - what does this code do?
Adds a step to the [Innovation batch email feature](https://github.com/department-of-veterans-affairs/diffusion-marketplace/pull/789) to send confirmation email containing batch email recipients, subject / message, and applied scope filters to the admin user that utilized.

## Testing done - how did you test it/steps on how can another person can test it 
same as qa steps for the [most recent pr](https://github.com/department-of-veterans-affairs/diffusion-marketplace/pull/789) for this feature, but verify a confirmation email is sent to the email for the admin account used to send the batch emails:

1. Send a batch email with no filters and verify that a confirmation email is sent to the admin user's email indicating the message has been sent, the confirmation email should contain the original message and subject and indicate that it was sent to the owners and editors of all published innovations (1st screenshot)
2. Repeat but utilize the filters in the email form to scope the innovations, confirm the same as step 1 but verify the confirmation message indicates filters were applied and all the names of innovations included in the emails to editors and users are listed (with no repeats) in the confirmation (screenshot 2).
3. Repeat but utilize the filters in a way that no Innovations will be returned in the scope, verify that a confirmation email is sent and indicates this along with the filters utilized (screenshot 3)

## Screenshots, Gifs, Videos from application (if applicable)
<img width="1577" alt="Screenshot 2024-02-27 at 2 49 00 PM" src="https://github.com/department-of-veterans-affairs/diffusion-marketplace/assets/65036872/49b3601f-8818-4bbc-9202-5ca6067096ef">

<img width="801" alt="Screenshot 2024-02-27 at 2 54 32 PM" src="https://github.com/department-of-veterans-affairs/diffusion-marketplace/assets/65036872/888dc24f-e79a-41e3-8e30-840c1b8cb006">


<img width="1567" alt="Screenshot 2024-02-27 at 2 51 53 PM" src="https://github.com/department-of-veterans-affairs/diffusion-marketplace/assets/65036872/1335238a-5083-4bf8-8ea1-a6bb37c3b948">

## Link to mock-ups/mock ups (image file if you have it) (if applicable)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Unit tests written (if applicable)
- [ ] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating JIRA issue
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs