### PR TITLE
update innovation batch email template

### DIFF
--- a/app/views/admin/practices/_email_preview_modal.html.erb
+++ b/app/views/admin/practices/_email_preview_modal.html.erb
@@ -15,6 +15,7 @@
         <p>
           If you have any questions, issues, or feedback to share with us please send an email to <%= mail_to 'Marketplace@VA.gov ', 'Marketplace@VA.gov ' %>
         </p>
+        <p>Thank you for being a valued member of our Diffusion of Excellence community.</p>
         <div class="usa-modal-footer">
           <%= image_tag('dm-footer-logo.png', alt: "Footer Logo") %>
           <button class="usa-button" data-close-modal>Cancel</button>

--- a/app/views/practice_editor_mailer/send_batch_email_confirmation.html.erb
+++ b/app/views/practice_editor_mailer/send_batch_email_confirmation.html.erb
@@ -16,7 +16,7 @@
     <p>
       If you have any questions, issues, or feedback to share with us please send an email to <%= mail_to 'Marketplace@VA.gov ', 'Marketplace@VA.gov ' %>
     </p>
-
+    <p>Thank you for being a valued member of our Diffusion of Excellence community.</p>
     <% if @practice_names.empty? %>
       <h3>You attempted to send the above message to filtered Innovation owners and editors but the applied filters returned no Innovation results.</h3>
     <% else %>

--- a/app/views/practice_editor_mailer/send_batch_email_confirmation.html.erb
+++ b/app/views/practice_editor_mailer/send_batch_email_confirmation.html.erb
@@ -17,33 +17,34 @@
       If you have any questions, issues, or feedback to share with us please send an email to <%= mail_to 'Marketplace@VA.gov ', 'Marketplace@VA.gov ' %>
     </p>
     <p>Thank you for being a valued member of our Diffusion of Excellence community.</p>
-    <% if @practice_names.empty? %>
-      <h3>You attempted to send the above message to filtered Innovation owners and editors but the applied filters returned no Innovation results.</h3>
-    <% else %>
-      <h3>The above message has been sent to the editors and owners of <%= @filters.empty? ? "all published Innovations." : "the following Innovations:" %> </h3>
-    <% end %>
-    <% unless @filters.empty? %>
-      <ul>
-        <% @practice_names.each do |practice| %>
-          <li>
-            <%= practice %>
-          </li>
-        <% end %>
-      </ul>
-
-      <h3>The following @filters were applied to scope the message recipients:</h3>
-      <ul>
-        <% @filters.each do |k, v| %>
-          <li>
-            <% unless v.empty? %>
-              <%= k.to_s + ": " + v %>
-            <% end %>
-          </li>
-        <% end %>
-      </ul>
-    <% end %>
   </body>
   <footer>
     <%= image_tag('dm-footer-logo.png', alt: "Diffusion Marketplace Logo", host: "https://marketplace.va.gov") %>
   </footer>
+
+  <% if @practice_names.empty? %>
+    <h3>You attempted to send the above message to filtered Innovation owners and editors but the applied filters returned no Innovation results.</h3>
+  <% else %>
+    <h3>The above message has been sent to the editors and owners of <%= @filters.empty? ? "all published Innovations." : "the following Innovations:" %> </h3>
+  <% end %>
+  <% unless @filters.empty? %>
+    <ul>
+      <% @practice_names.each do |practice| %>
+        <li>
+          <%= practice %>
+        </li>
+      <% end %>
+    </ul>
+
+    <h3>The following filters were applied to scope the message recipients:</h3>
+    <ul>
+      <% @filters.each do |k, v| %>
+        <% unless v.empty? %>
+          <li>
+              <%= k.to_s + ": " + v %>
+          </li>
+        <% end %>
+      <% end %>
+    </ul>
+  <% end %>
 </html>

--- a/app/views/practice_editor_mailer/send_batch_email_to_editor.html.erb
+++ b/app/views/practice_editor_mailer/send_batch_email_to_editor.html.erb
@@ -19,6 +19,7 @@
     <p>
       If you have any questions, issues, or feedback to share with us please send an email to <%= mail_to 'Marketplace@VA.gov ', 'Marketplace@VA.gov ' %>
     </p>
+    <p>Thank you for being a valued member of our Diffusion of Excellence community.</p>
   </body>
   <footer>
     <%= image_tag('dm-footer-logo.png', alt: "Diffusion Marketplace Logo", host: "https://marketplace.va.gov") %>


### PR DESCRIPTION
adds language to the bottom of the template body

### JIRA issue link


## Description - what does this code do?
* Adds language to the bottom of Innovation batch email template
* moves confirmation email specific language, the filters applied and Innovation recipient list, to bottom of template

## Testing done - how did you test it/steps on how can another person can test it 
1. As admin utilize the batch email feature from `admin/practices`
2. Verify the preview modal, the batch emails, and the confirmation emails all contain the new language at the bottom above the footer


## Screenshots, Gifs, Videos from application (if applicable)

Innovation editor email:
![Screenshot 2024-03-04 at 10 38 21 AM](https://github.com/department-of-veterans-affairs/diffusion-marketplace/assets/65036872/cdaad7af-fad0-4122-9adb-adfdeaa9609a)

Admin confirmation email:
![Screenshot 2024-03-04 at 11 02 52 AM](https://github.com/department-of-veterans-affairs/diffusion-marketplace/assets/65036872/fe0ea73e-b4c7-4436-9d63-97831d0afcde)

## Link to mock-ups/mock ups (image file if you have it) (if applicable)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Unit tests written (if applicable)
- [ ] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating JIRA issue
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs