### PR TITLE
Update Shark Tank banner for 2024

### DIFF
--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -2,7 +2,7 @@
   <%= render partial: "shared/messages", locals: {small_text: false} %>
   <div class="font-sans-2xs shark-tank-banner display-flex flex-align-center">
     <div class="padding-x-2 desktop:padding-x-7">
-      <span>Learn more about the <a href="/competitions/shark-tank" class="text-bold dm-alt-link-dark">2023 VHA Shark Tank competition</a></span>
+      <span>Learn more about the <a href="/competitions/shark-tank" class="text-bold dm-alt-link-dark">2024 VHA Shark Tank competition</a></span>
     </div>
   </div>
   <!-- "Welcome" section -->


### PR DESCRIPTION
### JIRA issue link
DM-4478

## Description - what does this code do?
- Updates the homepage banner text for the 2024 Shark Tank competition

## Screenshots, Gifs, Videos from application (if applicable)
<img width="1172" alt="Screenshot 2024-03-04 at 10 34 33 AM" src="https://github.com/department-of-veterans-affairs/diffusion-marketplace/assets/5402927/661abfe4-8b39-4fa3-8da3-9b5ceb75984f">
