### PR TITLE
DM-4479: Reorder innovation editor navbar & update edit innovation button

### DIFF
--- a/app/views/practices/form/editors.html.erb
+++ b/app/views/practices/form/editors.html.erb
@@ -1,6 +1,7 @@
 <% provide :main_classes, 'bg-gray-0' %>
 <% provide :footer_classes, 'bg-gray-0' %>
 <% provide :head_tags do %>
+  <%= javascript_include_tag '_practice_editor_header', 'data-turbolinks-track': 'reload' %>
   <%= javascript_tag 'data-turbolinks-track': 'reload' do %>
     <%= render partial: 'editors', formats: [:js] %>
     <%= render partial: 'practices/form/session_monitor', formats: [:js] %>

--- a/app/views/practices/shared/_practice_editor_header.html.erb
+++ b/app/views/practices/shared/_practice_editor_header.html.erb
@@ -42,13 +42,13 @@
       <div class="grid-col-6">
         <ul class="usa-nav__primary usa-accordion">
           <li class="usa-nav__primary-item">
-            <%= link_to 'Metrics', practice_metrics_path(@practice), class: "margin-right-3 margin-y-2px desktop-lg:margin-y-0 usa-nav__link #{'usa-current' if params[:action] === 'metrics' }" %>
+            <%= link_to 'Edit your innovation', practice_editors_path(@practice), class: "margin-right-3 margin-y-2px desktop-lg:margin-y-0 usa-nav__link #{'usa-current' if NavigationHelper::PRACTICE_EDITOR_PAGES.include?(params[:action]) }" %>
           </li>
           <li class="usa-nav__primary-item">
             <a href="#dm-editing-guide-modal" class="margin-right-3 margin-y-2px desktop-lg:margin-y-0 usa-nav__link" aria-controls="dm-editing-guide-modal" data-open-modal>Editing guide</a>
           </li>
           <li class="usa-nav__primary-item">
-            <%= link_to 'Edit your innovation', practice_editors_path(@practice), class: "margin-right-3 margin-y-2px desktop-lg:margin-y-0 usa-nav__link #{'usa-current' if NavigationHelper::PRACTICE_EDITOR_PAGES.include?(params[:action]) }" %>
+            <%= link_to 'Metrics', practice_metrics_path(@practice), class: "margin-right-3 margin-y-2px desktop-lg:margin-y-0 usa-nav__link #{'usa-current' if params[:action] === 'metrics' }" %>
           </li>
         </ul>
       </div>

--- a/app/views/practices/show/show.html.erb
+++ b/app/views/practices/show/show.html.erb
@@ -44,7 +44,6 @@
       main_email = @practice.support_network_email
       practice_emails = @practice.practice_emails
       cc_emails = practice_emails.map(&:address).join(', ')
-      metrics_path = practice_metrics_path(@practice)
     %>
     <div class="text-center margin-bottom-1">
       <%= mail_to main_email, 'Email innovation', subject: "Question about #{@practice.name}", cc: cc_emails, class: 'usa-button  width-full display-flex flex-align-center flex-justify-center
@@ -52,7 +51,7 @@
     </div>
     <% if (current_user.present?) && (@practice.user_id == current_user.id || current_user.roles.any? || is_user_an_editor_for_practice(@practice, current_user)) %>
       <div class="text-center">
-        <%= link_to practice_metrics_path(@practice), id: 'edit-link-in-nav', class: 'usa-button usa-button--secondary width-full' do %>
+        <%= link_to practice_editors_path(@practice), id: 'edit-link-in-nav', class: 'usa-button usa-button--secondary width-full' do %>
           <i class="fas fa-edit margin-right-1"></i>Edit innovation
         <% end %>
       </div>
@@ -63,7 +62,7 @@
 <div class="practice-mobile-nav padding-1 z-top desktop:display-none display-flex flex-justify-center">
   <%= mail_to main_email, 'Email', cc: cc_emails, id: 'email-link-in-mobile-nav', class: 'width-full usa-button  display-flex flex-align-center flex-justify-center margin-right-2', 'aria-label': "Mobile nav email #{main_email}"  %>
   <% if (current_user.present?) && (@practice.user_id == current_user.id || current_user.roles.any?) %>
-    <%= link_to 'Edit', practice_metrics_path(@practice), id: 'edit-link-in-mobile-nav', class: 'width-full usa-button usa-button--secondary margin-right-0' %>
+    <%= link_to 'Edit', practice_editors_path(@practice), id: 'edit-link-in-mobile-nav', class: 'width-full usa-button usa-button--secondary margin-right-0' %>
   <% end %>
 </div>
 

--- a/spec/features/practice_editor/authorization_spec.rb
+++ b/spec/features/practice_editor/authorization_spec.rb
@@ -26,7 +26,7 @@ describe 'Practice editor', type: :feature, js: true do
             @user_practice.update(approved: true, published: true)
             visit practice_path(@user_practice)
             expect(page).to be_accessible.according_to :wcag2a, :section508
-            expect(page).to have_link(href: "/innovations/#{@user_practice.slug}/edit/metrics")
+            expect(page).to have_link(href: "/innovations/#{@user_practice.slug}/edit/editors")
         end
 
         it 'should allow practice editors to edit a practice they\'re associated with' do

--- a/spec/features/practice_editor/header_and_footer_spec.rb
+++ b/spec/features/practice_editor/header_and_footer_spec.rb
@@ -27,7 +27,7 @@ describe 'Practice editor', type: :feature, js: true do
 
       it 'should display the correct header and footer on each page' do
         click_on('Edit innovation')
-        expect(page).to have_current_path(practice_metrics_path(@published_pr))
+        expect(page).to have_current_path(practice_editors_path(@published_pr))
         editor_header = "#dm-practice-editor-header"
         editor_footer = "footer"
 
@@ -204,7 +204,7 @@ describe 'Practice editor', type: :feature, js: true do
 
       it 'should display the correct header and footer on each page' do
         click_on('Edit innovation')
-        expect(page).to have_current_path(practice_metrics_path(@unpublished_pr))
+        expect(page).to have_current_path(practice_editors_path(@unpublished_pr))
         editor_header = "#dm-practice-editor-header"
         editor_footer = "footer"
 

--- a/spec/features/practice_editor/header_and_footer_spec.rb
+++ b/spec/features/practice_editor/header_and_footer_spec.rb
@@ -32,15 +32,16 @@ describe 'Practice editor', type: :feature, js: true do
         editor_footer = "footer"
 
         # metrics
+        click_link('Metrics')
         expect(page).to have_current_path(practice_metrics_path(@published_pr))
         within(:css, editor_header) do
           expect(page).to have_no_link(href: root_path)
           expect(page).to have_link(href: practice_metrics_path(@published_pr))
-          metrics_nav_link = find_all('.usa-nav__primary-item').first
+          metrics_nav_link = all('.usa-nav__primary-item').last
           expect(metrics_nav_link).to have_css('.usa-current')
           expect(page).to have_content('Editing guide')
           expect(page).to have_content('Edit your innovation')
-          edit_nav_link = find_all('.usa-nav__primary-item').last
+          edit_nav_link = find_all('.usa-nav__primary-item').first
           expect(edit_nav_link).to have_no_css('.usa-current')
           expect(page).to have_no_content('Save as draft')
           expect(page).to have_no_content('Save and publish')
@@ -58,11 +59,11 @@ describe 'Practice editor', type: :feature, js: true do
         within(:css, editor_header) do
           expect(page).to have_no_link(href: root_path)
           expect(page).to have_link(href: practice_metrics_path(@published_pr))
-          metrics_nav_link = find_all('.usa-nav__primary-item').first
+          metrics_nav_link = find_all('.usa-nav__primary-item').last
           expect(metrics_nav_link).to have_no_css('.usa-current')
           expect(page).to have_content('Editing guide')
           expect(page).to have_content('Edit your innovation')
-          edit_nav_link = find_all('.usa-nav__primary-item').last
+          edit_nav_link = find_all('.usa-nav__primary-item').first
           expect(edit_nav_link).to have_css('.usa-current')
           expect(page).to have_no_content('Save as draft')
           expect(page).to have_no_content('Save and publish')
@@ -81,11 +82,11 @@ describe 'Practice editor', type: :feature, js: true do
         within(:css, editor_header) do
           expect(page).to have_no_link(href: root_path)
           expect(page).to have_link(href: practice_metrics_path(@published_pr))
-          metrics_nav_link = find_all('.usa-nav__primary-item').first
+          metrics_nav_link = find_all('.usa-nav__primary-item').last
           expect(metrics_nav_link).to have_no_css('.usa-current')
           expect(page).to have_content('Editing guide')
           expect(page).to have_content('Edit your innovation')
-          edit_nav_link = find_all('.usa-nav__primary-item').last
+          edit_nav_link = find_all('.usa-nav__primary-item').first
           expect(edit_nav_link).to have_css('.usa-current')
           expect(page).to have_no_content('Save as draft')
           expect(page).to have_no_content('Save and publish')
@@ -105,11 +106,11 @@ describe 'Practice editor', type: :feature, js: true do
         within(:css, editor_header) do
           expect(page).to have_no_link(href: root_path)
           expect(page).to have_link(href: practice_metrics_path(@published_pr))
-          metrics_nav_link = find_all('.usa-nav__primary-item').first
+          metrics_nav_link = find_all('.usa-nav__primary-item').last
           expect(metrics_nav_link).to have_no_css('.usa-current')
           expect(page).to have_content('Editing guide')
           expect(page).to have_content('Edit your innovation')
-          edit_nav_link = find_all('.usa-nav__primary-item').last
+          edit_nav_link = find_all('.usa-nav__primary-item').first
           expect(edit_nav_link).to have_css('.usa-current')
           expect(page).to have_no_content('Save as draft')
           expect(page).to have_no_content('Save and publish')
@@ -129,11 +130,11 @@ describe 'Practice editor', type: :feature, js: true do
         within(:css, editor_header) do
           expect(page).to have_no_link(href: root_path)
           expect(page).to have_link(href: practice_metrics_path(@published_pr))
-          metrics_nav_link = find_all('.usa-nav__primary-item').first
+          metrics_nav_link = find_all('.usa-nav__primary-item').last
           expect(metrics_nav_link).to have_no_css('.usa-current')
           expect(page).to have_content('Editing guide')
           expect(page).to have_content('Edit your innovation')
-          edit_nav_link = find_all('.usa-nav__primary-item').last
+          edit_nav_link = find_all('.usa-nav__primary-item').first
           expect(edit_nav_link).to have_css('.usa-current')
           expect(page).to have_no_content('Save as draft')
           expect(page).to have_no_content('Save and publish')
@@ -153,11 +154,11 @@ describe 'Practice editor', type: :feature, js: true do
         within(:css, editor_header) do
           expect(page).to have_no_link(href: root_path)
           expect(page).to have_link(href: practice_metrics_path(@published_pr))
-          metrics_nav_link = find_all('.usa-nav__primary-item').first
+          metrics_nav_link = find_all('.usa-nav__primary-item').last
           expect(metrics_nav_link).to have_no_css('.usa-current')
           expect(page).to have_content('Editing guide')
           expect(page).to have_content('Edit your innovation')
-          edit_nav_link = find_all('.usa-nav__primary-item').last
+          edit_nav_link = find_all('.usa-nav__primary-item').first
           expect(edit_nav_link).to have_css('.usa-current')
           expect(page).to have_no_content('Save as draft')
           expect(page).to have_no_content('Save and publish')
@@ -177,11 +178,11 @@ describe 'Practice editor', type: :feature, js: true do
         within(:css, editor_header) do
           expect(page).to have_no_link(href: root_path)
           expect(page).to have_link(href: practice_metrics_path(@published_pr))
-          metrics_nav_link = find_all('.usa-nav__primary-item').first
+          metrics_nav_link = find_all('.usa-nav__primary-item').last
           expect(metrics_nav_link).to have_no_css('.usa-current')
           expect(page).to have_content('Editing guide')
           expect(page).to have_content('Edit your innovation')
-          edit_nav_link = find_all('.usa-nav__primary-item').last
+          edit_nav_link = find_all('.usa-nav__primary-item').first
           expect(edit_nav_link).to have_css('.usa-current')
           expect(page).to have_no_content('Save as draft')
           expect(page).to have_no_content('Save and publish')
@@ -209,15 +210,16 @@ describe 'Practice editor', type: :feature, js: true do
         editor_footer = "footer"
 
         # metrics
+        click_on('Metrics')
         expect(page).to have_current_path(practice_metrics_path(@unpublished_pr))
         within(:css, editor_header) do
           expect(page).to have_no_link(href: root_path)
           expect(page).to have_link(href: practice_metrics_path(@unpublished_pr))
-          metrics_nav_link = find_all('.usa-nav__primary-item').first
+          metrics_nav_link = find_all('.usa-nav__primary-item').last
           expect(metrics_nav_link).to have_css('.usa-current')
           expect(page).to have_content('Editing guide')
           expect(page).to have_content('Edit your innovation')
-          edit_nav_link = find_all('.usa-nav__primary-item').last
+          edit_nav_link = find_all('.usa-nav__primary-item').first
           expect(edit_nav_link).to have_no_css('.usa-current')
           expect(page).to have_no_content('Save as draft')
           expect(page).to have_no_content('Save and publish')
@@ -235,11 +237,11 @@ describe 'Practice editor', type: :feature, js: true do
         within(:css, editor_header) do
           expect(page).to have_no_link(href: root_path)
           expect(page).to have_link(href: practice_metrics_path(@unpublished_pr))
-          metrics_nav_link = find_all('.usa-nav__primary-item').first
+          metrics_nav_link = find_all('.usa-nav__primary-item').last
           expect(metrics_nav_link).to have_no_css('.usa-current')
           expect(page).to have_content('Editing guide')
           expect(page).to have_content('Edit your innovation')
-          edit_nav_link = find_all('.usa-nav__primary-item').last
+          edit_nav_link = find_all('.usa-nav__primary-item').first
           expect(edit_nav_link).to have_css('.usa-current')
           expect(page).to have_no_content('Save as draft')
           expect(page).to have_no_content('Save and publish')
@@ -258,11 +260,11 @@ describe 'Practice editor', type: :feature, js: true do
         within(:css, editor_header) do
           expect(page).to have_no_link(href: root_path)
           expect(page).to have_link(href: practice_metrics_path(@unpublished_pr))
-          metrics_nav_link = find_all('.usa-nav__primary-item').first
+          metrics_nav_link = find_all('.usa-nav__primary-item').last
           expect(metrics_nav_link).to have_no_css('.usa-current')
           expect(page).to have_content('Editing guide')
           expect(page).to have_content('Edit your innovation')
-          edit_nav_link = find_all('.usa-nav__primary-item').last
+          edit_nav_link = find_all('.usa-nav__primary-item').first
           expect(edit_nav_link).to have_css('.usa-current')
           expect(page).to have_content('Save as draft')
           expect(page).to have_content('Save and publish')
@@ -283,11 +285,11 @@ describe 'Practice editor', type: :feature, js: true do
           expect(page).to have_no_link(href: root_path)
           expect(page).to have_content('Metrics')
           expect(page).to have_link(href: practice_metrics_path(@unpublished_pr))
-          metrics_nav_link = find_all('.usa-nav__primary-item').first
+          metrics_nav_link = find_all('.usa-nav__primary-item').last
           expect(metrics_nav_link).to have_no_css('.usa-current')
           expect(page).to have_content('Editing guide')
           expect(page).to have_content('Edit your innovation')
-          edit_nav_link = find_all('.usa-nav__primary-item').last
+          edit_nav_link = find_all('.usa-nav__primary-item').first
           expect(edit_nav_link).to have_css('.usa-current')
           expect(page).to have_no_content('Save as draft')
           expect(page).to have_no_content('Save and publish')
@@ -307,11 +309,11 @@ describe 'Practice editor', type: :feature, js: true do
         within(:css, editor_header) do
           expect(page).to have_no_link(href: root_path)
           expect(page).to have_link(href: practice_metrics_path(@unpublished_pr))
-          metrics_nav_link = find_all('.usa-nav__primary-item').first
+          metrics_nav_link = find_all('.usa-nav__primary-item').last
           expect(metrics_nav_link).to have_no_css('.usa-current')
           expect(page).to have_content('Editing guide')
           expect(page).to have_content('Edit your innovation')
-          edit_nav_link = find_all('.usa-nav__primary-item').last
+          edit_nav_link = find_all('.usa-nav__primary-item').first
           expect(edit_nav_link).to have_css('.usa-current')
           expect(page).to have_content('Save as draft')
           expect(page).to have_content('Save and publish')
@@ -331,11 +333,11 @@ describe 'Practice editor', type: :feature, js: true do
         within(:css, editor_header) do
           expect(page).to have_no_link(href: root_path)
           expect(page).to have_link(href: practice_metrics_path(@unpublished_pr))
-          metrics_nav_link = find_all('.usa-nav__primary-item').first
+          metrics_nav_link = find_all('.usa-nav__primary-item').last
           expect(metrics_nav_link).to have_no_css('.usa-current')
           expect(page).to have_content('Editing guide')
           expect(page).to have_content('Edit your innovation')
-          edit_nav_link = find_all('.usa-nav__primary-item').last
+          edit_nav_link = find_all('.usa-nav__primary-item').first
           expect(edit_nav_link).to have_css('.usa-current')
           expect(page).to have_content('Save as draft')
           expect(page).to have_content('Save and publish')
@@ -355,11 +357,11 @@ describe 'Practice editor', type: :feature, js: true do
         within(:css, editor_header) do
           expect(page).to have_no_link(href: root_path)
           expect(page).to have_link(href: practice_metrics_path(@unpublished_pr))
-          metrics_nav_link = find_all('.usa-nav__primary-item').first
+          metrics_nav_link = find_all('.usa-nav__primary-item').last
           expect(metrics_nav_link).to have_no_css('.usa-current')
           expect(page).to have_content('Editing guide')
           expect(page).to have_content('Edit your innovation')
-          edit_nav_link = find_all('.usa-nav__primary-item').last
+          edit_nav_link = find_all('.usa-nav__primary-item').first
           expect(edit_nav_link).to have_css('.usa-current')
           expect(page).to have_content('Save as draft')
           expect(page).to have_content('Save and publish')

--- a/spec/features/practice_editor/metrics_spec.rb
+++ b/spec/features/practice_editor/metrics_spec.rb
@@ -55,6 +55,7 @@ describe 'Metrics section', type: :feature, js: true do
       login_as(@user1, :scope => :user, :run_callbacks => false)
       visit practice_path(@practice)
       click_link('Edit innovation')
+      click_link('Metrics')
       expect(page).to have_content(@practice.name)
     end
 
@@ -125,6 +126,7 @@ describe 'Metrics section', type: :feature, js: true do
       visit practice_path(@practice)
       click_link 'Bookmark'
       click_link 'Edit innovation'
+      click_link('Metrics')
 
       within(:css, '.dm-metrics-overall-stats') do
         bookmark_ct = find_all('td[style="font-size: 32px"]')[2].text


### PR DESCRIPTION
### JIRA issue link
[DM-4479](https://agile6.atlassian.net/browse/DM-4479)

## Description - what does this code do?
- Updates order of links in innovation editor navbar
- Points 'Edit innovation' button at the first editing page instead of metrics

## Testing done - how did you test it/steps on how can another person can test it 


## Screenshots, Gifs, Videos from application (if applicable)
### Before
![Screenshot 2024-03-04 at 5 41 12 PM](https://github.com/department-of-veterans-affairs/diffusion-marketplace/assets/5402927/932f0a33-313e-4c88-b6db-5f703250c96b)


### After
![Screenshot 2024-03-04 at 5 29 49 PM](https://github.com/department-of-veterans-affairs/diffusion-marketplace/assets/5402927/30a8b326-524f-4f1d-a231-78c5068c2292)


## Link to mock-ups/mock ups (image file if you have it) (if applicable)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Unit tests written (if applicable)
- [ ] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating JIRA issue
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs