### PR TITLE
Dm 4383 tinymce rails 6.8.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,8 +10,9 @@ gem 'pg'
 # Use Puma as the app server
 gem 'puma', '~> 6.4.2'
 # Use Uglifier as compressor for JavaScript assets
-gem 'uglifier', '>= 1.3.0'
+
 # See https://github.com/rails/execjs#readme for more supported runtimes
+gem 'terser'
 
 gem 'babel-transpiler'
 

--- a/Gemfile
+++ b/Gemfile
@@ -149,7 +149,7 @@ gem 'activeadmin_addons'
 gem 'active_skin'
 gem 'active_admin_theme'
 gem 'caxlsx'
-gem 'tinymce-rails', '6.5'
+gem 'tinymce-rails', '>= 6.7.3'
 gem 'sassc'
 
 gem "chartkick"

--- a/Gemfile
+++ b/Gemfile
@@ -148,7 +148,7 @@ gem 'activeadmin_addons'
 gem 'active_skin'
 gem 'active_admin_theme'
 gem 'caxlsx'
-gem 'tinymce-rails', '< 6.5'
+gem 'tinymce-rails', '6.5'
 gem 'sassc'
 
 gem "chartkick"

--- a/Gemfile
+++ b/Gemfile
@@ -9,10 +9,8 @@ gem 'pg'
 # gem 'pg', '1.1.4',  platforms: [:mingw, :x64_mingw]
 # Use Puma as the app server
 gem 'puma', '~> 6.4.2'
-# Use Uglifier as compressor for JavaScript assets
-
-# See https://github.com/rails/execjs#readme for more supported runtimes
 gem 'terser'
+# See https://github.com/rails/execjs#readme for more supported runtimes
 
 gem 'babel-transpiler'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -774,7 +774,7 @@ GEM
     thread_safe (0.3.6)
     tilt (2.0.10)
     timeout (0.4.1)
-    tinymce-rails (6.1.0)
+    tinymce-rails (6.5.0)
       railties (>= 3.1.1)
     turbolinks (5.2.1)
       turbolinks-source (~> 5.2)
@@ -922,7 +922,7 @@ DEPENDENCIES
   spring-watcher-listen (~> 2.0.0)
   sprockets
   survey_monkey_api!
-  tinymce-rails (< 6.5)
+  tinymce-rails (= 6.5)
   turbolinks (~> 5)
   tzinfo-data
   uglifier (>= 1.3.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -770,6 +770,8 @@ GEM
       sprockets (>= 3.0.0)
     terrapin (0.6.0)
       climate_control (>= 0.0.3, < 1.0)
+    terser (1.2.0)
+      execjs (>= 0.3.0, < 3)
     thor (1.3.1)
     thread_safe (0.3.6)
     tilt (2.0.10)
@@ -783,8 +785,6 @@ GEM
       concurrent-ruby (~> 1.0)
     tzinfo-data (1.2022.5)
       tzinfo (>= 1.0.0)
-    uglifier (4.2.0)
-      execjs (>= 0.3.0, < 3)
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.8.2)
@@ -922,10 +922,10 @@ DEPENDENCIES
   spring-watcher-listen (~> 2.0.0)
   sprockets
   survey_monkey_api!
+  terser
   tinymce-rails (= 6.5)
   turbolinks (~> 5)
   tzinfo-data
-  uglifier (>= 1.3.0)
   uswds-rails!
   web-console (>= 3.3.0)
   webdrivers

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -776,7 +776,7 @@ GEM
     thread_safe (0.3.6)
     tilt (2.0.10)
     timeout (0.4.1)
-    tinymce-rails (6.5.0)
+    tinymce-rails (6.8.3)
       railties (>= 3.1.1)
     turbolinks (5.2.1)
       turbolinks-source (~> 5.2)
@@ -923,7 +923,7 @@ DEPENDENCIES
   sprockets
   survey_monkey_api!
   terser
-  tinymce-rails (= 6.5)
+  tinymce-rails (>= 6.7.3)
   turbolinks (~> 5)
   tzinfo-data
   uswds-rails!

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -23,7 +23,8 @@ Rails.application.configure do
   config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
 
   # Compress JavaScripts and CSS.
-  config.assets.js_compressor = Uglifier.new(harmony: true)
+  config.assets.js_compressor = :terser
+
   # config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.


### PR DESCRIPTION
### JIRA issue link
https://agile6.atlassian.net/browse/DM-4383

## Description - what does this code do?
1. bumps `tinymce-rails` minor version from 6.1 to 6.8.3 (latest)
2. adds `terser` gem to replace removed `uglifier` gem
3. updates `production.rb` to implement `:terser` as JS compression tool

## Testing done - how did you test it/steps on how can another person can test it 
1. Run the app locally and click around various places where tinymce editor can be found, verify it works as expected
2. With this branch deployed on DEV repeat step 1 , also take a quick peek at the deployment logs to verify there are no hidden errors I missed.
3. Verify that JS files are being compressed in dev tools on DEV (compare with PROD or STG, they should generally be the same sizes for the various files)

## Screenshots, Gifs, Videos from application (if applicable)


## Link to mock-ups/mock ups (image file if you have it) (if applicable)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Unit tests written (if applicable)
- [ ] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating JIRA issue
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs