### PR TITLE
DM-4504: Fix 'Presented by' field in Event components

### DIFF
--- a/app/admin/pages.rb
+++ b/app/admin/pages.rb
@@ -67,6 +67,7 @@ ActiveAdmin.register Page do
                     :start_date,
                     :end_date,
                     :location,
+                    :presented_by,
                     :flipped_ratio,
                     practices: []
                   ],

--- a/app/views/page/_events_list.html.erb
+++ b/app/views/page/_events_list.html.erb
@@ -9,7 +9,7 @@
             <div id="<%= event.id %>" class="event-item-description usa-prose usa-card__body">
                 <div class="event-metadata">
                   <% if event.presented_by? %>
-                    <p>Presented by: <%= event.presented_by%></p>
+                    <p>Presented by <%= event.presented_by%></p>
                   <% end %>
                   <% if event&.start_date.present? %>
                     <p><i class="fas fa-calendar-alt"></i><span class='sr-only'>Date: </span> <%= event.rendered_date %></span></p>

--- a/spec/factories/page_event_component.rb
+++ b/spec/factories/page_event_component.rb
@@ -1,0 +1,11 @@
+FactoryBot.define do
+  factory :page_event_component do
+    title { "Event Title" }
+    url { "https://example.com" }
+    presented_by { "VHA Innovation Network"}
+    location { "Virtual" }
+    text { "A compelling event description" }
+    start_date { Date.new(2024,3,7) }
+    end_date {Date.new(2024,3,8) }
+  end
+end

--- a/spec/features/pages/paginated_components_spec.rb
+++ b/spec/features/pages/paginated_components_spec.rb
@@ -163,7 +163,7 @@ end
 
 def create_event_components(num = 1, page)
   num.times do
-    event_component =  PageEventComponent.create(title: 'Event', url: 'https://wikipedia.org', text: 'event description')
+    event_component = create(:page_event_component)
     PageComponent.create(page: page, component: event_component, created_at: Time.now)
   end
 end


### PR DESCRIPTION
### JIRA issue link
[DM-4504](https://agile6.atlassian.net/browse/DM-4504)

## Description - what does this code do?
- Fixes up params so the "Presented by" field is rendered on Events components
- Adds a factory for event components

## Testing done - how did you test it/steps on how can another person can test it 
1. in `master`, log in as an admin
1. create a page group and page
1. add an event component to that page with the "Presented by" field filled out
1. save the page
1. review server output. The presented_by params should have been rejected. The UI does not show any `Presented by` value. 

## Scree
![Screenshot 2024-03-07 at 5 27 10 PM](https://github.com/department-of-veterans-affairs/diffusion-marketplace/assets/5402927/28617564-ac97-4fb5-b328-19e36f5d7c44)
nshots, Gifs, Videos from application (if applicable)


## Link to mock-ups/mock ups (image file if you have it) (if applicable)
https://www.figma.com/file/ccwLbt94U9QGfnuFCwOXzY/Core-Designs---VA-DM?type=design&node-id=6181%3A38873&mode=design&t=rqbj4JitmMQo3zhB-1
