### PR TITLE
DM-4501: Change 'Save and update' button to 'Save and publish'

### DIFF
--- a/app/views/practices/shared/_practice_editor_header.html.erb
+++ b/app/views/practices/shared/_practice_editor_header.html.erb
@@ -2,7 +2,7 @@
   is_editors_or_adoptions =  params[:action] === 'editors' || params[:action] === 'adoptions'
   save_btn_pgs = ['introduction', 'overview', 'contact', 'implementation','about']
   has_save_btn = save_btn_pgs.include?(params[:action])
-  save_btn_text = @practice.published ? 'Save and update' : 'Save as draft'
+  save_btn_text = @practice.published ? 'Save and publish' : 'Save as draft'
   save_btn_classes = @practice.published ? 'dm-button--success margin-right-0' : 'dm-button--inverse-secondary margin-right-2'
 %>
 <%= render partial: 'practices/shared/close_modal' unless is_editors_or_adoptions %>

--- a/spec/features/practice_editor/header_and_footer_spec.rb
+++ b/spec/features/practice_editor/header_and_footer_spec.rb
@@ -216,7 +216,6 @@ describe 'Practice editor', type: :feature, js: true do
           expect(edit_nav_link).to have_no_css('.usa-current')
           expect(page).to have_no_content('Save as draft')
           expect(page).to have_no_content('Save and publish')
-          expect(page).to have_no_content('Save and update')
         end
         within(editor_footer) do
           expect(page).to have_no_content('Back')
@@ -238,7 +237,6 @@ describe 'Practice editor', type: :feature, js: true do
           expect(edit_nav_link).to have_css('.usa-current')
           expect(page).to have_no_content('Save as draft')
           expect(page).to have_no_content('Save and publish')
-          expect(page).to have_no_content('Save and update')
         end
         within(editor_footer) do
           expect(page).to have_no_content('Back')
@@ -261,7 +259,6 @@ describe 'Practice editor', type: :feature, js: true do
           expect(edit_nav_link).to have_css('.usa-current')
           expect(page).to have_content('Save as draft')
           expect(page).to have_content('Save and publish')
-          expect(page).to have_no_content('Save and update')
         end
         within(editor_footer) do
           expect(page).to have_content('Back')
@@ -286,7 +283,6 @@ describe 'Practice editor', type: :feature, js: true do
           expect(edit_nav_link).to have_css('.usa-current')
           expect(page).to have_no_content('Save as draft')
           expect(page).to have_no_content('Save and publish')
-          expect(page).to have_no_content('Save and update')
         end
         within(editor_footer) do
           expect(page).to have_content('Back')
@@ -310,7 +306,6 @@ describe 'Practice editor', type: :feature, js: true do
           expect(edit_nav_link).to have_css('.usa-current')
           expect(page).to have_content('Save as draft')
           expect(page).to have_content('Save and publish')
-          expect(page).to have_no_content('Save and update')
         end
         within(editor_footer) do
           expect(page).to have_content('Back')
@@ -334,7 +329,6 @@ describe 'Practice editor', type: :feature, js: true do
           expect(edit_nav_link).to have_css('.usa-current')
           expect(page).to have_content('Save as draft')
           expect(page).to have_content('Save and publish')
-          expect(page).to have_no_content('Save and update')
         end
         within(editor_footer) do
           expect(page).to have_content('Back')
@@ -358,7 +352,6 @@ describe 'Practice editor', type: :feature, js: true do
           expect(edit_nav_link).to have_css('.usa-current')
           expect(page).to have_content('Save as draft')
           expect(page).to have_content('Save and publish')
-          expect(page).to have_no_content('Save and update')
         end
         within(editor_footer) do
           expect(page).to have_content('Back')

--- a/spec/features/practice_editor/header_and_footer_spec.rb
+++ b/spec/features/practice_editor/header_and_footer_spec.rb
@@ -45,7 +45,6 @@ describe 'Practice editor', type: :feature, js: true do
           expect(edit_nav_link).to have_no_css('.usa-current')
           expect(page).to have_no_content('Save as draft')
           expect(page).to have_no_content('Save and publish')
-          expect(page).to have_no_content('Save and update')
         end
         within(editor_footer) do
           expect(page).to have_no_content('Back')
@@ -67,7 +66,6 @@ describe 'Practice editor', type: :feature, js: true do
           expect(edit_nav_link).to have_css('.usa-current')
           expect(page).to have_no_content('Save as draft')
           expect(page).to have_no_content('Save and publish')
-          expect(page).to have_no_content('Save and update')
         end
         within(editor_footer) do
           expect(page).to have_no_content('Back')
@@ -89,8 +87,7 @@ describe 'Practice editor', type: :feature, js: true do
           edit_nav_link = find_all('.usa-nav__primary-item').first
           expect(edit_nav_link).to have_css('.usa-current')
           expect(page).to have_no_content('Save as draft')
-          expect(page).to have_no_content('Save and publish')
-          expect(page).to have_content('Save and update')
+          expect(page).to have_content('Save and publish')
         end
         within(editor_footer) do
           expect(page).to have_content('Back')
@@ -114,7 +111,6 @@ describe 'Practice editor', type: :feature, js: true do
           expect(edit_nav_link).to have_css('.usa-current')
           expect(page).to have_no_content('Save as draft')
           expect(page).to have_no_content('Save and publish')
-          expect(page).to have_no_content('Save and update')
         end
         within(editor_footer) do
           expect(page).to have_content('Back')
@@ -137,8 +133,7 @@ describe 'Practice editor', type: :feature, js: true do
           edit_nav_link = find_all('.usa-nav__primary-item').first
           expect(edit_nav_link).to have_css('.usa-current')
           expect(page).to have_no_content('Save as draft')
-          expect(page).to have_no_content('Save and publish')
-          expect(page).to have_content('Save and update')
+          expect(page).to have_content('Save and publish')
         end
         within(editor_footer) do
           expect(page).to have_content('Back')
@@ -161,8 +156,7 @@ describe 'Practice editor', type: :feature, js: true do
           edit_nav_link = find_all('.usa-nav__primary-item').first
           expect(edit_nav_link).to have_css('.usa-current')
           expect(page).to have_no_content('Save as draft')
-          expect(page).to have_no_content('Save and publish')
-          expect(page).to have_content('Save and update')
+          expect(page).to have_content('Save and publish')
         end
         within(editor_footer) do
           expect(page).to have_content('Back')
@@ -185,8 +179,7 @@ describe 'Practice editor', type: :feature, js: true do
           edit_nav_link = find_all('.usa-nav__primary-item').first
           expect(edit_nav_link).to have_css('.usa-current')
           expect(page).to have_no_content('Save as draft')
-          expect(page).to have_no_content('Save and publish')
-          expect(page).to have_content('Save and update')
+          expect(page).to have_content('Save and publish')
         end
         within(editor_footer) do
           expect(page).to have_content('Back')


### PR DESCRIPTION
### JIRA issue link
[DM-4501](https://agile6.atlassian.net/browse/DM-4501)

## Description - what does this code do?
- For published innovations: changes the `Save and update` button text to `Save and publish`
- Update specs that look for the `Save and update` button

## Testing done - how did you test it/steps on how can another person can test it 
1. In local dev, log in as an admin.
1. look for a published practice and click on `Edit your innovation`
1. For each of the editor steps (except for `Adoptions`), check that the header button says `Save and publish`
1. Create a new innovation in `/admin/practices` and go to its edit page
1. Confirm that each editor section (except for `Adoptions`) has two header buttons, `Save and draft` and `Save and publish`.

## Screenshots, Gifs, Videos from application (if applicable)
### Before
![Screenshot 2024-03-08 at 4 44 55 PM](https://github.com/department-of-veterans-affairs/diffusion-marketplace/assets/5402927/fb2ecdce-12c7-4cf3-94ed-a5697cc96afc)

### After
![Screenshot 2024-03-08 at 4 44 25 PM](https://github.com/department-of-veterans-affairs/diffusion-marketplace/assets/5402927/2f84dc35-c07a-44b3-acf4-82ad202dde0a)


## Acceptance criteria
A/C:
1. The 'Save and update' CTA on existing, published pages within the Innovation Editor should be replaced with the 'Save and publish' CTA.
2. Clicking on the 'Save and publish' CTA should result in the changes being successfully published to the Marketplace.
3. Editors should no longer have the option to select ‘Save and update’.
