### PR TITLE
Dm 4500 add updated date to batch emails

### DIFF
--- a/app/services/practice_mailer_service.rb
+++ b/app/services/practice_mailer_service.rb
@@ -88,7 +88,8 @@ class PracticeMailerService
     {
       practice_name: practice.name,
       show_url: Rails.application.routes.url_helpers.practice_url(practice, host_options),
-      practice_id: practice.id
+      practice_id: practice.id,
+      last_updated_on: practice.updated_at.strftime('%m/%d/%Y')
     }
   end
 end

--- a/app/views/admin/practices/_email_preview_modal.html.erb
+++ b/app/views/admin/practices/_email_preview_modal.html.erb
@@ -10,7 +10,10 @@
         <p id="previewMessage"></p>
         <p>Visit your Innovation(s) at the following link(s) and click "Edit" to begin editing. Please note that only one person can edit the innovation at a time.</p>
         <ul>
-          <li><a href="#">Sample Innovation Link</a></li>
+          <li>
+            <a href="#">Sample Innovation Link</a> -
+            <strong>Updated 1/1/2001</strong>
+          </li>
         </ul>
         <p>
           If you have any questions, issues, or feedback to share with us please send an email to <%= mail_to 'Marketplace@VA.gov ', 'Marketplace@VA.gov ' %>

--- a/app/views/practice_editor_mailer/send_batch_email_to_editor.html.erb
+++ b/app/views/practice_editor_mailer/send_batch_email_to_editor.html.erb
@@ -12,7 +12,8 @@
     <ul>
       <% @practices.each do |practice| %>
         <li>
-          <%= link_to "#{practice[:practice_name]}", practice[:show_url] %>
+          <%= link_to "#{practice[:practice_name]}", practice[:show_url] %> -
+          <strong>Updated <%= "#{practice[:last_updated_on]}" %></strong>
         </li>
       <% end %>
     </ul>

--- a/spec/features/admin/email_selected_practices_editors_spec.rb
+++ b/spec/features/admin/email_selected_practices_editors_spec.rb
@@ -69,7 +69,9 @@ describe 'Admin email all editors button', type: :feature do
     expect(email.subject).to eq 'Important Update'
 
     expect(email.body.encoded).to include older_practice.name
+    expect(email.body.encoded).to include older_practice.updated_at.strftime('%m/%d/%Y')
     expect(email.body.encoded).to include unemailed_practice.name
+    expect(email.body.encoded).to include unemailed_practice.updated_at.strftime('%m/%d/%Y')
     expect(email.body.encoded).to include recently_updated_practice.name
     expect(email.body.encoded).not_to include unpublished_practice.name
 


### PR DESCRIPTION
### JIRA issue link
https://agile6.atlassian.net/browse/DM-4500

## Description - what does this code do?
Adds `updated_at` dates beside listed practices in batch email template

## Testing done - how did you test it/steps on how can another person can test it 
1. Locally, log in as admin and send a batch email from `admin/practices`
2. Verify the preview modal includes a date next to the example innovation link (screenshot 1)
3. Verify the emails generated include the `updated_at`s next to the respective innovation names listed in the editor / owner emails (screenshot 2) 

## Screenshots, Gifs, Videos from application (if applicable)
<img width="855" alt="Screenshot 2024-03-11 at 4 54 56 PM" src="https://github.com/department-of-veterans-affairs/diffusion-marketplace/assets/65036872/d54031b8-3dde-437c-84a8-b87e36b24671">
<img width="1025" alt="Screenshot 2024-03-11 at 4 55 27 PM" src="https://github.com/department-of-veterans-affairs/diffusion-marketplace/assets/65036872/69e45312-9f66-43da-82cc-2752d0c3a3f8">


## Link to mock-ups/mock ups (image file if you have it) (if applicable)


## Acceptance criteria
- [ ]

## Definition of done
- [x] Unit tests written (if applicable)
- [x] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating JIRA issue
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs