### PR TITLE
DM-4456: Remove webdrivers and upgrade selenium-webdriver

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -65,7 +65,7 @@ group :development, :test do
   gem 'figaro'
   gem 'rspec-retry'
   gem 'axe-matchers'
-  gem 'webdrivers'
+  gem 'selenium-webdriver'
 
   gem 'brakeman', '5.0.2'
   gem 'bundler-audit'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -188,6 +188,7 @@ GEM
     babel-transpiler (0.7.0)
       babel-source (>= 4.0, < 6)
       execjs (~> 2.0)
+    base64 (0.2.0)
     bcrypt (3.1.18)
     bindex (0.8.1)
     bootsnap (1.17.0)
@@ -745,7 +746,8 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
-    selenium-webdriver (4.10.0)
+    selenium-webdriver (4.18.1)
+      base64 (~> 0.2)
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
@@ -803,10 +805,6 @@ GEM
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
-    webdrivers (5.3.1)
-      nokogiri (~> 1.6)
-      rubyzip (>= 1.3.0)
-      selenium-webdriver (~> 4.0, < 4.11)
     webrick (1.7.0)
     webrobots (0.1.2)
     websocket (1.2.10)
@@ -916,6 +914,7 @@ DEPENDENCIES
   rubocop-rspec
   rubyzip
   sassc
+  selenium-webdriver
   shoulda-matchers
   simplecov
   spring
@@ -928,7 +927,6 @@ DEPENDENCIES
   tzinfo-data
   uswds-rails!
   web-console (>= 3.3.0)
-  webdrivers
   wt_s3_signer
 
 RUBY VERSION

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,7 @@ require 'simplecov'
 require 'rspec/retry'
 require 'axe/rspec'
 require "rack_session_access/capybara"
+require 'selenium-webdriver'
 
 if ENV['CIRCLE_ARTIFACTS']
   dir = File.join(ENV['CIRCLE_ARTIFACTS'], 'coverage')


### PR DESCRIPTION
### JIRA issue link
[DM-4456](https://agile6.atlassian.net/browse/DM-4456)

## Description - what does this code do?
- Removes the `webdrivers` gem and upgrades `selenium-webdriver`, per the [maintainer's advice](https://github.com/titusfortner/webdrivers#update-future-of-this-project):
> With Google's new [Chrome for Testing](https://developer.chrome.com/blog/chrome-for-testing/) project, and Selenium's new [Selenium Manager](https://www.selenium.dev/documentation/selenium_manager/) feature, what is required of this gem has changed.
If you can update to the latest version of Selenium (4.11+), please do so and stop requiring this gem. Provide feedback or raise issues to [Selenium Project](https://github.com/SeleniumHQ/selenium/issues/new/choose)
If you cannot upgrade to Selenium 4.11, Webdrivers 5.3.0 will continue to support Ruby 2.6+ and Selenium 4.0 - 4.10

## Testing done - how did you test it/steps on how can another person can test it 
1Run the test suite in your local dev to confirm! 
