### PR TITLE
add custom css class for pb triple paragraph component bg color

### DIFF
--- a/app/assets/stylesheets/dm/components/page_component.scss
+++ b/app/assets/stylesheets/dm/components/page_component.scss
@@ -186,6 +186,10 @@
     height: 440px;
   }
 
+  .page-triple-paragraph-component-bg {
+    background-color: #f5f5f5;
+  }
+
   // replicates .dm-practice-card-img-container
   .dm-news-img-container {
     max-height: 165px;
@@ -203,8 +207,8 @@
   }
 
   // disable USWDS USA card styles the affect whitespace
-  .page-event-component, 
-  .page-news-component, 
+  .page-event-component,
+  .page-news-component,
   .publication-component-list-cards .page-publication-component { // Publication lists with <2 components
     margin-top: 0;
     margin-bottom: 0;

--- a/app/views/page/show.html.erb
+++ b/app/views/page/show.html.erb
@@ -29,7 +29,7 @@
 
         <%# Three Text Columns %>
         <% if pc.component_type == 'PageTripleParagraphComponent' && component.text1.present? %>
-          <div class=<%='bg-primary-lighter' if component.has_background_color %>>
+          <div class=<%='page-triple-paragraph-component-bg' if component.has_background_color %>>
             <div class="grid-container">
               <div class="page-triple-paragraph-component padding-top-7 padding-bottom-7 margin-bottom-10 <%= page_narrow_classes %><%= ' margin-bottom-0' if last_component === index %>">
                 <div class="grid-row grid-gap">
@@ -43,7 +43,7 @@
                   </div>
                   <div class="grid-col-12 desktop:grid-col-4">
                     <h3><%= component.title3.html_safe %></h3>
-                    <p><%= component.text3.html_safe %></p>  
+                    <p><%= component.text3.html_safe %></p>
                   </div>
                 </div>
               </div>
@@ -136,7 +136,7 @@
                     class="dm-button--inverse-secondary margin-top-4 margin-bottom-4 margin-left-4">
                     <%= component.button_text %>
                   </a>
-                </div>  
+                </div>
               </div>
             </div>
           <% else %>


### PR DESCRIPTION
### JIRA issue link
https://agile6.atlassian.net/browse/DM-4531

## Description - what does this code do?
adds custom css class for background color of `page-triple-paragraph-component`

## Testing done - how did you test it/steps on how can another person can test it 
1. Add the `page-triple-paragraph-component` to a page locally, toggle the background color
2. Verify the page renders with the correct color for the component (#f5f5f5)

## Screenshots, Gifs, Videos from application (if applicable)


## Link to mock-ups/mock ups (image file if you have it) (if applicable)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Unit tests written (if applicable)
- [ ] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating JIRA issue
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs