### PR TITLE
DM-4544: Move the page group to the top of the form and update hints

### DIFF
--- a/app/admin/pages.rb
+++ b/app/admin/pages.rb
@@ -179,10 +179,13 @@ ActiveAdmin.register Page do
     f.actions # adds the 'Submit' and 'Cancel' buttons
     f.semantic_errors *f.object.errors.attribute_names # shows errors on :base
     f.inputs "Page Information" do
+      f.input :page_group,
+              label: 'Community',
+              hint: 'The community name will be included in the URL. (e.g.: "/communities/va-immersive/about-us" where "va-immersive" is the Community and "about-us" is the URL suffix chosen below.'
       if resource.ever_published
-        f.input :slug, input_html: { disabled: true } , label: 'URL suffix', hint: 'Enter a brief and descriptive page URL suffix (Ex: "page-title"). Note: to make a page the home or landing page for a page group, enter "home". If this page was ever published, the URL Suffix cannot be edited.'
+        f.input :slug, input_html: { disabled: true } , label: 'URL suffix', hint: 'A hyphenated page name used in the URL. (e.g. "about"). Note: A page with the URL suffix "home" will be the communnity landing page. If this page was ever published, the URL Suffix cannot be edited.'
       else
-        f.input :slug, label: 'URL suffix', hint: 'Enter a brief and descriptive page URL suffix (Ex: "page-title"). Note: to make a page the home or landing page for a page group, enter "home".'
+        f.input :slug, label: 'URL suffix', hint: 'Enter a hyphenated page name used in the URL. (e.g. "about-us"). Note: to create a community homepage, use the suffix "home".'
       end
       f.input :template_type
       f.input :title, label: 'Title', hint: 'The main heading/"H1" of the page.'
@@ -218,10 +221,6 @@ ActiveAdmin.register Page do
       f.input :is_visible,
               label: 'Title and Description are visible?',
               hint: 'This field allows you to show or hide the page title and description.'
-      f.input :page_group,
-              label: 'Group',
-              hint: 'The Group is the page type and will be included in the url. (Ex: "/competitions/page-title" where "competitions" '\
-                    'is the Group and "page-title" is the chosen url suffix from above. If the url suffix is "home", the complete URL will be "/competitions")'
       f.input :has_chrome_warning_banner,
               label: 'Switch to Chrome warning banner',
               hint: 'Check this if the page has any call to action or link that only works or is optimal in the Chrome Browser.'

--- a/app/admin/pages.rb
+++ b/app/admin/pages.rb
@@ -180,7 +180,7 @@ ActiveAdmin.register Page do
     f.semantic_errors *f.object.errors.attribute_names # shows errors on :base
     f.inputs "Page Information" do
       f.input :page_group,
-              label: 'Community',
+              label: 'Page Group / Community',
               hint: 'The community name will be included in the URL. (e.g.: "/communities/va-immersive/about-us" where "va-immersive" is the Community and "about-us" is the URL suffix chosen below.'
       if resource.ever_published
         f.input :slug, input_html: { disabled: true } , label: 'URL suffix', hint: 'A hyphenated page name used in the URL. (e.g. "about"). Note: A page with the URL suffix "home" will be the communnity landing page. If this page was ever published, the URL Suffix cannot be edited.'

--- a/app/assets/stylesheets/active_admin.scss
+++ b/app/assets/stylesheets/active_admin.scss
@@ -231,7 +231,7 @@
     }
   }
 
-  #page_is_visible_input, #page_page_group_input, #page_has_chrome_warning_banner_input, #page_is_public_input {
+  #page_is_visible_input, #page_has_chrome_warning_banner_input, #page_is_public_input {
     // Active admin 'hint'
     .inline-hints {
       @include u-display('inline-block');

--- a/spec/features/admin/admin_page_spec.rb
+++ b/spec/features/admin/admin_page_spec.rb
@@ -198,6 +198,6 @@ describe 'Page Builder', type: :feature do
     fill_in 'URL', with: url
     fill_in 'Title', with: 'Hello world!'
     fill_in 'Description', with: 'This is the first page built.'
-    select('programming', from: 'Group*')
+    select('programming', from: 'Page Group / Community*')
   end
 end


### PR DESCRIPTION
### JIRA issue link
[DM-4544](https://agile6.atlassian.net/browse/DM-4544)

## Description - what does this code do?
- Move `Page Group` above the URL suffix for a more intuitive page creation experience.
- Rename `Page Group` to `Community` and update inline hint guidance

## Screenshots, Gifs, Videos from application (if applicable)
### Before
![Screenshot 2024-03-14 at 5 20 52 PM](https://github.com/department-of-veterans-affairs/diffusion-marketplace/assets/5402927/107cc539-8afc-4f3e-8f28-c4e9ab5b1c69)

### After
![Screenshot 2024-03-25 at 3 52 52 PM](https://github.com/department-of-veterans-affairs/diffusion-marketplace/assets/5402927/071c4a25-1371-4c32-b733-b7ec3e9a47bc)


