### PR TITLE
Bump font-awesome-sass to v5.15

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -116,7 +116,7 @@ gem 'aws-sdk-s3'
 gem 'aws-sdk-rds'
 gem 'wt_s3_signer'
 gem 'paperclip', github: 'agilesix/paperclip', branch: 'ruby-3-2-patched'
-gem 'font-awesome-sass', '~> 5.13.0'
+gem 'font-awesome-sass', '< 6'
 
 gem 'survey_monkey_api', github: 'agilesix/surveymonkey'
 gem 'mechanize', '2.8.5'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -281,7 +281,7 @@ GEM
     ffi (1.16.3)
     figaro (1.2.0)
       thor (>= 0.14.0, < 2)
-    font-awesome-sass (5.13.1)
+    font-awesome-sass (5.15.1)
       sassc (>= 1.11)
     formtastic (5.0.0)
       actionpack (>= 6.0.0)
@@ -861,7 +861,7 @@ DEPENDENCIES
   faker
   ffi
   figaro
-  font-awesome-sass (~> 5.13.0)
+  font-awesome-sass (< 6)
   friendly_id (~> 5.2.4)
   gmaps4rails!
   groupdate


### PR DESCRIPTION
### JIRA issue link
N/A

## Description - what does this code do?
- bumps our font-awesome-sass to the highest version. v6 will require some manual migration tasks, see [DM-4545](https://agile6.atlassian.net/browse/DM-4545)
- code diff and release notes: https://github.com/FortAwesome/Font-Awesome/compare/5.13.0...5.15.1
- code diff for Sass distro: https://github.com/FortAwesome/font-awesome-sass/compare/5.13.1...5.15.1

## Testing done - how did you test it/steps on how can another person can test it 
- Review the UI to look for icon breakage
