### PR TITLE
fix homepage dropdown category link param

### DIFF
--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -59,7 +59,7 @@
               <ul id="category-list" class="usa-list usa-list--unstyled padding-top-1">
                 <% @dropdown_categories[0..2].each do |category| %>
                   <li class="search-result" data-category-id=<%= category[:id] %>>
-                    <a href=<%= "/search?category=#{category[:name]}" %>><%= category[:name] %></a>
+                    <a href=<%= "/search?category=#{URI.encode_www_form_component(category[:name])}" %>><%= category[:name] %></a>
                   </li>
                 <% end %>
               </ul>


### PR DESCRIPTION
### JIRA issue link


## Description - what does this code do?
adds `URI.encode_www_form_component` call to category name so that properly encoded param is sent in request

## Testing done - how did you test it/steps on how can another person can test it 
verify that when clicking a category in the homepage dropdown, the `/search` page loads with the category pre-selected as a filter

## Screenshots, Gifs, Videos from application (if applicable)


## Link to mock-ups/mock ups (image file if you have it) (if applicable)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Unit tests written (if applicable)
- [ ] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating JIRA issue
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs