### PR TITLE
DM-4509: Add subnav for VA Immersive community pages

### DIFF
--- a/app/assets/javascripts/_page_show.es6
+++ b/app/assets/javascripts/_page_show.es6
@@ -105,6 +105,15 @@ const COMPONENT_CLASSES = [
         }
     }
 
+    function showCommunitySubNav(){
+        $('#communitySubnavBtn').on('click', function(){
+            $('#community-subnav ul').toggleClass('display-none');
+            $('#communitySubnavBtn i').toggleClass(['fa-minus', 'fa-plus']);
+            $('#communitySubnavBtn').attr('aria-expanded', function (i, attr) {
+            return attr == 'true' ? 'false' : 'true'})
+        })
+    }
+
     function execPageBuilderFunctions() {
         browsePageBuilderPageHappy();
         containerizeSubpageHyperlinkCards();
@@ -112,6 +121,7 @@ const COMPONENT_CLASSES = [
         identifyExternalLinks();
         chromeWorkaroundForAnchorTags();
         replaceImagePlaceholders();
+        showCommunitySubNav();
     }
 
     $document.on('turbolinks:load', execPageBuilderFunctions);

--- a/app/assets/stylesheets/dm/pages/_page_builder_page.scss
+++ b/app/assets/stylesheets/dm/pages/_page_builder_page.scss
@@ -27,6 +27,10 @@
     }
   }
 
+  a.current-page {
+      text-decoration: underline;
+  }
+
   @media screen and (max-width: 640px) {
     li {
       margin-top: 1rem;

--- a/app/assets/stylesheets/dm/pages/_page_builder_page.scss
+++ b/app/assets/stylesheets/dm/pages/_page_builder_page.scss
@@ -1,3 +1,16 @@
+#communitySubnavBtn {
+  border: none;
+  font-weight: 700;
+  width: 100%;
+  background-color: #D9D9D985;
+  color: #1B1B1B;
+  text-align: left;
+
+  // push text and icon to opposite ends
+  display: flex;
+  justify-content: space-between;
+}
+
 #community-subnav {
   ul {
     list-style: none;
@@ -14,6 +27,11 @@
     }
   }
 
+  @media screen and (max-width: 640px) {
+    li {
+      margin-top: 1rem;
+    }
+  }
 }
 
 #page-builder-page {

--- a/app/assets/stylesheets/dm/pages/_page_builder_page.scss
+++ b/app/assets/stylesheets/dm/pages/_page_builder_page.scss
@@ -1,3 +1,21 @@
+#community-subnav {
+  ul {
+    list-style: none;
+    justify-content: space-evenly;
+  }
+
+  a, a:visited {
+    color: white;
+    text-decoration: none;
+    font-weight: 700;
+
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+
+}
+
 #page-builder-page {
   .usa-accordion__content {
     p {

--- a/app/assets/stylesheets/dm/pages/_page_builder_page.scss
+++ b/app/assets/stylesheets/dm/pages/_page_builder_page.scss
@@ -9,6 +9,10 @@
   // push text and icon to opposite ends
   display: flex;
   justify-content: space-between;
+
+  @media screen and (min-width: 640px) {
+    display: none;
+  }
 }
 
 #community-subnav {

--- a/app/views/shared/_breadcrumbs.html.erb
+++ b/app/views/shared/_breadcrumbs.html.erb
@@ -17,13 +17,26 @@
   end
 
   is_page_builder_page = controller === 'page'
+  is_commmunity_page = is_page_builder_page && PageGroup.where(slug: params["page_group_friendly_id"]).first.is_community? 
+  community_name = params["page_group_friendly_id"]
   page_image = session[:page_image]
   alt_text = session[:page_image_alt_text]
 %>
 
 <section class="<%= 'dm-gradient-banner' if heading.present? %><%= ' gradient-banner-with-image' if page_image.present? %> <%= classes if classes.present? %>">
-  <div class="grid-container<%= ' padding-y-4 desktop:padding-y-8' if heading.present? %>">
-    <% if breadcrumbs.present? %>
+  <div class="grid-container <%= 'padding-top-2 padding-bottom-8' if is_commmunity_page %> <%= 'padding-y-4 desktop:padding-y-8' if heading.present? && !is_commmunity_page %>">
+    <% if is_commmunity_page %>
+    <nav id="community-subnav" class="font-sans-lg" aria-label="Community subnavigation">
+      <ul class="padding-x-0 padding-bottom-8 flex-row display-none tablet:display-flex">
+        <li class=""><a href="/communities/<%= community_name %>/">Community</a></li>
+        <li class=""><a href="/communities/<%= community_name %>/about">About</a></li>
+        <li class=""><a href="/communities/<%= community_name %>/innovations">Innovations</a></li>
+        <li class=""><a href="/communities/<%= community_name %>/events-and-news">Events and News</a></li>
+        <li class=""><a href="/communities/<%= community_name %>/getting-started">Getting Started</a></li>
+        <li class=""><a href="/communities/<%= community_name %>/publications">Publications</a></li>
+      </ul>
+    </nav>
+    <% elsif breadcrumbs.present? %>
       <div id="breadcrumbs"
            class="grid-col-auto usa-breadcrumb breadcrumbs-container <%= heading.present? ? "dm-breadcrumb--gradient-bg padding-top-0 padding-bottom-105" : 'padding-y-4' %>"
            aria-label="Breadcrumbs">

--- a/app/views/shared/_breadcrumbs.html.erb
+++ b/app/views/shared/_breadcrumbs.html.erb
@@ -23,20 +23,26 @@
   alt_text = session[:page_image_alt_text]
 %>
 
+<% if is_commmunity_page # only shown on mobile width %>
+  <button type="button" id="communitySubnavBtn" class="nav-container tablet:display-none desktop:display-none padding-y-2 padding-x-2" aria-controls="community-subnav" aria-expanded="false">
+        <span>VA Immersive</span>
+        <i class="text-align-right fa fa-plus"></i>
+  </button>
+<% end %>
 <section class="<%= 'dm-gradient-banner' if heading.present? %><%= ' gradient-banner-with-image' if page_image.present? %> <%= classes if classes.present? %>">
   <div class="grid-container <%= 'padding-top-2 padding-bottom-8' if is_commmunity_page %> <%= 'padding-y-4 desktop:padding-y-8' if heading.present? && !is_commmunity_page %>">
     <% if is_commmunity_page %>
-    <nav id="community-subnav" class="font-sans-lg" aria-label="Community subnavigation">
-      <ul class="padding-x-0 padding-bottom-8 flex-row display-none tablet:display-flex">
-        <li class=""><a href="/communities/<%= community_name %>/">Community</a></li>
-        <li class=""><a href="/communities/<%= community_name %>/about">About</a></li>
-        <li class=""><a href="/communities/<%= community_name %>/innovations">Innovations</a></li>
-        <li class=""><a href="/communities/<%= community_name %>/events-and-news">Events and News</a></li>
-        <li class=""><a href="/communities/<%= community_name %>/getting-started">Getting Started</a></li>
-        <li class=""><a href="/communities/<%= community_name %>/publications">Publications</a></li>
-      </ul>
-    </nav>
-    <% elsif breadcrumbs.present? %>
+      <nav id="community-subnav" class="font-sans-lg" aria-label="Community subnavigation">
+        <ul class="padding-x-0 padding-bottom-8 display-none flex-row tablet:display-flex">
+          <li class=""><a href="/communities/<%= community_name %>/">Community</a></li>
+          <li class=""><a href="/communities/<%= community_name %>/about">About</a></li>
+          <li class=""><a href="/communities/<%= community_name %>/innovations">Innovations</a></li>
+          <li class=""><a href="/communities/<%= community_name %>/events-and-news">Events and News</a></li>
+          <li class=""><a href="/communities/<%= community_name %>/getting-started">Getting Started</a></li>
+          <li class=""><a href="/communities/<%= community_name %>/publications">Publications</a></li>
+        </ul>
+      </nav>
+    <% elsif breadcrumbs.present? # use breadcrumbs on non-community pages %>
       <div id="breadcrumbs"
            class="grid-col-auto usa-breadcrumb breadcrumbs-container <%= heading.present? ? "dm-breadcrumb--gradient-bg padding-top-0 padding-bottom-105" : 'padding-y-4' %>"
            aria-label="Breadcrumbs">

--- a/app/views/shared/_breadcrumbs.html.erb
+++ b/app/views/shared/_breadcrumbs.html.erb
@@ -33,13 +33,22 @@
   <div class="grid-container <%= 'padding-top-2 padding-bottom-8' if is_commmunity_page %> <%= 'padding-y-4 desktop:padding-y-8' if heading.present? && !is_commmunity_page %>">
     <% if is_commmunity_page %>
       <nav id="community-subnav" class="font-sans-lg" aria-label="Community subnavigation">
-        <ul class="padding-x-0 padding-bottom-8 display-none flex-row tablet:display-flex">
+        <ul class="padding-x-0 padding-bottom-2 display-none tablet:padding-bottom-8 desktop:tablet:padding-bottom-8 flex-row tablet:display-flex">
           <li class=""><a href="/communities/<%= community_name %>/">Community</a></li>
-          <li class=""><a href="/communities/<%= community_name %>/about">About</a></li>
-          <li class=""><a href="/communities/<%= community_name %>/innovations">Innovations</a></li>
-          <li class=""><a href="/communities/<%= community_name %>/events-and-news">Events and News</a></li>
-          <li class=""><a href="/communities/<%= community_name %>/getting-started">Getting Started</a></li>
-          <li class=""><a href="/communities/<%= community_name %>/publications">Publications</a></li>
+          <% subpages = {
+            "About": "about",
+            "Innovations": "innovations",
+            "Events and News": "events-and-news",
+            "Getting Started": "getting-started",
+            "Publications": "publications"
+          } %>
+          <% subpages.each do |title,slug| %>
+            <li>
+              <a href="/communities/<%= community_name%>/<%= slug %>" class="<%= "current-page" if params["page_slug"] == slug %>">
+                <%= title %>
+              </a>
+            </li>
+          <% end %>
         </ul>
       </nav>
     <% elsif breadcrumbs.present? # use breadcrumbs on non-community pages %>

--- a/spec/features/shared/breadcrumbs_spec.rb
+++ b/spec/features/shared/breadcrumbs_spec.rb
@@ -294,13 +294,5 @@ describe 'Breadcrumbs', type: :feature do
       visit '/programming/home'
       expect(page).to_not have_css('#breadcrumbs')
     end
-
-    it 'provides a single breadcrumb for /communities subpages' do
-      visit '/communities/xr-network/test-page'
-      expect(page).to have_css('#breadcrumbs', visible: true)
-      expect(page).to have_css('.usa-breadcrumb__link', text: @community_page_group.name)
-      expect(page).to have_link(href: '/communities/xr-network')
-      expect(page).not_to have_css('.usa-breadcrumb__link', text: @community_sub_page.title)
-    end
   end
 end


### PR DESCRIPTION
### JIRA issue link
[DM-4509](https://agile6.atlassian.net/browse/DM-4509) / [DM-4527](https://agile6.atlassian.net/browse/DM-4527)

## Description - what does this code do?
- Adds subnavigation links to the PageBuilder pages that are part of a whitelisted community `PageGroup`.
- Subnav links are hidden in a toggle when in mobile widths

## Testing done - how did you test it/steps on how can another person can test it 
1. Log in as an admin
1. In `/admin/page_groups` create a page group named `va-immersive`
1. Create a page and add it to the `va-immersive` community
1. Go to the page and confirm that the hardcoded subpages are rendered
1. Reduce window size to mobile. Confirm that a toggle menu button appears above the page's blue banner. 
1. Open and close the menu
1. check that the rendered link slugs match their title

## Screenshots, Gifs, Videos from application (if applicable)
### Mobile
![Screenshot 2024-03-20 at 12 31 36 PM](https://github.com/department-of-veterans-affairs/diffusion-marketplace/assets/5402927/9e6c4e70-36a6-454e-bbd0-e585c220763f)
![Screenshot 2024-03-20 at 12 31 29 PM](https://github.com/department-of-veterans-affairs/diffusion-marketplace/assets/5402927/3480a9a0-fc56-4702-89b9-895e6c83c287)

### Tablet and desktop
<img width="1387" alt="subnav-centered" src="https://github.com/department-of-veterans-affairs/diffusion-marketplace/assets/5402927/8d3a512c-a5b1-4c5d-8296-375b2fae8f7f">


## Link to mock-ups/mock ups (image file if you have it) (if applicable)
https://agile6.atlassian.net/browse/DM-4509

