### PR TITLE
DM-4552: Allow innovation editors to hide their contact info from public users

### DIFF
--- a/app/controllers/practices_controller.rb
+++ b/app/controllers/practices_controller.rb
@@ -578,7 +578,7 @@ class PracticesController < ApplicationController # rubocop:disable Metrics/Clas
   def practice_params
     params.require(:practice).permit(:need_training, :tagline, :process, :it_required, :need_new_license, :description, :name, :initiating_facility, :summary, :origin_title, :origin_story, :cost_to_implement_aggregate, :sustainability_aggregate, :veteran_satisfaction_aggregate, :difficulty_aggregate, :date_initiated,
                                      :number_adopted, :number_departments, :number_failed, :implementation_time_estimate, :implementation_time_estimate_description, :implentation_summary, :implentation_fte,
-                                     :training_provider, :training_length, :training_test, :training_provider_role, :required_training_summary, :support_network_email,
+                                     :training_provider, :training_length, :training_test, :training_provider_role, :required_training_summary, :private_contact_info, :support_network_email,
                                      :initiating_facility_type, :initiating_department_office_id,
                                      :main_display_image, :main_display_image_alt_text, :crop_x, :crop_y, :crop_h, :crop_w,
                                      :tagline, :delete_main_display_image,

--- a/app/views/practices/form/about.html.erb
+++ b/app/views/practices/form/about.html.erb
@@ -115,6 +115,10 @@
               </p>
 
               <div class="grid-col-7 main-practice-email-container">
+                <div class=" margin-bottom-3">
+                  <%= f.check_box :private_contact_info, { class: ''}, 'true', 'false' %>
+                  <%= f.label :private_contact_info, 'Hide contact info from public users', class:'margin-left-1'%>
+                </div>
                 <%= f.label :support_network_email, 'Main email address', class: 'usa-label line-height-26 margin-top-0 main-practice-email-label' %>
                 <%= f.text_field :support_network_email, class: 'usa-input practice-input width-tablet main-practice-email-input margin-bottom-2 dm-required-field', required: @practice.published %>
               </div>

--- a/app/views/practices/show/contact/_contact.html.erb
+++ b/app/views/practices/show/contact/_contact.html.erb
@@ -23,15 +23,17 @@
       </div>
 
       <!--Email-->
-      <%
-        main_email = @practice.support_network_email
-        practice_emails = @practice.practice_emails
-      %>
-      <% if main_email.present? %>
-        <h2 id="email" class="font-sans-lg text-bold margin-top-5 margin-bottom-1 line-height-25px">Email</h2>
-        <p class="line-height-26 margin-bottom-0 main-email-address-container">
-          Email <%= mail_to main_email, main_email, cc: practice_emails.map(&:address).join(', '), class: 'usa-link usa-link--external dm-email-practice', 'aria-label': "Email #{main_email}", data: {practice_id: @practice.id} %> with questions about this innovation.
-        </p>
+      <% if (@practice.private_contact_info == true && current_user.present?) || @practice.private_contact_info == false %>
+        <%
+          main_email = @practice.support_network_email
+          practice_emails = @practice.practice_emails
+        %>
+        <% if main_email.present? %>
+          <h2 id="email" class="font-sans-lg text-bold margin-top-5 margin-bottom-1 line-height-25px">Email</h2>
+          <p class="line-height-26 margin-bottom-0 main-email-address-container">
+            Email <%= mail_to main_email, main_email, cc: practice_emails.map(&:address).join(', '), class: 'usa-link usa-link--external dm-email-practice', 'aria-label': "Email #{main_email}", data: {practice_id: @practice.id} %> with questions about this innovation.
+          </p>
+        <% end %>
       <% end %>
     </div>
   </div>

--- a/app/views/practices/show/contact/_contact.html.erb
+++ b/app/views/practices/show/contact/_contact.html.erb
@@ -23,7 +23,7 @@
       </div>
 
       <!--Email-->
-      <% if (@practice.private_contact_info == true && current_user.present?) || @practice.private_contact_info == false %>
+      <% unless @practice.private_contact_info? && is_user_a_guest? %>
         <%
           main_email = @practice.support_network_email
           practice_emails = @practice.practice_emails

--- a/app/views/practices/show/show.html.erb
+++ b/app/views/practices/show/show.html.erb
@@ -45,7 +45,7 @@
       practice_emails = @practice.practice_emails
       cc_emails = practice_emails.map(&:address).join(', ')
     %>
-    <% if (@practice.private_contact_info == true && current_user.present?) || @practice.private_contact_info == false %>
+    <% unless @practice.private_contact_info? && is_user_a_guest? %>
       <div class="text-center margin-bottom-1">
         <%= mail_to main_email, 'Email innovation', subject: "Question about #{@practice.name}", cc: cc_emails, class: 'usa-button  width-full display-flex flex-align-center flex-justify-center
         dm-email-practice', 'aria-label': "side nav email #{main_email}", data: {practice_id: @practice.id} %>

--- a/app/views/practices/show/show.html.erb
+++ b/app/views/practices/show/show.html.erb
@@ -45,10 +45,12 @@
       practice_emails = @practice.practice_emails
       cc_emails = practice_emails.map(&:address).join(', ')
     %>
-    <div class="text-center margin-bottom-1">
-      <%= mail_to main_email, 'Email innovation', subject: "Question about #{@practice.name}", cc: cc_emails, class: 'usa-button  width-full display-flex flex-align-center flex-justify-center
-      dm-email-practice', 'aria-label': "side nav email #{main_email}", data: {practice_id: @practice.id} %>
-    </div>
+    <% if (@practice.private_contact_info == true && current_user.present?) || @practice.private_contact_info == false %>
+      <div class="text-center margin-bottom-1">
+        <%= mail_to main_email, 'Email innovation', subject: "Question about #{@practice.name}", cc: cc_emails, class: 'usa-button  width-full display-flex flex-align-center flex-justify-center
+        dm-email-practice', 'aria-label': "side nav email #{main_email}", data: {practice_id: @practice.id} %>
+      </div>
+    <% end %>
     <% if (current_user.present?) && (@practice.user_id == current_user.id || current_user.roles.any? || is_user_an_editor_for_practice(@practice, current_user)) %>
       <div class="text-center">
         <%= link_to practice_editors_path(@practice), id: 'edit-link-in-nav', class: 'usa-button usa-button--secondary width-full' do %>

--- a/db/migrate/20240320195215_add_private_contact_info_to_practices.rb
+++ b/db/migrate/20240320195215_add_private_contact_info_to_practices.rb
@@ -1,0 +1,5 @@
+class AddPrivateContactInfoToPractices < ActiveRecord::Migration[6.1]
+  def change
+    add_column :practices, :private_contact_info, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_02_16_165100) do
+ActiveRecord::Schema.define(version: 2024_03_20_195215) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -1142,6 +1142,7 @@ ActiveRecord::Schema.define(version: 2024_02_16_165100) do
     t.text "main_display_image_alt_text"
     t.integer "diffusion_histories_count", default: 0
     t.datetime "last_email_date"
+    t.boolean "private_contact_info", default: false
     t.index ["slug"], name: "index_practices_on_slug", unique: true
     t.index ["user_id"], name: "index_practices_on_user_id"
   end


### PR DESCRIPTION
### JIRA issue link
[DM-4552](https://agile6.atlassian.net/browse/DM-4552)

## Description - what does this code do?
- Allows innovation editors to hide the `Email` section from public users

## Testing done - how did you test it/steps on how can another person can test it 
1. Log in as an admin
1. In `/admin/practices`, choose an innovation and make it public
1. Go to the innovation's edit page
1. Under `About`, add a main contact email address.
1. Go to the innovation page and confirm there is an `Email` section with the listed contact
1. Go back to the editor's `About` section and select `Hide contact info from public users`
1. Go to the innovation page. Confirm there is an `Email` section with the listed contact
1. Log out. Go to the innovation page.
1. Confirm the `Email` section is hidden. Confirm there is no `Email innovation` button in the side navigation.


## Screenshots, Gifs, Videos from application (if applicable)
![Screenshot 2024-03-20 at 1 58 42 PM](https://github.com/department-of-veterans-affairs/diffusion-marketplace/assets/5402927/1dcffc9a-39dc-497d-9ed0-3d384f82ad4f)
