### PR TITLE
DM-4574: Remove Partners page from main nav

### DIFF
--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -39,11 +39,6 @@
           </a>
         </li>
         <li class="usa-nav__primary-item border-base-light">
-          <a class="margin-y-2px desktop:margin-y-0 usa-nav__link <%= 'usa-current' if request.fullpath == '/partners' %>" href="/partners">
-            <span class="text-normal desktop:text-semibold">Partners</span>
-          </a>
-        </li>
-        <li class="usa-nav__primary-item border-base-light">
           <a class="margin-y-2px desktop:margin-y-0 usa-nav__link <%= 'usa-current' if request.fullpath == '/competitions/shark-tank' %>" href="/competitions/shark-tank">
             <span class="text-normal desktop:text-semibold">Shark Tank</span>
           </a>

--- a/spec/features/shared/breadcrumbs_spec.rb
+++ b/spec/features/shared/breadcrumbs_spec.rb
@@ -89,7 +89,7 @@ describe 'Breadcrumbs', type: :feature do
     end
 
     it 'should not display breadcrumbs for the partners index' do
-      find_all("a[href='/partners']").first.click
+      visit(partners_path)
       expect(page).to_not have_css('#breadcrumbs')
     end
 
@@ -156,7 +156,7 @@ describe 'Breadcrumbs', type: :feature do
   describe 'Innovations partners' do
     it 'should show display breadcrumbs only for the show pages' do
       @user_practice.update(published: true, approved: true)
-      find("a[href='/partners']").click
+      visit(partners_path)
       click_on('Diffusion of Excellence')
       expect(page).to have_css("#breadcrumbs", visible: true)
       expect(page).to have_css('.dm-gradient-banner')

--- a/spec/features/shared/header_spec.rb
+++ b/spec/features/shared/header_spec.rb
@@ -38,8 +38,6 @@ describe 'Diffusion Marketplace header', type: :feature, js: true do
       within('header.usa-header') do
         expect(page).to have_content('About us')
         expect(page).to have_link(href: '/about')
-        expect(page).to have_content('Partners')
-        expect(page).to have_link(href: '/partners')
         expect(page).to have_content('Shark Tank')
         expect(page).to have_link(href: '/competitions/shark-tank')
         expect(page).to have_content('Your profile')
@@ -58,8 +56,6 @@ describe 'Diffusion Marketplace header', type: :feature, js: true do
       within('header.usa-header') do
         expect(page).to have_content('About us')
         expect(page).to have_link(href: '/about')
-        expect(page).to have_content('Partners')
-        expect(page).to have_link(href: '/partners')
         expect(page).to have_content('Shark Tank')
         expect(page).to have_link(href: '/competitions/shark-tank')
         expect(page).to have_content('Browse by locations')
@@ -81,13 +77,6 @@ describe 'Diffusion Marketplace header', type: :feature, js: true do
       it 'should redirect to the Shark Tank page' do
         click_on 'Shark Tank'
         expect(page).to have_current_path('/competitions/shark-tank')
-      end
-    end
-
-    context 'clicking on the Partners link' do
-      it 'should redirect to partners page' do
-        click_on 'Partners'
-        expect(page).to have_current_path('/partners')
       end
     end
 
@@ -186,8 +175,6 @@ describe 'Diffusion Marketplace header', type: :feature, js: true do
       expect(page).to have_css('.dm-navbar-search-field')
       expect(page).to have_content('About us')
       expect(page).to have_link(href: '/about')
-      expect(page).to have_content('Partners')
-      expect(page).to have_link(href: '/partners')
       expect(page).to have_content('Shark Tank')
       expect(page).to have_link(href: '/competitions/shark-tank')
       expect(page).to have_content('Your profile')


### PR DESCRIPTION
### JIRA issue link
[DM-4574](https://agile6.atlassian.net/browse/DM-4574)

## Description - what does this code do?
- Removes `Partners` page from main nav

## Screenshots, Gifs, Videos from application (if applicable)
### Before
![Screenshot 2024-03-22 at 1 54 25 PM](https://github.com/department-of-veterans-affairs/diffusion-marketplace/assets/5402927/ed347967-becb-4ae1-b726-8c97c5bbbf43)

### After
![Screenshot 2024-03-22 at 1 54 35 PM](https://github.com/department-of-veterans-affairs/diffusion-marketplace/assets/5402927/f06c553b-cd67-417a-be40-a175ff3d7410)

