### PR TITLE
DM-4574: Update navbar hover color

### DIFF
--- a/app/assets/stylesheets/dm/pages/_partials/_header.scss
+++ b/app/assets/stylesheets/dm/pages/_partials/_header.scss
@@ -76,10 +76,10 @@
 
   .usa-nav__link {
     &:hover {
-      @include u-text('primary-vivid', !important);
+      @include u-text('primary-darker');
 
       &::after {
-        @include u-bg('primary-vivid', !important);
+        @include u-bg('primary-darker');
       }
     }
   }
@@ -90,11 +90,11 @@
 
   .usa-nav__submenu-item a {
     &.usa-current {
-      @include u-text('primary-vivid', !important);
+      @include u-text('primary-darker', !important);
     }
 
     &:hover {
-      @include u-text('primary-vivid', !important);
+      @include u-text('primary-darker', !important);
     }
   }
 


### PR DESCRIPTION
### JIRA issue link
[DM-4574](https://agile6.atlassian.net/browse/DM-4575)

## Description - what does this code do?
- Banish `primary-vivid` from the homepage
- Use one of the new blues for the navbar hover

## Screenshots, Gifs, Videos from application (if applicable)
![Screenshot 2024-03-22 at 3 33 11 PM](https://github.com/department-of-veterans-affairs/diffusion-marketplace/assets/5402927/b2329f2b-0d64-4222-a3d5-401040c41fff)


