### PR TITLE
DM-4469 fix pb update silent failure

### DIFF
--- a/app/admin/pages.rb
+++ b/app/admin/pages.rb
@@ -279,7 +279,7 @@ ActiveAdmin.register Page do
         if @page.nil?
           @page = Page.create!(permitted_params[:page])
         else
-          @page.update(permitted_params[:page])
+          @page.update!(permitted_params[:page])
         end
 
         respond_to do |format|

--- a/app/admin/pages.rb
+++ b/app/admin/pages.rb
@@ -244,6 +244,7 @@ ActiveAdmin.register Page do
 
   controller do
     before_action :set_page,
+                  :delete_page_image_and_alt_text,
                   only: [:create, :update]
     rescue_from StandardError, with: :handle_standard_error
     rescue_from ActiveRecord::RecordInvalid, with: :handle_record_invalid
@@ -313,6 +314,14 @@ ActiveAdmin.register Page do
       path = action_name == 'update' ? edit_admin_page_path(@page) : new_admin_page_path
 
       redirect_to path, flash: flash
+    end
+
+    def delete_page_image_and_alt_text
+      if @page.present? && params[:page][:delete_image_and_alt_text] === '1'
+
+        params[:page][:image] = nil
+        params[:page][:image_alt_text] = nil
+      end
     end
   end
 end

--- a/app/models/page_component.rb
+++ b/app/models/page_component.rb
@@ -74,7 +74,7 @@ class PageComponent < ApplicationRecord
   private
 
   def custom_component_validation_message
-    return if component.valid?
+    return if component.nil? || component.valid?
 
     class_name = user_facing_component_name(component.class.to_s)
     error_messages = component.errors.full_messages

--- a/app/models/page_component.rb
+++ b/app/models/page_component.rb
@@ -4,6 +4,7 @@ class PageComponent < ApplicationRecord
   belongs_to :component, polymorphic: true, autosave: true
 
   accepts_nested_attributes_for :component
+  validate :custom_component_validation_message
 
   after_destroy :destroy_component
 
@@ -68,5 +69,24 @@ class PageComponent < ApplicationRecord
 
   def self.ransackable_attributes(auth_object = nil)
     ["component_id", "component_type", "created_at", "id", "page_id", "position", "updated_at"]
+  end
+
+  private
+
+  def custom_component_validation_message
+    return if component.valid?
+
+    class_name = user_facing_component_name(component.class.to_s)
+    error_messages = component.errors.full_messages
+    error_message = "PageComponent #{class_name} errors: #{error_messages}".delete('"')
+
+    errors.add(:component, error_message)
+  end
+
+  def user_facing_component_name(class_name)
+    h = COMPONENT_SELECTION
+    if h.values.include?(class_name.to_s)
+      h.key(class_name).to_s
+    end
   end
 end

--- a/spec/factories/page_block_quote_component.rb
+++ b/spec/factories/page_block_quote_component.rb
@@ -1,0 +1,10 @@
+FactoryBot.define do
+  factory :page_block_quote_component do
+    text { "<p>This is a block quote text.</p>" }
+    citation { "<p>Author Name</p>" }
+
+    after(:build) do |component|
+      component.page_component ||= build(:page_component, component: component)
+    end
+  end
+end

--- a/spec/features/admin/admin_page_spec.rb
+++ b/spec/features/admin/admin_page_spec.rb
@@ -38,7 +38,7 @@ describe 'Page Builder', type: :feature do
       select 'programming', from: 'page_page_group_id'
       save_page
 
-      expect(page).to have_content('Validation failed. Page description cannot be longer than 140 characters.')
+      expect(page).to have_content('Description is too long (maximum is 140 characters')
       expect(Page.last.slug).to_not eq('test-page-1')
       expect(Page.last.slug).to eq('test-page')
     end
@@ -51,7 +51,7 @@ describe 'Page Builder', type: :feature do
       end
       save_page
 
-      expect(page).to have_content('Validation failed. Page cannot have an optional image without alternative text.')
+      expect(page).to have_content("Image alt text can't be blank if Page image is present")
       expect(@page.image.present?).to eq(false)
     end
   end
@@ -164,6 +164,17 @@ describe 'Page Builder', type: :feature do
 
         expect(page).to have_content('Page was successfully updated.')
         expect(page).to have_text('Has border: true')
+      end
+    end
+
+    context 'Validations' do
+      it 'should indicate validation errors for page components' do
+        visit edit_admin_page_path(@page)
+        # Add a 'PageAccordionComponent' and select the border option
+        click_link('Add New Page component')
+        select('Block Quote', from: 'page_page_components_attributes_0_component_type')
+        save_page
+        expect(page).to have_content("Block Quote errors: [Text can't be blank, Citation can't be blank]")
       end
     end
   end

--- a/spec/models/page_component_spec.rb
+++ b/spec/models/page_component_spec.rb
@@ -3,6 +3,11 @@ require 'rails_helper'
 RSpec.describe PageComponent, type: :model do
   let(:component) { create(:page_header2_component) }
   let(:page_component) { create(:page_component, component: component) }
+  let(:invalid_component) { build(:page_block_quote_component, text: nil, citation: nil) } # Assumes both fields are required and being nil makes the component invalid
+
+  let(:page_component_with_invalid_component) do
+    build(:page_component, component: invalid_component)
+  end
 
   describe 'associations' do
     it { is_expected.to belong_to(:page).optional }
@@ -15,6 +20,23 @@ RSpec.describe PageComponent, type: :model do
     end
   end
 
+
+  describe 'validations' do
+    context 'with an invalid associated component' do
+      it 'is not valid' do
+        expect(page_component_with_invalid_component).not_to be_valid
+      end
+
+      it 'contains error messages from the associated component' do
+        page_component_with_invalid_component.valid? # Triggers validation
+        error_messages = page_component_with_invalid_component.errors.full_messages.to_sentence
+
+        expect(error_messages).to include("PageComponent Block Quote errors:")
+        expect(error_messages).to include("Text can't be blank", "Citation can't be blank")
+      end
+    end
+  end
+
   describe '#destroy_component' do
     it 'destroys the associated component after PageComponent is destroyed' do
       component_id = page_component.component_id
@@ -23,6 +45,23 @@ RSpec.describe PageComponent, type: :model do
       page_component.destroy
 
       expect { component_type.constantize.find(component_id) }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+  end
+
+  describe '#custom_component_validation_message' do
+    let(:invalid_component) { build(:page_block_quote_component, text: nil, citation: nil) }
+    let(:page_component_with_invalid_component) { build(:page_component, component: invalid_component) }
+
+    before do
+      page_component_with_invalid_component.valid? # Triggers validation
+    end
+
+    it 'adds custom validation error messages to the PageComponent' do
+      error_messages = page_component_with_invalid_component.errors[:component]
+
+      expect(error_messages).not_to be_empty
+      expect(error_messages.first).to include("PageComponent Block Quote errors:")
+      expect(error_messages.first).to include("Text can't be blank", "Citation can't be blank")
     end
   end
 end


### PR DESCRIPTION
### JIRA issue link
https://agile6.atlassian.net/browse/DM-4469

## Description - what does this code do?
This fix makes use of the established pattern for validation error handling for submitting a pagebuilder form. Previously, most validation errors relating the `page` or its `components` would fail silently as the user was redirected back to the top level admin show page for the `page` with no indication that their changes were not persisted due.

The main story here is the addition of `validate :custom_component_validation_message` to the `PageComponent` model which drills down into error messages generated by the `component` association, which is necessary to extract the class name of the component in order to deliver a helpful error message, via 2 new helper methods, that indicates the user-facing name of the component and the attribute issue.

This still results in a bit of a messy error message, especially when there are multiple validation errors for the submitted form, so the `controller` logic in `admin/pages` was refactored in order to rescue `ActiveRecord::Record` invalid errors so that the message can be reformatted and delivered in a concise and useful way to the user. Along with the refactor I attempted to clean up the existing logic a bit while retaining previous functionality.

## Testing done - how did you test it/steps on how can another person can test it 
1. As admin create a page and add a component that has a required field, such as a block quote
2. Submit the form with both text fields blank
3. Verify the page redirects back to the edit view and indicates the component that errored with it's specific errors within brackets (screenshot 2)
4. Repeat, adding a block quote component with blank text fields, and add another component with missing fields that are required such as an image component.
5. Verify that upon submission the page redirects back to the form with both components identified as having errors with their respective attribute errors listed (screenshot 3)
6. Repeat step 5 but this time leave some required fields blank for the page itself in addition to the components added with blank required fields
7. Verify that the components and page errors are indicated above the form after the redirect(screenshot 4)
8. Click around the form for updating and creating a page, generally making sure things behave as expected.

## Screenshots, Gifs, Videos from application (if applicable)
before (silent failure):
![Screenshot 2024-03-29 at 2 08 10 PM](https://github.com/department-of-veterans-affairs/diffusion-marketplace/assets/65036872/c8d0b5c7-c171-4bd9-b612-43c0883b7533)

after fix:
<img width="968" alt="Screenshot 2024-04-02 at 2 36 52 PM" src="https://github.com/department-of-veterans-affairs/diffusion-marketplace/assets/65036872/fb61747f-0630-45b4-b9d6-5609daee5884">

<img width="1093" alt="Screenshot 2024-04-02 at 2 40 15 PM" src="https://github.com/department-of-veterans-affairs/diffusion-marketplace/assets/65036872/5a75deb1-5a3b-42e0-a28f-354e37fc3509">

<img width="1478" alt="Screenshot 2024-04-02 at 2 56 38 PM" src="https://github.com/department-of-veterans-affairs/diffusion-marketplace/assets/65036872/ece83038-a2b1-4cc4-a83f-006e32b87df3">

## Link to mock-ups/mock ups (image file if you have it) (if applicable)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Unit tests written (if applicable)
- [ ] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating JIRA issue
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs