### PR TITLE
Clean up code around community subnav and breadcrumbs

### DIFF
--- a/app/helpers/navigation_helper.rb
+++ b/app/helpers/navigation_helper.rb
@@ -243,7 +243,7 @@ module NavigationHelper
           empty_breadcrumbs
         elsif @page_group.is_community?
           empty_breadcrumbs
-        elsif @builder_landing_page.exists?
+        elsif @builder_landing_page
           empty_breadcrumbs
           add_landing_page_breadcrumb("/#{@page_group_slug}")
           add_sub_page_breadcrumb

--- a/app/helpers/navigation_helper.rb
+++ b/app/helpers/navigation_helper.rb
@@ -235,10 +235,6 @@ module NavigationHelper
           session[:breadcrumbs] << { 'display': "#{@page_group.name}", 'path': path }
         end
 
-        def add_sub_page_breadcrumb
-          session[:breadcrumbs] << { 'display': "#{@page.title}", 'path': @builder_page_path }
-        end
-
         if @page_slug == 'home'
           empty_breadcrumbs
         elsif @page_group.is_community?

--- a/app/helpers/navigation_helper.rb
+++ b/app/helpers/navigation_helper.rb
@@ -239,9 +239,8 @@ module NavigationHelper
 
         if @page_slug == 'home'
           empty_breadcrumbs
-        elsif @page.page_group.is_community? && @builder_landing_page.exists?
+        elsif @page.page_group.is_community?
           empty_breadcrumbs
-          add_landing_page_breadcrumb("/communities/#{params[:page_group_friendly_id]}")
         elsif @builder_landing_page.exists?
           empty_breadcrumbs
           add_landing_page_breadcrumb("/#{params[:page_group_friendly_id]}")

--- a/app/helpers/navigation_helper.rb
+++ b/app/helpers/navigation_helper.rb
@@ -225,10 +225,11 @@ module NavigationHelper
     if controller == 'page'
       if action == 'show'
         @page_slug = params[:page_slug] ? params[:page_slug] : 'home'
-        @page_group = PageGroup.find_by(slug: params[:page_group_friendly_id])
+        @page_group_slug = params[:page_group_friendly_id]
+        @page_group = PageGroup.find_by(slug: @page_group_slug)
         @page = Page.find_by(slug: @page_slug, page_group: @page_group.id)
         @builder_landing_page = @page_group.landing_page
-        @builder_page_path = "/#{@page_group.slug}/#{@page_slug}"
+        @builder_page_path = "/#{@page_group_slug}/#{@page_slug}"
 
         def add_landing_page_breadcrumb(path)
           session[:breadcrumbs] << { 'display': "#{@page_group.name}", 'path': path }
@@ -242,10 +243,9 @@ module NavigationHelper
           empty_breadcrumbs
         elsif @page_group.is_community?
           empty_breadcrumbs
-        elsif @builder_landing_page
+        elsif @builder_landing_page.present?
           empty_breadcrumbs
           add_landing_page_breadcrumb("/#{@page_group_slug}")
-          add_sub_page_breadcrumb
         else
           empty_breadcrumbs
         end

--- a/app/helpers/navigation_helper.rb
+++ b/app/helpers/navigation_helper.rb
@@ -225,11 +225,10 @@ module NavigationHelper
     if controller == 'page'
       if action == 'show'
         @page_slug = params[:page_slug] ? params[:page_slug] : 'home'
-        @page_group_slug = params[:page_group_friendly_id]
-        @page = Page.includes(:page_group).find_by(slug: @page_slug.downcase, page_groups: {slug: @page_group_slug.downcase}) || nil
-        @page_group = @page.page_group
-        @builder_landing_page = @page_group.landing_page || nil
-        @builder_page_path = "/#{@page_group_slug}/#{@page_slug}"
+        @page_group = PageGroup.find_by(slug: params[:page_group_friendly_id])
+        @page = Page.find_by(slug: @page_slug, page_group: @page_group.id)
+        @builder_landing_page = @page_group.landing_page
+        @builder_page_path = "/#{@page_group.slug}/#{@page_slug}"
 
         def add_landing_page_breadcrumb(path)
           session[:breadcrumbs] << { 'display': "#{@page_group.name}", 'path': path }

--- a/app/helpers/navigation_helper.rb
+++ b/app/helpers/navigation_helper.rb
@@ -225,12 +225,14 @@ module NavigationHelper
     if controller == 'page'
       if action == 'show'
         @page_slug = params[:page_slug] ? params[:page_slug] : 'home'
-        @page = Page.includes(:page_group).find_by(slug: @page_slug.downcase, page_groups: {slug: params[:page_group_friendly_id].downcase}) || nil
-        @builder_landing_page = Page.where(slug: 'home', page_group_id: @page.page_group_id) || nil
-        @builder_page_path = "/#{params[:page_group_friendly_id]}/#{@page_slug}"
+        @page_group_slug = params[:page_group_friendly_id]
+        @page = Page.includes(:page_group).find_by(slug: @page_slug.downcase, page_groups: {slug: @page_group_slug.downcase}) || nil
+        @page_group = @page.page_group
+        @builder_landing_page = @page_group.landing_page || nil
+        @builder_page_path = "/#{@page_group_slug}/#{@page_slug}"
 
         def add_landing_page_breadcrumb(path)
-          session[:breadcrumbs] << { 'display': "#{@page.page_group.name}", 'path': path }
+          session[:breadcrumbs] << { 'display': "#{@page_group.name}", 'path': path }
         end
 
         def add_sub_page_breadcrumb
@@ -239,11 +241,11 @@ module NavigationHelper
 
         if @page_slug == 'home'
           empty_breadcrumbs
-        elsif @page.page_group.is_community?
+        elsif @page_group.is_community?
           empty_breadcrumbs
         elsif @builder_landing_page.exists?
           empty_breadcrumbs
-          add_landing_page_breadcrumb("/#{params[:page_group_friendly_id]}")
+          add_landing_page_breadcrumb("/#{@page_group_slug}")
           add_sub_page_breadcrumb
         else
           empty_breadcrumbs

--- a/app/models/page_group.rb
+++ b/app/models/page_group.rb
@@ -36,6 +36,10 @@ class PageGroup < ApplicationRecord
     COMMUNITIES.include?(self.name)
   end
 
+  def landing_page
+    Page.find_by(page_group_id: self.id, slug: 'home')
+  end
+
   def self.ransackable_attributes(auth_object = nil)
     ["created_at", "description", "id", "name", "slug", "updated_at", "pages_id"]
   end

--- a/app/models/page_group.rb
+++ b/app/models/page_group.rb
@@ -41,7 +41,12 @@ class PageGroup < ApplicationRecord
   end
 
   def subnav_hash
-    published_pages = self.pages.filter { |page| page.published? }.pluck("slug")
+    return nil if self.pages.empty?
+    if self.landing_page&.published? # Use all pages when community homepage has not been published
+      subpages = self.pages.filter { |page| page.published? }.pluck("slug")
+    else # Only show published subnav pages when homepage has been published
+      subpages = self.pages.pluck("slug")
+    end
     # TODO: replace hash with PageBuilder UI supplied info
     approved_subpages =  { # Use hardcoded titles for nav because of mismatch with actual page names
       "Community": "home",
@@ -51,7 +56,8 @@ class PageGroup < ApplicationRecord
       "Getting Started": "getting-started",
       "Publications": "publications"
     }
-    existing_pages = approved_subpages.filter {|k,v| published_pages.include?(v)}
+
+    approved_subpages.filter {|k,v| subpages.include?(v)}
   end
 
   def self.ransackable_attributes(auth_object = nil)

--- a/app/models/page_group.rb
+++ b/app/models/page_group.rb
@@ -40,6 +40,20 @@ class PageGroup < ApplicationRecord
     Page.find_by(page_group_id: self.id, slug: 'home')
   end
 
+  def subnav_hash
+    published_pages = self.pages.filter { |page| page.published? }.pluck("slug")
+    # TODO: replace hash with PageBuilder UI supplied info
+    approved_subpages =  { # Use hardcoded titles for nav because of mismatch with actual page names
+      "Community": "home",
+      "About": "about",
+      "Innovations": "innovations",
+      "Events and News": "events-and-news",
+      "Getting Started": "getting-started",
+      "Publications": "publications"
+    }
+    existing_pages = approved_subpages.filter {|k,v| published_pages.include?(v)}
+  end
+
   def self.ransackable_attributes(auth_object = nil)
     ["created_at", "description", "id", "name", "slug", "updated_at", "pages_id"]
   end

--- a/app/views/page/_community_subnav.html.erb
+++ b/app/views/page/_community_subnav.html.erb
@@ -2,7 +2,6 @@
   <ul class="padding-x-0 padding-bottom-2 display-none tablet:padding-bottom-8 desktop:tablet:padding-bottom-8 flex-row tablet:display-flex">
     <li class=""><a href="/communities/<%= community_slug %>/">Community</a></li>
     <%
-      community = PageGroup.find_by(slug: community_slug)
       # TODO: replace hardcoded list with PageBuilder UI
       subpages = { # Use hardcoded titles for nav because of mismatch with actual page names
       "About": "about",

--- a/app/views/page/_community_subnav.html.erb
+++ b/app/views/page/_community_subnav.html.erb
@@ -1,0 +1,19 @@
+<nav id="community-subnav" class="font-sans-lg" aria-label="Community subnavigation">
+  <ul class="padding-x-0 padding-bottom-2 display-none tablet:padding-bottom-8 desktop:tablet:padding-bottom-8 flex-row tablet:display-flex">
+    <li class=""><a href="/communities/<%= community_slug %>/">Community</a></li>
+    <% subpages = {
+      "About": "about",
+      "Innovations": "innovations",
+      "Events and News": "events-and-news",
+      "Getting Started": "getting-started",
+      "Publications": "publications"
+    } %>
+    <% subpages.each do |title, page_slug| %>
+      <li>
+        <a href="/communities/<%= community_slug%>/<%= page_slug %>" class="<%= "current-page" if params["page_slug"] == page_slug %>">
+          <%= title %>
+        </a>
+      </li>
+    <% end %>
+  </ul>
+</nav>

--- a/app/views/page/_community_subnav.html.erb
+++ b/app/views/page/_community_subnav.html.erb
@@ -1,19 +1,9 @@
 <nav id="community-subnav" class="font-sans-lg" aria-label="Community subnavigation">
   <ul class="padding-x-0 padding-bottom-2 display-none tablet:padding-bottom-8 desktop:tablet:padding-bottom-8 flex-row tablet:display-flex">
-    <li class=""><a href="/communities/<%= community_slug %>/">Community</a></li>
-    <%
-      # TODO: replace hardcoded list with PageBuilder UI
-      subpages = { # Use hardcoded titles for nav because of mismatch with actual page names
-      "About": "about",
-      "Innovations": "innovations",
-      "Events and News": "events-and-news",
-      "Getting Started": "getting-started",
-      "Publications": "publications"
-    } %>
-    <% subpages.each do |title, page_slug| %>
-      <% next unless Page.find_by(page_group_id: community.id, slug: page_slug) %>
+    <% subnav_hash.each do |title, page_slug| %>
+      <% break if @page_group.subnav_hash.length == 1 %>
       <li>
-        <a href="/communities/<%= community_slug%>/<%= page_slug %>" class="<%= "current-page" if params["page_slug"] == page_slug %>">
+        <a href="/communities/<%= @page_group_slug %>/<%= page_slug %>" class="<%= "current-page" if params["page_slug"] == page_slug %>">
           <%= title %>
         </a>
       </li>

--- a/app/views/page/_community_subnav.html.erb
+++ b/app/views/page/_community_subnav.html.erb
@@ -1,7 +1,10 @@
 <nav id="community-subnav" class="font-sans-lg" aria-label="Community subnavigation">
   <ul class="padding-x-0 padding-bottom-2 display-none tablet:padding-bottom-8 desktop:tablet:padding-bottom-8 flex-row tablet:display-flex">
     <li class=""><a href="/communities/<%= community_slug %>/">Community</a></li>
-    <% subpages = {
+    <%
+      community = PageGroup.find_by(slug: community_slug)
+      # TODO: replace hardcoded list with PageBuilder UI
+      subpages = { # Use hardcoded titles for nav because of mismatch with actual page names
       "About": "about",
       "Innovations": "innovations",
       "Events and News": "events-and-news",
@@ -9,6 +12,7 @@
       "Publications": "publications"
     } %>
     <% subpages.each do |title, page_slug| %>
+      <% next unless Page.find_by(page_group_id: community.id, slug: page_slug) %>
       <li>
         <a href="/communities/<%= community_slug%>/<%= page_slug %>" class="<%= "current-page" if params["page_slug"] == page_slug %>">
           <%= title %>

--- a/app/views/page/_community_subnav_mobile.html.erb
+++ b/app/views/page/_community_subnav_mobile.html.erb
@@ -1,4 +1,4 @@
 <button type="button" id="communitySubnavBtn" class="nav-container tablet:display-none desktop:display-none padding-y-2 padding-x-2" aria-controls="community-subnav" aria-expanded="false">
-        <span>VA Immersive</span>
+        <span><%= PageGroup.find_by(slug: community_slug).name %></span>
         <i class="text-align-right fa fa-plus"></i>
 </button>

--- a/app/views/page/_community_subnav_mobile.html.erb
+++ b/app/views/page/_community_subnav_mobile.html.erb
@@ -1,4 +1,4 @@
 <button type="button" id="communitySubnavBtn" class="nav-container tablet:display-none desktop:display-none padding-y-2 padding-x-2" aria-controls="community-subnav" aria-expanded="false">
-        <span><%= PageGroup.find_by(slug: community_slug).name %></span>
+        <span><%= @page_group.name %></span>
         <i class="text-align-right fa fa-plus"></i>
 </button>

--- a/app/views/page/_community_subnav_mobile.html.erb
+++ b/app/views/page/_community_subnav_mobile.html.erb
@@ -1,0 +1,4 @@
+<button type="button" id="communitySubnavBtn" class="nav-container tablet:display-none desktop:display-none padding-y-2 padding-x-2" aria-controls="community-subnav" aria-expanded="false">
+        <span>VA Immersive</span>
+        <i class="text-align-right fa fa-plus"></i>
+</button>

--- a/app/views/shared/_breadcrumbs.html.erb
+++ b/app/views/shared/_breadcrumbs.html.erb
@@ -16,21 +16,42 @@
     breadcrumbs.pop
   end
 
-  if controller === 'page'
-    is_commmunity_page = @page_group.is_community?
-  end
   page_image = session[:page_image]
   alt_text = session[:page_image_alt_text]
 %>
 
-<% if is_commmunity_page # only shown on mobile width %>
+<% if @page_group.is_community? # only shown on mobile width %>
   <%= render "page/community_subnav_mobile", community_slug: @page_group_slug %>
-<% end %>
+  <section class="<%= 'dm-gradient-banner' if heading.present? %><%= ' gradient-banner-with-image' if page_image.present? %> <%= classes if classes.present? %>">
+    <div class="grid-container padding-top-2 padding-bottom-8">
+        <%= render "page/community_subnav", subnav_hash: @page_group.subnav_hash %>
+      <% if heading.present? %>
+        <div class="dm-breadcrumb-heading grid-row grid-gap-3">
+          <div class="grid-col-12<%= ' desktop:grid-col-7' if page_image.present? %>">
+            <h1 class="usa-prose-h1 margin-top-0 margin-bottom-4 text-white grid-col-12">
+              <%= heading %>
+            </h1>
+            <% if description.present? %>
+              <p class="dm-heading-description font-sans-lg <%= page_image.present? ? ' grid-col-12' : ' grid-col-10' %> text-white dm-word-break-break-word hyphens-auto">
+                <%= description %>
+              </p>
+            <% end %>
+          </div>
+          <% if page_image.present? %>
+            <div class="page-image-column desktop:grid-col-5">
+              <div class="page-image-container">
+                <img src="<%= page_image %>" alt="<%= alt_text %>" class="height-full width-full"/>
+              </div>
+            </div>
+          <% end %>
+        </div>
+      <% end %>
+    </div>
+  </section>
+<% else %>
 <section class="<%= 'dm-gradient-banner' if heading.present? %><%= ' gradient-banner-with-image' if page_image.present? %> <%= classes if classes.present? %>">
-  <div class="grid-container <%= 'padding-top-2 padding-bottom-8' if is_commmunity_page %> <%= 'padding-y-4 desktop:padding-y-8' if heading.present? && !is_commmunity_page %>">
-    <% if is_commmunity_page %>
-      <%= render "page/community_subnav", subnav_hash: @page_group.subnav_hash %>
-    <% elsif breadcrumbs.present? # use breadcrumbs on non-community pages %>
+  <div class="grid-container <%= 'padding-y-4 desktop:padding-y-8' if heading.present? && !is_commmunity_page %>">
+    <% if breadcrumbs.present? %>
       <div id="breadcrumbs"
            class="grid-col-auto usa-breadcrumb breadcrumbs-container <%= heading.present? ? "dm-breadcrumb--gradient-bg padding-top-0 padding-bottom-105" : 'padding-y-4' %>"
            aria-label="Breadcrumbs">
@@ -78,3 +99,4 @@
     <% end %>
   </div>
 </section>
+<% end %>

--- a/app/views/shared/_breadcrumbs.html.erb
+++ b/app/views/shared/_breadcrumbs.html.erb
@@ -20,7 +20,7 @@
   alt_text = session[:page_image_alt_text]
 %>
 
-<% if @page_group.is_community? # only shown on mobile width %>
+<% if @page_group&.is_community? # only shown on mobile width %>
   <%= render partial: "page/community_subnav_mobile", locals: { community_slug: @page_group_slug } %>
   <section class="<%= 'dm-gradient-banner' if heading.present? %><%= ' gradient-banner-with-image' if page_image.present? %> <%= classes if classes.present? %>">
     <div class="grid-container padding-top-2 padding-bottom-8">

--- a/app/views/shared/_breadcrumbs.html.erb
+++ b/app/views/shared/_breadcrumbs.html.erb
@@ -17,9 +17,7 @@
   end
 
   if controller === 'page'
-    is_page_builder_page = true
-    community_slug = params["page_group_friendly_id"]
-    is_commmunity_page = PageGroup.find_by(slug: community_slug).is_community? 
+    is_commmunity_page = @page_group.is_community?
   end
   page_image = session[:page_image]
   alt_text = session[:page_image_alt_text]
@@ -31,7 +29,7 @@
 <section class="<%= 'dm-gradient-banner' if heading.present? %><%= ' gradient-banner-with-image' if page_image.present? %> <%= classes if classes.present? %>">
   <div class="grid-container <%= 'padding-top-2 padding-bottom-8' if is_commmunity_page %> <%= 'padding-y-4 desktop:padding-y-8' if heading.present? && !is_commmunity_page %>">
     <% if is_commmunity_page %>
-      <%= render "page/community_subnav", community_slug: @page_group_slug %>
+      <%= render "page/community_subnav", subnav_hash: @page_group.subnav_hash %>
     <% elsif breadcrumbs.present? # use breadcrumbs on non-community pages %>
       <div id="breadcrumbs"
            class="grid-col-auto usa-breadcrumb breadcrumbs-container <%= heading.present? ? "dm-breadcrumb--gradient-bg padding-top-0 padding-bottom-105" : 'padding-y-4' %>"
@@ -45,7 +43,7 @@
               breadcrumb_display = is_same_path ? 'Home' : breadcrumbs.first['display'] || breadcrumbs.first[:display]
               breadcrumb_display.upcase if heading.present?
             %>
-            <li class="usa-breadcrumb__list-item<%= ' page-builder-breadcrumb position-static' if is_page_builder_page %>">
+            <li class="usa-breadcrumb__list-item<%= ' page-builder-breadcrumb position-static' if @page %>">
               <i class='fas fa-arrow-left margin-right-05 <%= heading.present? ? 'text-white' : 'text-gray-50' %>'></i>
               <%= link_to(breadcrumb_display, breadcrumb_path, class: 'usa-breadcrumb__link padding-left-05 font-sans-sm') %>
             </li>

--- a/app/views/shared/_breadcrumbs.html.erb
+++ b/app/views/shared/_breadcrumbs.html.erb
@@ -21,36 +21,23 @@
 %>
 
 <% if @page_group.is_community? # only shown on mobile width %>
-  <%= render "page/community_subnav_mobile", community_slug: @page_group_slug %>
+  <%= render partial: "page/community_subnav_mobile", locals: { community_slug: @page_group_slug } %>
   <section class="<%= 'dm-gradient-banner' if heading.present? %><%= ' gradient-banner-with-image' if page_image.present? %> <%= classes if classes.present? %>">
     <div class="grid-container padding-top-2 padding-bottom-8">
-        <%= render "page/community_subnav", subnav_hash: @page_group.subnav_hash %>
-      <% if heading.present? %>
-        <div class="dm-breadcrumb-heading grid-row grid-gap-3">
-          <div class="grid-col-12<%= ' desktop:grid-col-7' if page_image.present? %>">
-            <h1 class="usa-prose-h1 margin-top-0 margin-bottom-4 text-white grid-col-12">
-              <%= heading %>
-            </h1>
-            <% if description.present? %>
-              <p class="dm-heading-description font-sans-lg <%= page_image.present? ? ' grid-col-12' : ' grid-col-10' %> text-white dm-word-break-break-word hyphens-auto">
-                <%= description %>
-              </p>
-            <% end %>
-          </div>
-          <% if page_image.present? %>
-            <div class="page-image-column desktop:grid-col-5">
-              <div class="page-image-container">
-                <img src="<%= page_image %>" alt="<%= alt_text %>" class="height-full width-full"/>
-              </div>
-            </div>
-          <% end %>
-        </div>
-      <% end %>
+        <%= render partial: "page/community_subnav", locals: { subnav_hash: @page_group.subnav_hash } %>
+        <%= render partial: 'shared/page_heading_banner',
+          locals: {
+            heading: heading,
+            description: description,
+            page_image: page_image,
+            alt_text: alt_text
+          }
+        %>
     </div>
   </section>
 <% else %>
 <section class="<%= 'dm-gradient-banner' if heading.present? %><%= ' gradient-banner-with-image' if page_image.present? %> <%= classes if classes.present? %>">
-  <div class="grid-container <%= 'padding-y-4 desktop:padding-y-8' if heading.present? && !is_commmunity_page %>">
+  <div class="grid-container <%= 'padding-y-4 desktop:padding-y-8' if heading.present? %>">
     <% if breadcrumbs.present? %>
       <div id="breadcrumbs"
            class="grid-col-auto usa-breadcrumb breadcrumbs-container <%= heading.present? ? "dm-breadcrumb--gradient-bg padding-top-0 padding-bottom-105" : 'padding-y-4' %>"
@@ -76,27 +63,14 @@
         </ol>
       </div>
     <% end %>
-    <% if heading.present? %>
-      <div class="dm-breadcrumb-heading grid-row grid-gap-3">
-        <div class="grid-col-12<%= ' desktop:grid-col-7' if page_image.present? %>">
-          <h1 class="usa-prose-h1 margin-top-0 margin-bottom-4 text-white grid-col-12">
-            <%= heading %>
-          </h1>
-          <% if description.present? %>
-            <p class="dm-heading-description font-sans-lg <%= page_image.present? ? ' grid-col-12' : ' grid-col-10' %> text-white dm-word-break-break-word hyphens-auto">
-              <%= description %>
-            </p>
-          <% end %>
-        </div>
-        <% if page_image.present? %>
-          <div class="page-image-column desktop:grid-col-5">
-            <div class="page-image-container">
-              <img src="<%= page_image %>" alt="<%= alt_text %>" class="height-full width-full"/>
-            </div>
-          </div>
-        <% end %>
-      </div>
-    <% end %>
+    <%= render partial: 'shared/page_heading_banner',
+          locals: {
+            heading: heading,
+            description: description,
+            page_image: page_image,
+            alt_text: alt_text
+          }
+    %>
   </div>
 </section>
 <% end %>

--- a/app/views/shared/_breadcrumbs.html.erb
+++ b/app/views/shared/_breadcrumbs.html.erb
@@ -16,18 +16,17 @@
     breadcrumbs.pop
   end
 
-  is_page_builder_page = controller === 'page'
-  is_commmunity_page = is_page_builder_page && PageGroup.where(slug: params["page_group_friendly_id"]).first.is_community? 
-  community_slug = params["page_group_friendly_id"]
+  if controller === 'page'
+    is_page_builder_page = true
+    community_slug = params["page_group_friendly_id"]
+    is_commmunity_page = PageGroup.find_by(slug: community_slug).is_community? 
+  end
   page_image = session[:page_image]
   alt_text = session[:page_image_alt_text]
 %>
 
 <% if is_commmunity_page # only shown on mobile width %>
-  <button type="button" id="communitySubnavBtn" class="nav-container tablet:display-none desktop:display-none padding-y-2 padding-x-2" aria-controls="community-subnav" aria-expanded="false">
-        <span>VA Immersive</span>
-        <i class="text-align-right fa fa-plus"></i>
-  </button>
+  <%= render "page/community_subnav_mobile" %>
 <% end %>
 <section class="<%= 'dm-gradient-banner' if heading.present? %><%= ' gradient-banner-with-image' if page_image.present? %> <%= classes if classes.present? %>">
   <div class="grid-container <%= 'padding-top-2 padding-bottom-8' if is_commmunity_page %> <%= 'padding-y-4 desktop:padding-y-8' if heading.present? && !is_commmunity_page %>">

--- a/app/views/shared/_breadcrumbs.html.erb
+++ b/app/views/shared/_breadcrumbs.html.erb
@@ -26,12 +26,12 @@
 %>
 
 <% if is_commmunity_page # only shown on mobile width %>
-  <%= render "page/community_subnav_mobile", community_slug: community_slug %>
+  <%= render "page/community_subnav_mobile", community_slug: @page_group_slug %>
 <% end %>
 <section class="<%= 'dm-gradient-banner' if heading.present? %><%= ' gradient-banner-with-image' if page_image.present? %> <%= classes if classes.present? %>">
   <div class="grid-container <%= 'padding-top-2 padding-bottom-8' if is_commmunity_page %> <%= 'padding-y-4 desktop:padding-y-8' if heading.present? && !is_commmunity_page %>">
     <% if is_commmunity_page %>
-      <%= render "page/community_subnav", community_slug: community_slug %>
+      <%= render "page/community_subnav", community_slug: @page_group_slug %>
     <% elsif breadcrumbs.present? # use breadcrumbs on non-community pages %>
       <div id="breadcrumbs"
            class="grid-col-auto usa-breadcrumb breadcrumbs-container <%= heading.present? ? "dm-breadcrumb--gradient-bg padding-top-0 padding-bottom-105" : 'padding-y-4' %>"

--- a/app/views/shared/_breadcrumbs.html.erb
+++ b/app/views/shared/_breadcrumbs.html.erb
@@ -26,7 +26,7 @@
 %>
 
 <% if is_commmunity_page # only shown on mobile width %>
-  <%= render "page/community_subnav_mobile" %>
+  <%= render "page/community_subnav_mobile", community_slug: community_slug %>
 <% end %>
 <section class="<%= 'dm-gradient-banner' if heading.present? %><%= ' gradient-banner-with-image' if page_image.present? %> <%= classes if classes.present? %>">
   <div class="grid-container <%= 'padding-top-2 padding-bottom-8' if is_commmunity_page %> <%= 'padding-y-4 desktop:padding-y-8' if heading.present? && !is_commmunity_page %>">

--- a/app/views/shared/_breadcrumbs.html.erb
+++ b/app/views/shared/_breadcrumbs.html.erb
@@ -18,7 +18,7 @@
 
   is_page_builder_page = controller === 'page'
   is_commmunity_page = is_page_builder_page && PageGroup.where(slug: params["page_group_friendly_id"]).first.is_community? 
-  community_name = params["page_group_friendly_id"]
+  community_slug = params["page_group_friendly_id"]
   page_image = session[:page_image]
   alt_text = session[:page_image_alt_text]
 %>
@@ -32,25 +32,7 @@
 <section class="<%= 'dm-gradient-banner' if heading.present? %><%= ' gradient-banner-with-image' if page_image.present? %> <%= classes if classes.present? %>">
   <div class="grid-container <%= 'padding-top-2 padding-bottom-8' if is_commmunity_page %> <%= 'padding-y-4 desktop:padding-y-8' if heading.present? && !is_commmunity_page %>">
     <% if is_commmunity_page %>
-      <nav id="community-subnav" class="font-sans-lg" aria-label="Community subnavigation">
-        <ul class="padding-x-0 padding-bottom-2 display-none tablet:padding-bottom-8 desktop:tablet:padding-bottom-8 flex-row tablet:display-flex">
-          <li class=""><a href="/communities/<%= community_name %>/">Community</a></li>
-          <% subpages = {
-            "About": "about",
-            "Innovations": "innovations",
-            "Events and News": "events-and-news",
-            "Getting Started": "getting-started",
-            "Publications": "publications"
-          } %>
-          <% subpages.each do |title,slug| %>
-            <li>
-              <a href="/communities/<%= community_name%>/<%= slug %>" class="<%= "current-page" if params["page_slug"] == slug %>">
-                <%= title %>
-              </a>
-            </li>
-          <% end %>
-        </ul>
-      </nav>
+      <%= render "page/community_subnav", community_slug: community_slug %>
     <% elsif breadcrumbs.present? # use breadcrumbs on non-community pages %>
       <div id="breadcrumbs"
            class="grid-col-auto usa-breadcrumb breadcrumbs-container <%= heading.present? ? "dm-breadcrumb--gradient-bg padding-top-0 padding-bottom-105" : 'padding-y-4' %>"

--- a/app/views/shared/_page_heading_banner.html.erb
+++ b/app/views/shared/_page_heading_banner.html.erb
@@ -1,0 +1,22 @@
+<% # aka "the big blue banner" %>
+<% if heading.present? %>
+	<div class="dm-breadcrumb-heading grid-row grid-gap-3">
+	  <div class="grid-col-12<%= ' desktop:grid-col-7' if page_image.present? %>">
+	    <h1 class="usa-prose-h1 margin-top-0 margin-bottom-4 text-white grid-col-12">
+	      <%= heading %>
+	    </h1>
+	    <% if description.present? %>
+	      <p class="dm-heading-description font-sans-lg <%= page_image.present? ? ' grid-col-12' : ' grid-col-10' %> text-white dm-word-break-break-word hyphens-auto">
+	        <%= description %>
+	      </p>
+	    <% end %>
+	  </div>
+	  <% if page_image.present? %>
+	    <div class="page-image-column desktop:grid-col-5">
+	      <div class="page-image-container">
+	        <img src="<%= page_image %>" alt="<%= alt_text %>" class="height-full width-full"/>
+	      </div>
+	    </div>
+	  <% end %>
+	</div>
+<% end %>

--- a/spec/factories/page_groups.rb
+++ b/spec/factories/page_groups.rb
@@ -4,4 +4,10 @@ FactoryBot.define do
     description { "Description for Sample Page Group" }
     slug { name.parameterize }
   end
+
+  factory :community, class: 'PageGroup' do
+    name { "VA Immersive"}
+    description { "Description for an allowed community"}
+    slug { name.parameterize }
+  end
 end

--- a/spec/features/pages/community_spec.rb
+++ b/spec/features/pages/community_spec.rb
@@ -4,36 +4,50 @@ describe 'Communities', type: :feature, js:true do
 	before do
 		@approved_community = create(:community)
 		@non_community_pagegroup = PageGroup.create(name: "Competitions", slug: 'competitions', description: "not a community")
-		@community_landing_page = Page.create(page_group: @approved_community, title: 'Community homepage', description: 'cool stuff', slug: 'home', created_at: Time.now, is_public: true, published: Time.now)		
+		@community_landing_page = Page.create(page_group: @approved_community, title: 'Community homepage', description: 'cool stuff', slug: 'home', created_at: Time.now, is_public: true, published: Time.now)
 		@non_community_landing_page = Page.create(page_group: @non_community_pagegroup, title: 'Competitions open call', description: 'not a community', slug: 'home', created_at: Time.now, is_public: true, published: Time.now)
 		@community_subpage = Page.create(page_group: @approved_community, title: 'Community about page', description: 'about us', slug: 'about', created_at: Time.now, is_public: true, published: Time.now)
 	end
 
-	context 'subnav' do
-		it 'is rendered for approved communities' do
-			visit('/communities/va-immersive')
-			expect(page).to have_css('#community-subnav')
-			within('#community-subnav') do
-				expect(page).to have_content('Community')
-				expect(page).to have_content('About')
-			end
-		end
-
-		it 'only shows pages that exist' do
-			another_subpage = Page.create(page_group: @approved_community, title: 'Community Events and News page', description: 'events and news', slug: 'events-and-news', created_at: Time.now, is_public: true, published: Time.now)
-			visit('/communities/va-immersive/about')
-			within('#community-subnav') do
-				expect(page).to have_content('About')
-				expect(page).to have_link('About', class: 'current-page')
-				expect(page).to have_content('Events and News')
-				expect(page).to have_link('Events and News')
-				expect(page).not_to have_content('Publications')
-			end
-		end
-
+	describe 'subnav' do
 		it 'does not render for generic pagegroups' do
 			visit page_show_path(@non_community_pagegroup.slug, @non_community_landing_page.slug)
 			expect(page).not_to have_css('#community-subnav')
+		end
+
+		context 'published homepage' do
+			it 'is rendered for approved communities' do
+				visit('/communities/va-immersive')
+				expect(page).to have_css('#community-subnav')
+				within('#community-subnav') do
+					expect(page).to have_content('Community')
+					expect(page).to have_content('About')
+				end
+			end
+
+			it 'only shows pages that exist and have been published' do
+				another_subpage = Page.create(page_group: @approved_community, title: 'Community Events and News page', description: 'events and news', slug: 'events-and-news', created_at: Time.now, is_public: true, published: Time.now)
+				visit('/communities/va-immersive/about')
+				within('#community-subnav') do
+					expect(page).to have_content('About')
+					expect(page).to have_link('About', class: 'current-page')
+					expect(page).to have_content('Events and News')
+					expect(page).to have_link('Events and News')
+					expect(page).not_to have_content('Publications')
+				end
+			end
+		end
+
+		context 'unpublished homepage' do
+			it 'renders all approved subpages regardless of publication status' do
+				@community_landing_page.update(published: nil)
+				unpublished_subpage = Page.create(page_group: @approved_community, title: 'Publications', description: 'approved subpage', slug: 'publications', created_at: Time.now, is_public: true, published: nil)
+				visit('/communities/va-immersive/about')
+				within('#community-subnav') do
+					expect(page).to have_link('About', class: 'current-page')
+					expect(page).to have_link('Publications')
+				end
+			end
 		end
 	end
 end

--- a/spec/features/pages/community_spec.rb
+++ b/spec/features/pages/community_spec.rb
@@ -6,6 +6,7 @@ describe 'Communities', type: :feature, js:true do
 		@non_community_pagegroup = PageGroup.create(name: "Competitions", slug: 'competitions', description: "not a community")
 		@community_landing_page = Page.create(page_group: @approved_community, title: 'Community homepage', description: 'cool stuff', slug: 'home', created_at: Time.now, is_public: true, published: Time.now)		
 		@non_community_landing_page = Page.create(page_group: @non_community_pagegroup, title: 'Competitions open call', description: 'not a community', slug: 'home', created_at: Time.now, is_public: true, published: Time.now)
+		@community_subpage = Page.create(page_group: @approved_community, title: 'Community about page', description: 'about us', slug: 'about', created_at: Time.now, is_public: true, published: Time.now)
 	end
 
 	context 'subnav' do
@@ -14,17 +15,19 @@ describe 'Communities', type: :feature, js:true do
 			expect(page).to have_css('#community-subnav')
 			within('#community-subnav') do
 				expect(page).to have_content('Community')
-				expect(page).not_to have_content('About')
+				expect(page).to have_content('About')
 			end
 		end
 
 		it 'only shows pages that exist' do
-			community_subpage = Page.create(page_group: @approved_community, title: 'Community about page', description: 'about us', slug: 'about', created_at: Time.now, is_public: true, published: Time.now)
-			visit('/communities/va-immersive')
+			another_subpage = Page.create(page_group: @approved_community, title: 'Community Events and News page', description: 'events and news', slug: 'events-and-news', created_at: Time.now, is_public: true, published: Time.now)
+			visit('/communities/va-immersive/about')
 			within('#community-subnav') do
 				expect(page).to have_content('About')
-				expect(page).to have_link('About', css: '.current-page')
-				expect(page).not_to have_content('Events and News')
+				expect(page).to have_link('About', class: 'current-page')
+				expect(page).to have_content('Events and News')
+				expect(page).to have_link('Events and News')
+				expect(page).not_to have_content('Publications')
 			end
 		end
 

--- a/spec/features/pages/community_spec.rb
+++ b/spec/features/pages/community_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 describe 'Communities', type: :feature, js:true do
 	before do
-		@approved_community = PageGroup.create(name: 'VA Immersive', slug: 'va-immersive', description: "approved community")
+		@approved_community = create(:community)
 		@non_community_pagegroup = PageGroup.create(name: "Competitions", slug: 'competitions', description: "not a community")
 		@community_landing_page = Page.create(page_group: @approved_community, title: 'Community homepage', description: 'cool stuff', slug: 'home', created_at: Time.now, is_public: true, published: Time.now)		
 		@non_community_landing_page = Page.create(page_group: @non_community_pagegroup, title: 'Competitions open call', description: 'not a community', slug: 'home', created_at: Time.now, is_public: true, published: Time.now)

--- a/spec/features/pages/community_spec.rb
+++ b/spec/features/pages/community_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+describe 'Communities', type: :feature, js:true do
+	before do
+		@approved_community = PageGroup.create(name: 'VA Immersive', slug: 'va-immersive', description: "approved community")
+		@non_community_pagegroup = PageGroup.create(name: "Competitions", slug: 'competitions', description: "not a community")
+		@community_landing_page = Page.create(page_group: @approved_community, title: 'Community homepage', description: 'cool stuff', slug: 'home', created_at: Time.now, is_public: true, published: Time.now)		
+		@non_community_landing_page = Page.create(page_group: @non_community_pagegroup, title: 'Competitions open call', description: 'not a community', slug: 'home', created_at: Time.now, is_public: true, published: Time.now)
+	end
+
+	context 'subnav' do
+		it 'is rendered for approved communities' do
+			visit('/communities/va-immersive')
+			expect(page).to have_css('#community-subnav')
+			within('#community-subnav') do
+				expect(page).to have_content('Community')
+				expect(page).not_to have_content('About')
+			end
+		end
+
+		it 'only shows pages that exist' do
+			community_subpage = Page.create(page_group: @approved_community, title: 'Community about page', description: 'about us', slug: 'about', created_at: Time.now, is_public: true, published: Time.now)
+			visit('/communities/va-immersive')
+			within('#community-subnav') do
+				expect(page).to have_content('About')
+				expect(page).to have_link('About', css: '.current-page')
+				expect(page).not_to have_content('Events and News')
+			end
+		end
+
+		it 'does not render for generic pagegroups' do
+			visit page_show_path(@non_community_pagegroup.slug, @non_community_landing_page.slug)
+			expect(page).not_to have_css('#community-subnav')
+		end
+	end
+end

--- a/spec/features/shared/breadcrumbs_spec.rb
+++ b/spec/features/shared/breadcrumbs_spec.rb
@@ -59,11 +59,11 @@ describe 'Breadcrumbs', type: :feature do
     PracticePartnerPractice.create!(practice_partner: @pp, practice: @user_practice)
     @page_group = PageGroup.create!(name: 'programming', description: 'Pages about programming go in this group.')
     @page_group2 = PageGroup.create!(name: 'test', description: 'Pages about tests go in this group.')
-    @community_page_group = PageGroup.create!(name: 'xr-network', description: 'Pages related to a community')
+    @community_page_group = PageGroup.create!(name: 'va-immersive', description: 'Whitelisted community')
     @page = Page.create!(title: 'Test', description: 'This is a test page', slug: 'home', page_group: @page_group, published: Time.now)
     @page2 = Page.create!(title: 'Test', description: 'This is a test page', slug: 'test-page', page_group: @page_group2, published: Time.now)
     @page3 = Page.create!(title: 'Test', description: 'This is a test page', slug: 'test-page', page_group: @page_group, published: Time.now)
-    @community_home_page = Page.create!(title: 'Community home page', description: 'This is a community home page', slug: 'home', page_group: @community_page_group, published: Time.now)
+    @community_home_page = Page.create!(title: 'Community homepage', description: 'This is a community home page', slug: 'home', page_group: @community_page_group, published: Time.now)
     @community_sub_page = Page.create!(title: 'Community subpage', description: 'This is a community subpage', slug: 'test-page', page_group: @community_page_group, published: Time.now)
     visit '/'
   end
@@ -273,21 +273,28 @@ describe 'Breadcrumbs', type: :feature do
     end
   end
 
-  describe 'Page builder flow' do
-    it 'Should only show a single breadcrumb for the landing page of a page group, if the user is on a subpage' do
+  describe 'PageBuilder' do
+    it 'does not show breadcrumbs on a page group homepage' do
+      visit '/programming/home'
+      expect(page).to_not have_css('#breadcrumbs')
+    end
+
+    it 'shows a single breadcrumb when on the subpage of a page group with a homepage' do
       visit '/programming/test-page'
       expect(page).to have_css('#breadcrumbs', visible: true)
-      expect(page).to have_css('.usa-breadcrumb__link', text: @page_group.name)
+      expect(page).to have_css('.usa-breadcrumb__link', text: 'programming')
       expect(page).to have_link(href: '/programming')
     end
 
-    it 'Should not show any breadcrumbs for a subpage that has a page group without a landing page or the landing page of a page group' do
+    it 'does not show breadcrumbs for a subpage of page group without a homepage' do
       visit '/test/test-page'
       expect(page).to_not have_css('#breadcrumbs')
       expect(page).to_not have_css('.usa-breadcrumb__link')
+    end
 
-      visit '/programming/home'
-      expect(page).to_not have_css('#breadcrumbs')
+    it 'does not render breadcrumbs for communities' do
+      visit '/communities/va-immersive/test-page'
+      expect(page).not_to have_css('#breadcrumbs')
     end
   end
 end

--- a/spec/features/shared/breadcrumbs_spec.rb
+++ b/spec/features/shared/breadcrumbs_spec.rb
@@ -57,15 +57,6 @@ describe 'Breadcrumbs', type: :feature do
     DiffusionHistoryStatus.create!(diffusion_history: dh_1, status: 'Completed')
     login_as(@user, :scope => :user, :run_callbacks => false)
     PracticePartnerPractice.create!(practice_partner: @pp, practice: @user_practice)
-    @page_group = PageGroup.create!(name: 'programming', description: 'Pages about programming go in this group.')
-    @page_group2 = PageGroup.create!(name: 'test', description: 'Pages about tests go in this group.')
-    @page = Page.create!(title: 'Test', description: 'This is a test page', slug: 'home', page_group: @page_group, published: Time.now)
-    @page2 = Page.create!(title: 'Test', description: 'This is a test page', slug: 'test-page', page_group: @page_group2, published: Time.now)
-    @page3 = Page.create!(title: 'Test', description: 'This is a test page', slug: 'test-page', page_group: @page_group, published: Time.now)
-    @community_page_group = PageGroup.create(name: 'VA Immersive', description: 'Whitelisted community', slug: 'va-immersive')
-    @community_home_page = Page.create(title: 'Community homepage', description: 'This is a community home page', slug: 'home', page_group: @community_page_group, published: Time.now)
-    @community_approved_sub_page = Page.create(title: 'Subnav approved community subpage', description: 'Subnav approved community subpage', slug: 'About', page_group: @community_page_group, published: Time.now)
-    @community_unapproved_sub_page = Page.create(title: 'Community subpage', description: 'This is a community subpage', slug: 'test-page', page_group: @community_page_group, published: Time.now)
     visit '/'
   end
 
@@ -275,23 +266,38 @@ describe 'Breadcrumbs', type: :feature do
   end
 
   describe 'PageBuilder community' do
+    before do
+      @community_page_group = create(:community)
+      @community_home_page = Page.create(title: 'Community homepage', description: 'This is a community home page', slug: 'home', page_group: @community_page_group, published: Time.now)
+    end
+
     it 'does not show breadcrumbs on homepage' do
       visit '/va-immersive/home'
       expect(page).to_not have_css('#breadcrumbs')
     end
 
     it 'does not render breadcrumbs for allowlisted subpages' do
+      @community_approved_sub_page = Page.create(title: 'Subnav approved community subpage', description: 'Subnav approved community subpage', slug: 'About', page_group: @community_page_group, published: Time.now)
       visit '/communities/va-immersive/about'
       expect(page).not_to have_css('#breadcrumbs')
     end
 
     it 'does not render breadcrumbs for unapproved subpages' do
+      @community_unapproved_sub_page = Page.create(title: 'Community subpage', description: 'This is a community subpage', slug: 'test-page', page_group: @community_page_group, published: Time.now)
       visit '/communities/va-immersive/test-page'
       expect(page).not_to have_css('#breadcrumbs')
     end
   end
 
   describe 'PageBuilder non-community' do
+    before do
+      @page_group = PageGroup.create!(name: 'programming', description: 'Pages about programming go in this group.')
+      @page_group2 = PageGroup.create!(name: 'test', description: 'Pages about tests go in this group.')
+      @page = Page.create!(title: 'Test', description: 'This is a test page', slug: 'home', page_group: @page_group, published: Time.now)
+      @page2 = Page.create!(title: 'Test', description: 'This is a test page', slug: 'test-page', page_group: @page_group2, published: Time.now)
+      @page3 = Page.create!(title: 'Test', description: 'This is a test page', slug: 'test-page', page_group: @page_group, published: Time.now)
+    end
+
     it 'does not show breadcrumbs on a page group homepage' do
       visit '/programming/home'
       expect(page).to_not have_css('#breadcrumbs')

--- a/spec/features/shared/breadcrumbs_spec.rb
+++ b/spec/features/shared/breadcrumbs_spec.rb
@@ -59,12 +59,13 @@ describe 'Breadcrumbs', type: :feature do
     PracticePartnerPractice.create!(practice_partner: @pp, practice: @user_practice)
     @page_group = PageGroup.create!(name: 'programming', description: 'Pages about programming go in this group.')
     @page_group2 = PageGroup.create!(name: 'test', description: 'Pages about tests go in this group.')
-    @community_page_group = PageGroup.create!(name: 'va-immersive', description: 'Whitelisted community')
     @page = Page.create!(title: 'Test', description: 'This is a test page', slug: 'home', page_group: @page_group, published: Time.now)
     @page2 = Page.create!(title: 'Test', description: 'This is a test page', slug: 'test-page', page_group: @page_group2, published: Time.now)
     @page3 = Page.create!(title: 'Test', description: 'This is a test page', slug: 'test-page', page_group: @page_group, published: Time.now)
-    @community_home_page = Page.create!(title: 'Community homepage', description: 'This is a community home page', slug: 'home', page_group: @community_page_group, published: Time.now)
-    @community_sub_page = Page.create!(title: 'Community subpage', description: 'This is a community subpage', slug: 'test-page', page_group: @community_page_group, published: Time.now)
+    @community_page_group = PageGroup.create(name: 'VA Immersive', description: 'Whitelisted community', slug: 'va-immersive')
+    @community_home_page = Page.create(title: 'Community homepage', description: 'This is a community home page', slug: 'home', page_group: @community_page_group, published: Time.now)
+    @community_approved_sub_page = Page.create(title: 'Subnav approved community subpage', description: 'Subnav approved community subpage', slug: 'About', page_group: @community_page_group, published: Time.now)
+    @community_unapproved_sub_page = Page.create(title: 'Community subpage', description: 'This is a community subpage', slug: 'test-page', page_group: @community_page_group, published: Time.now)
     visit '/'
   end
 
@@ -273,7 +274,24 @@ describe 'Breadcrumbs', type: :feature do
     end
   end
 
-  describe 'PageBuilder' do
+  describe 'PageBuilder community' do
+    it 'does not show breadcrumbs on homepage' do
+      visit '/va-immersive/home'
+      expect(page).to_not have_css('#breadcrumbs')
+    end
+
+    it 'does not render breadcrumbs for allowlisted subpages' do
+      visit '/communities/va-immersive/about'
+      expect(page).not_to have_css('#breadcrumbs')
+    end
+
+    it 'does not render breadcrumbs for unapproved subpages' do
+      visit '/communities/va-immersive/test-page'
+      expect(page).not_to have_css('#breadcrumbs')
+    end
+  end
+
+  describe 'PageBuilder non-community' do
     it 'does not show breadcrumbs on a page group homepage' do
       visit '/programming/home'
       expect(page).to_not have_css('#breadcrumbs')
@@ -290,11 +308,6 @@ describe 'Breadcrumbs', type: :feature do
       visit '/test/test-page'
       expect(page).to_not have_css('#breadcrumbs')
       expect(page).to_not have_css('.usa-breadcrumb__link')
-    end
-
-    it 'does not render breadcrumbs for communities' do
-      visit '/communities/va-immersive/test-page'
-      expect(page).not_to have_css('#breadcrumbs')
     end
   end
 end


### PR DESCRIPTION
### JIRA issue link


## Description - what does this code do?
This PR cleans up some code around communities & breadcrumbs
- Removes communities from breadcrumb code (we are not using these in the new Community designs) and updates specs
- Starts extracting partials from the breadcrumbs partial that's used across the app to make things clearer for a later refactor
- Stops hardcoding community name in community mobile subnav
- Adds feature tests for community subnav
- IF the homepage has been published:
  - Only render community subnav links for subpages that exist AND have been published
  -  ELSE: show all subnav links for subpages that exist

## Testing done - how did you test it/steps on how can another person can test it 
1. Log in as an admin. 
2. Create a page group with the slug "va-immersive". Save. 
3. Go back to edit the page group and update the name to "VA Immersive"
4. Create a page with the slug `home` and set its page group to `va-immersive`. 
5. Create a page with the slug `about` and set its page group to `va-immersive`. 
6. Visit `/communities/va-immersive` and confirm the subnav renders a link for `Community` and `About`. 
7. Go back to the admin page for VA immersive's home page and publish it
8. Go to `/communities/va-immersive` and confirm that no subnav is rendered.
9. Check out `master` branch and visit `/communities/va-immersive`. Confirm that links are rendered for pages that don't exist (e.g. Events and News)

## Screenshots, Gifs, Videos from application (if applicable)
### Before
<img width="1319" alt="Screenshot 2024-04-03 at 7 09 43 PM" src="https://github.com/department-of-veterans-affairs/diffusion-marketplace/assets/5402927/ca69a0ce-a940-46c6-a42a-d86c0256c405">

### After
![Screenshot 2024-04-15 at 4 12 32 PM](https://github.com/department-of-veterans-affairs/diffusion-marketplace/assets/5402927/6fcb152f-ddac-4972-9959-d165486ad7dc)

