### PR TITLE
fix regex for warning in `admin/pages#rewrite_error_message`

### DIFF
--- a/app/admin/pages.rb
+++ b/app/admin/pages.rb
@@ -293,7 +293,7 @@ ActiveAdmin.register Page do
       return "" unless error_message.is_a?(String)
 
       error_message = error_message.gsub(/Validation failed: |Page components component /, '')
-        error_message = error_message.split(/(?<=])/).map do |str|
+        error_message = error_message.split(/(?<=\])/).map do |str|
           if str.include?("PageComponent")
             index_of_component_error = str.index("PageComponent")
             str = str.slice(index_of_component_error, str.length)


### PR DESCRIPTION
### JIRA issue link


## Description - what does this code do?
adds escape for regex being used in `admin/pages` controller helper method `rewrite_error_message`

## Testing done - how did you test it/steps on how can another person can test it 
1. verify that `diffusion-marketplace/app/admin/pages.rb:296: warning: regular expression has ']' without escape: /(?<=])/` warning does not pop up when running the application locally

2. verify that the PB error messaging introduced with https://github.com/department-of-veterans-affairs/diffusion-marketplace/pull/838 still functions as expected

## Screenshots, Gifs, Videos from application (if applicable)


## Link to mock-ups/mock ups (image file if you have it) (if applicable)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Unit tests written (if applicable)
- [ ] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating JIRA issue
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs