### PR TITLE
DM-4629: Remove links from major partners on innovation show page

### DIFF
--- a/app/controllers/practices_controller.rb
+++ b/app/controllers/practices_controller.rb
@@ -80,6 +80,8 @@ class PracticesController < ApplicationController # rubocop:disable Metrics/Clas
     @in_progress_adoptions = helpers.sort_adoptions_by_state_and_station_name(diffusion_histories.get_by_in_progress_status)
     @unsuccessful_adoptions = helpers.sort_adoptions_by_state_and_station_name(diffusion_histories.get_by_unsuccessful_status)
 
+    @practice_partner_names = @practice.practice_partners.where.not(name: 'None of the above, or Unsure').order(:name).pluck('name').join(', ')
+
     if helpers.is_user_a_guest? && !@practice.is_public
       respond_to do |format|
         s_error = 'This innovation is not available for non-VA users.'

--- a/app/views/practices/show/introduction/_introduction.html.erb
+++ b/app/views/practices/show/introduction/_introduction.html.erb
@@ -6,7 +6,6 @@
   completed_adoptions = @practice.number_of_completed_adoptions
   in_progress_adoptions = @practice.number_of_in_progress_adoptions
   unsuccessful_adoptions = @practice.number_of_unsuccessful_adoptions
-  has_practice_partners = @practice.practice_partners.any? && @practice.practice_partners.find_by(name: 'None of the above, or Unsure').nil?
   has_practice_awards = @practice.practice_awards.any? && (@practice.practice_awards.size === 1 ? @practice.practice_awards.find_by(name: 'Other').nil? : true )
 %>
 
@@ -116,11 +115,11 @@
         <% end %>
 
         <%# practice partners %>
-        <% if has_practice_partners %>
+        <% if @practice_partner_names %>
           <div>
             <h5 class="text-uppercase display-inline margin-y-0">Partners:</h5>
             <p class="display-inline line-height-26">
-              <%= @practice.practice_partners.order(:name).pluck('name').join(', ') %>
+              <%= @practice_partner_names %>
             </p>
           </div>
         <% end %>

--- a/app/views/practices/show/introduction/_introduction.html.erb
+++ b/app/views/practices/show/introduction/_introduction.html.erb
@@ -124,7 +124,7 @@
                 <% needs_comma = @practice.practice_partners.size != index + 1 && @practice.practice_partners.size > 1 %>
 
                 <% if partner.is_major %>
-                  <a href="<%= practice_partner_path(partner) %>" class="usa-link"><%= partner.name %></a><%= ', ' if needs_comma %>
+                  <%= partner.name %><%= ', ' if needs_comma %>
                 <% else %>
                   <span><%= partner.name %></span><%= ', ' if needs_comma %>
                 <% end %>

--- a/app/views/practices/show/introduction/_introduction.html.erb
+++ b/app/views/practices/show/introduction/_introduction.html.erb
@@ -120,15 +120,7 @@
           <div>
             <h5 class="text-uppercase display-inline margin-y-0">Partners:</h5>
             <p class="display-inline line-height-26">
-              <% Naturalsorter::Sorter.sort_by_method(@practice.practice_partners, 'name', true, true).each_with_index do |partner, index| %>
-                <% needs_comma = @practice.practice_partners.size != index + 1 && @practice.practice_partners.size > 1 %>
-
-                <% if partner.is_major %>
-                  <%= partner.name %><%= ', ' if needs_comma %>
-                <% else %>
-                  <span><%= partner.name %></span><%= ', ' if needs_comma %>
-                <% end %>
-              <% end %>
+              <%= @practice.practice_partners.order(:name).pluck('name').join(', ') %>
             </p>
           </div>
         <% end %>

--- a/app/views/practices/show/introduction/_introduction.html.erb
+++ b/app/views/practices/show/introduction/_introduction.html.erb
@@ -115,8 +115,8 @@
         <% end %>
 
         <%# practice partners %>
-        <% if @practice_partner_names %>
-          <div>
+        <% if @practice_partner_names.present? %>
+          <div class="practice-partners-section">
             <h5 class="text-uppercase display-inline margin-y-0">Partners:</h5>
             <p class="display-inline line-height-26">
               <%= @practice_partner_names %>

--- a/spec/features/practice_editor/introduction/introduction_spec.rb
+++ b/spec/features/practice_editor/introduction/introduction_spec.rb
@@ -367,8 +367,8 @@ describe 'Practice editor - introduction', type: :feature, js: true do
 
     context 'partners' do
       it 'should allow changing partners' do
-        expect(find(:css, '#practice_practice_partner_practices_attributes_0_practice_partner_id').value).to eq('Diffusion of Excellence')
-        expect(find(:css, '#practice_practice_partner_practices_attributes_1_practice_partner_id').value).to eq('Office of Rural Health')
+        expect(find(:css, '#practice_practice_partner_practices_attributes_0_practice_partner_id').value).to eq(@pr_partner_1.name)
+        expect(find(:css, '#practice_practice_partner_practices_attributes_1_practice_partner_id').value).to eq(@pr_partner_2.name)
         # add another partner
         click_add_another('#link_to_add_link_practice_partner_practices')
         within(all('.dm-practice-editor-practice-partner-li').last) do
@@ -381,9 +381,11 @@ describe 'Practice editor - introduction', type: :feature, js: true do
         click_save
         expect(find(:css, '#practice_practice_partner_practices_attributes_1_practice_partner_id').value).to eq(@pr_partner_3.name)
         visit_practice_show
-        expect(page).to_not have_link('Diffusion of Excellence')
-        expect(page).to_not have_link(@pr_partner_3.name)
-        expect(page).to have_link('Office of Rural Health')
+        within('.practice-partners-section') do
+          expect(page).to_not have_content(@pr_partner_1.name)
+          expect(page).to have_content(@pr_partner_3.name)
+          expect(page).to have_content(@pr_partner_2.name)
+        end
       end
 
       context 'edge cases' do

--- a/spec/features/practice_viewer/introduction_spec.rb
+++ b/spec/features/practice_viewer/introduction_spec.rb
@@ -173,11 +173,9 @@ describe 'Practice viewer - introduction', type: :feature, js: true do
       visit practice_path(@pr_max)
     end
 
-    it 'should only have links for major practice partners' do
+    it 'renders major and minor partners' do
       expect(page).to have_content(@pr_partner_1.name)
       expect(page).to have_content(@pr_partner_2.name)
-      expect(page).to have_link(href: practice_partner_path(@pr_partner_1))
-      expect(page).to_not have_link(href: practice_partner_path(@pr_partner_2))
     end
   end
 


### PR DESCRIPTION
### JIRA issue link
[DM-4629](https://agile6.atlassian.net/browse/DM-4629)

## Description - what does this code do?
- Removes links to major practice partners from innovation show page
- Removes naturalsorter invocation 
- Move db query out of view into controller 

## Testing done - how did you test it/steps on how can another person can test it 
1. Log in as and go to an innovation's edit' page. e.g. `/innovations/flow3`
2. Go to the `Introduction` section and add several partners. 
3. Save the innovation
4. Go to the innovation show page and confirm that partners are sorted alphabetically by `name`.
5. Select `None of the above, or Unsure` from the list.
6. Save the innovation and go to the innovation's show page
7. Confirm that no `Partners` section is visible.

## Screenshots, Gifs, Videos from application (if applicable)
Innovation show page:
<img width="533" alt="Screenshot 2024-04-08 at 4 41 37 PM" src="https://github.com/department-of-veterans-affairs/diffusion-marketplace/assets/5402927/7543f077-a6f6-4d40-88e1-f6417b7615a9">
