### PR TITLE
DM-4553: Extract community subnav and update colors

### DIFF
--- a/app/assets/stylesheets/dm/pages/_page_builder_page.scss
+++ b/app/assets/stylesheets/dm/pages/_page_builder_page.scss
@@ -2,13 +2,27 @@
   border: none;
   font-weight: 700;
   width: 100%;
-  background-color: #D9D9D985;
+  background-color: #EBEBEB;
   color: #1B1B1B;
   text-align: left;
 
   // push text and icon to opposite ends
   display: flex;
   justify-content: space-between;
+
+  &:hover {
+    @include u-color('primary-dark');
+    span{
+      text-decoration: underline;
+    }
+  }
+
+  &:active {
+    @include u-color('primary-vivid');
+    span {
+      text-decoration: underline;
+    }
+  }
 
   @media screen and (min-width: 640px) {
     display: none;
@@ -17,17 +31,24 @@
 
 #community-subnav {
   ul {
+    flex-direction: row;
+    background-color: #F5F5F5;
     list-style: none;
     justify-content: space-evenly;
   }
 
   a, a:visited {
-    color: white;
+    @include u-color('primary-darker');
     text-decoration: none;
     font-weight: 700;
 
     &:hover {
+      @include u-color('primary-dark');
       text-decoration: underline;
+    }
+
+    &:active {
+      @include u-color('primary-vivid');
     }
   }
 
@@ -36,8 +57,14 @@
   }
 
   @media screen and (max-width: 640px) {
+    ul {
+      flex-direction: column;
+    }
+
     li {
-      margin-top: 1rem;
+      padding-top: 0.5rem;
+      padding-bottom: 0.5rem;
+      padding-left: 1rem;
     }
   }
 }

--- a/app/views/page/_community_subnav.html.erb
+++ b/app/views/page/_community_subnav.html.erb
@@ -1,8 +1,12 @@
+<button type="button" id="communitySubnavBtn" class="display-block tablet:display-none desktop:display-none padding-y-2 padding-x-2" aria-controls="community-subnav" aria-expanded="false">
+    <span><%= @page_group.name %></span>
+    <i class="text-align-right fa fa-plus"></i>
+</button>
 <nav id="community-subnav" class="font-sans-lg" aria-label="Community subnavigation">
-  <ul class="padding-x-0 padding-bottom-2 display-none tablet:padding-bottom-8 desktop:tablet:padding-bottom-8 flex-row tablet:display-flex">
+  <ul class="padding-x-0 padding-y-2 margin-y-0 display-none tablet:display-flex desktop:display-flex ">
     <% subnav_hash.each do |title, page_slug| %>
       <% break if @page_group.subnav_hash.length == 1 %>
-      <li>
+      <li class="subnav-item">
         <a href="/communities/<%= @page_group_slug %>/<%= page_slug %>" class="<%= "current-page" if params["page_slug"] == page_slug %>">
           <%= title %>
         </a>

--- a/app/views/page/_community_subnav_mobile.html.erb
+++ b/app/views/page/_community_subnav_mobile.html.erb
@@ -1,4 +1,0 @@
-<button type="button" id="communitySubnavBtn" class="nav-container tablet:display-none desktop:display-none padding-y-2 padding-x-2" aria-controls="community-subnav" aria-expanded="false">
-        <span><%= @page_group.name %></span>
-        <i class="text-align-right fa fa-plus"></i>
-</button>

--- a/app/views/shared/_breadcrumbs.html.erb
+++ b/app/views/shared/_breadcrumbs.html.erb
@@ -23,7 +23,7 @@
 <% if @page_group&.is_community? # only shown on mobile width %>
   <%= render partial: "page/community_subnav", locals: { community_slug: @page_group_slug, subnav_hash: @page_group.subnav_hash } %>
   <section class="<%= 'dm-gradient-banner' if heading.present? %><%= ' gradient-banner-with-image' if page_image.present? %> <%= classes if classes.present? %>">
-    <div class="grid-container padding-top-2 padding-bottom-8">
+    <div class="grid-container padding-y-4 desktop:padding-y-8">
         <%= render partial: 'shared/page_heading_banner',
           locals: {
             heading: heading,

--- a/app/views/shared/_breadcrumbs.html.erb
+++ b/app/views/shared/_breadcrumbs.html.erb
@@ -21,10 +21,9 @@
 %>
 
 <% if @page_group&.is_community? # only shown on mobile width %>
-  <%= render partial: "page/community_subnav_mobile", locals: { community_slug: @page_group_slug } %>
+  <%= render partial: "page/community_subnav", locals: { community_slug: @page_group_slug, subnav_hash: @page_group.subnav_hash } %>
   <section class="<%= 'dm-gradient-banner' if heading.present? %><%= ' gradient-banner-with-image' if page_image.present? %> <%= classes if classes.present? %>">
     <div class="grid-container padding-top-2 padding-bottom-8">
-        <%= render partial: "page/community_subnav", locals: { subnav_hash: @page_group.subnav_hash } %>
         <%= render partial: 'shared/page_heading_banner',
           locals: {
             heading: heading,


### PR DESCRIPTION
### JIRA issue link
[DM-4553](https://agile6.atlassian.net/browse/DM-4553)
(another PR coming soon)

## Description - what does this code do?
- Semantically moves community subnav out of blue banner
- Changes subnav background color & link styles
- Updates responsive behavior

## Testing done - how did you test it/steps on how can another person can test it 
In local dev: 
```
FactoryBot.create(:community)
approved_subpages =  { 
      "Community": "home",
      "About": "about",
      "Innovations": "innovations",
      "Events and News": "events-and-news",
      "Getting Started": "getting-started",
      "Publications": "publications"
}
approved_subpages.each {|k,v| FactoryBot.create(:page, title: k, slug: v, is_publi
c: true)}
```
1. Go to `/communities/va-immersive`
2. Confirm that all subnav links are rendered
3. Confirm that subnav is hidden at mobile widths 
4. Click on the "VA Immersive" button and confirm the menu opens 

## Screenshots, Gifs, Videos from application (if applicable)
![Screenshot 2024-04-17 at 4 46 55 PM](https://github.com/department-of-veterans-affairs/diffusion-marketplace/assets/5402927/4122b622-aad0-4b1b-8344-1a1494afc4b6)
![Screenshot 2024-04-17 at 4 54 44 PM](https://github.com/department-of-veterans-affairs/diffusion-marketplace/assets/5402927/534d824b-9d9f-47d9-b92c-cb0a89ba274e)

## Link to mock-ups/mock ups (image file if you have it) (if applicable)
https://www.figma.com/file/D16fyBygVx88HpyczTuqXs/Diffusion-Marketplace-(2024)%2B?type=design&node-id=502-2216&mode=design&t=bHWgVAlhQzrzj8ae-0

