### PR TITLE
fix event tracking for category selection from home page

### DIFF
--- a/app/assets/javascripts/homepage.es6
+++ b/app/assets/javascripts/homepage.es6
@@ -61,7 +61,7 @@ function updateDropdown(categories, innovations) {
           .text(category.name);
       let listItem = $('<li></li>')
           .addClass('search-result')
-          .attr('data-category-id', category.id)
+          .attr('data-category_id', category.id)
           .append(link);
 
       $('#category-list').append(listItem);
@@ -130,7 +130,7 @@ addEventListener('turbolinks:load', function () {
   if ($('#dm-homepage-search-button').length > 0) {
     setupSearchDropdown();
     setupClickTracking('#practice-list', "Dropdown Practice Link Clicked", 'data-practice-id');
-    setupClickTracking('#category-list', "Category selected", 'data-category-id');
+    setupClickTracking('#category-list', "Category selected", 'data-category_id');
     setupBrowseAllTracking();
   }
 });

--- a/app/assets/javascripts/homepage.es6
+++ b/app/assets/javascripts/homepage.es6
@@ -95,7 +95,7 @@ function setupClickTracking(listSelector, eventName, dataAttribute) {
 
       let properties = { from_homepage: true};
       properties[dataAttribute === 'data-practice-id' ? 'practice_name' : 'category_name'] = name;
-      properties[dataAttribute.slice(5)] = id; // Removes 'data-' and uses the rest as the key
+      properties[dataAttribute.slice(5)] = parseInt(id); // Removes 'data-' and uses the rest as the key
 
       ahoy.track(eventName, properties);
 

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -58,7 +58,7 @@
               <h3 class="search-header usa-prose-h3 margin-bottom-0" aria-label="Categories">Categories</h3>
               <ul id="category-list" class="usa-list usa-list--unstyled padding-top-1">
                 <% @dropdown_categories[0..2].each do |category| %>
-                  <li class="search-result" data-category-id=<%= category[:id] %>>
+                  <li class="search-result" data-category_id=<%= category[:id] %>>
                     <a href=<%= "/search?category=#{URI.encode_www_form_component(category[:name])}" %>><%= category[:name] %></a>
                   </li>
                 <% end %>


### PR DESCRIPTION
### JIRA issue link
https://agile6.atlassian.net/browse/DM-4705

## Description - what does this code do?
fix event tracking for category selection from home page

changes property key "category-id" to "category_id",  store "category_id" value as int

## Testing done - how did you test it/steps on how can another person can test it 
1. locally from the homepage select a category from the dropdown
2. In rails console check the last event by running `Ahoy::Event.last`
3. the `properties` jsonb hash should include the  selected category's id as `category_id => {int}` where `int` is an integer and not a string.

## Screenshots, Gifs, Videos from application (if applicable)


## Link to mock-ups/mock ups (image file if you have it) (if applicable)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Unit tests written (if applicable)
- [ ] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating JIRA issue
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs