### PR TITLE
Dm 4702 editor page groups

### DIFF
--- a/app/admin/editor/page_group.rb
+++ b/app/admin/editor/page_group.rb
@@ -1,0 +1,157 @@
+ActiveAdmin.register PageGroup, namespace: :editor do
+  actions :all, except: [:destroy, :new]
+
+  config.filters = false
+  config.batch_actions = false
+
+  permit_params :name, :description, :slug, :has_landing_page, :new_editors
+  form do |f|
+    f.inputs "Editors", class: 'inputs' do
+      if f.object.persisted?
+        li do
+          label "Current Editors", for: "current_editors", class: "label"
+          if f.object.editors.any?
+            ul id: 'current_editors', style: 'margin-left: 340px;' do
+              f.object.editors.each do |editor|
+                li class: 'margin-bottom-1' do
+                  span editor.email
+                  unless editor.email == current_user.email
+                    span class: 'margin-left-1' do
+                      f.check_box(:remove_editors, { multiple: true, name: "page_group[remove_editors][]"}, editor.id, nil)
+                      span " Delete", class: 'margin-left-1'
+                    end
+                  end
+                end
+              end
+            end
+          else
+            span "No editors assigned", class: 'placeholder'
+          end
+        end
+      end
+      f.input :new_editors,
+              label: 'Add Community Editor(s)',
+              as: :text,
+              input_html: { class: 'height-7'},
+              hint: "Enter VA emails as a comma-separated list, e.g. marketplace@va.gov, test@va.gov"
+    end
+
+    f.actions
+  end
+
+  index download_links: false
+
+  show do
+    attributes_table do
+      row :name
+      row :slug
+      row :description
+      row "Editors" do |pg|
+        ul do
+          pg.editors.each do |editor|
+            li editor.email
+          end
+        end
+      end
+    end
+  end
+
+  controller do
+    before_action :set_page_group, only: [:create, :update]
+
+    def scoped_collection
+      super.then do |scope|
+        if current_user.has_role?(:admin)
+          scope
+        else
+          editor_page_group_ids = PageGroup.accessible_by(current_user).pluck(:id)
+          scope.where(id: editor_page_group_ids)
+        end
+      end
+    end
+
+    def page_group_params
+      params.require(:page_group).permit(:name, :description, :slug, :has_landing_page, editors: [])
+    end
+
+    def set_page_group
+      page_group_slug = params[:id]
+      @page_group = page_group_slug.present? ? PageGroup.find_by(slug: page_group_slug) : nil
+    end
+
+    def find_resource
+      scoped_collection.friendly.find(params[:id])
+    end
+
+    def create
+      @page_group = PageGroup.new(page_group_params.except(:new_editors, :remove_editors))
+
+      if params[:page_group][:new_editors].present?
+        users_to_add_roles, non_existent_emails = validate_editor_emails
+        if non_existent_emails.present?
+          flash.now[:error] = "Page group could not be created. User not found with email(s): #{non_existent_emails.join(', ')}"
+          render :new and return
+        end
+      end
+
+      ActiveRecord::Base.transaction do
+        @page_group.save!
+        add_editor_roles(users_to_add_roles) if users_to_add_roles.present?
+      end
+
+      redirect_to admin_page_group_path(@page_group), notice: 'Page group was successfully created.'
+    rescue ActiveRecord::RecordInvalid
+      render :new, status: :unprocessable_entity
+    end
+
+
+    def update
+      ActiveRecord::Base.transaction do
+        @page_group.assign_attributes(page_group_params.except(:remove_editors, :new_editors))
+        if @page_group.save
+          if update_editors
+            redirect_to editor_page_group_path(@page_group), notice: 'Page group was successfully updated.'
+          else
+            raise ActiveRecord::Rollback
+          end
+        else
+          render :edit
+        end
+      rescue ActiveRecord::Rollback
+        flash.now[:error] = @error_message if @error_message
+        render :edit
+      end
+    end
+
+    private
+
+    def update_editors
+      if params[:page_group][:remove_editors].present?
+        @page_group.remove_editor_roles(params[:page_group][:remove_editors])
+      end
+
+      if params[:page_group][:new_editors].present?
+        users_to_add_roles, non_existent_emails = validate_editor_emails
+
+        if non_existent_emails.present?
+          @error_message = "User not found with email(s): #{non_existent_emails.join(', ')}"
+          return false
+        elsif users_to_add_roles.present?
+          add_editor_roles(users_to_add_roles)
+          return true
+        end
+      end
+
+      true
+    end
+
+    def validate_editor_emails
+      editor_emails = params[:page_group][:new_editors].split(',').map(&:strip).uniq
+      User.validate_users_by_emails(editor_emails)
+    end
+
+    def add_editor_roles(users_to_add_roles)
+      users_to_add_roles.each { |user| user.add_role(User::USER_ROLES[1], @page_group) }
+    end
+  end
+end

--- a/app/admin/editor/page_group.rb
+++ b/app/admin/editor/page_group.rb
@@ -5,6 +5,7 @@ ActiveAdmin.register PageGroup, namespace: :editor do
   config.batch_actions = false
 
   permit_params :name, :description, :slug, :has_landing_page, :new_editors
+
   form do |f|
     f.inputs "Editors", class: 'inputs' do
       if f.object.persisted?

--- a/app/admin/editor/pages.rb
+++ b/app/admin/editor/pages.rb
@@ -1,5 +1,10 @@
 ActiveAdmin.register Page, namespace: :editor do
-  menu if: proc { current_user.has_role?(:admin) || current_user.has_role?(:page_group_editor, :any) }
+  menu priority: 1
+
+  actions :all, except: [:destroy]
+
+  config.filters = false
+  config.batch_actions = false
 
   permit_params :title,
                 :page_group_id,
@@ -71,9 +76,6 @@ ActiveAdmin.register Page, namespace: :editor do
                     practices: []
                   ],
                 ]
-
-  config.filters = false
-  config.batch_actions = false
 
   index download_links: false do
     selectable_column

--- a/app/models/editor_auth_adapter.rb
+++ b/app/models/editor_auth_adapter.rb
@@ -2,11 +2,17 @@ class EditorAuthAdapter < ActiveAdmin::AuthorizationAdapter
   def authorized?(action, subject = nil)
     return true if user.has_role?(:admin)
 
-    case subject
-    when normalized(Page)
-      user.has_role?(:page_group_editor, :any)
+    if subject.is_a?(Class)
+      user.has_role?(:page_group_editor, :any) if subject <= Page || subject <= PageGroup
     else
-      false
+      case subject
+      when Page
+        user.has_role?(:page_group_editor, subject.page_group)
+      when PageGroup
+        user.has_role?(:page_group_editor, subject)
+      else
+        false
+      end
     end
   end
 end

--- a/spec/features/admin/admin_page_group_spec.rb
+++ b/spec/features/admin/admin_page_group_spec.rb
@@ -4,7 +4,6 @@ RSpec.describe 'PageGroup Management', type: :feature do
   describe 'Creating a PageGroup' do
     let!(:admin) { create(:user, :admin) }
     let!(:valid_editor) { create(:user) }
-    let!(:nonexistent_email) { "nonexistent@va.gov" }
 
     before do
       login_as(admin, scope: :user, run_callbacks: false)
@@ -35,6 +34,7 @@ RSpec.describe 'PageGroup Management', type: :feature do
     end
 
     it 'fails to create a PageGroup with invalid editor emails and shows an error message' do
+      nonexistent_email = "nonexistent@va.gov"
       visit new_admin_page_group_path
 
       fill_in 'Name', with: 'Failed Page Group'
@@ -54,7 +54,6 @@ RSpec.describe 'PageGroup Management', type: :feature do
     let!(:page_group) { create(:page_group) }
     let!(:editor) { create(:user, email: "editor_email1@va.gov") }
     let!(:existing_editor) { create(:user) }
-    let!(:nonexistent_email) { "nonexistent@va.gov" }
 
     before do
       login_as(admin, scope: :user, run_callbacks: false)
@@ -139,6 +138,7 @@ RSpec.describe 'PageGroup Management', type: :feature do
       end
 
       it 'attempts to update a PageGroup with a nonexistent editor email' do
+        nonexistent_email = "nonexistent@va.gov"
         visit edit_admin_page_group_path(page_group)
 
         fill_in 'Name', with: 'Updated Page Group Name'

--- a/spec/features/editor/editor_page_group_spec.rb
+++ b/spec/features/editor/editor_page_group_spec.rb
@@ -1,0 +1,69 @@
+require 'rails_helper'
+
+RSpec.describe 'PageGroup Management', type: :feature, js: true do
+  describe 'Editing a PageGroup' do
+    let!(:page_group) { create(:page_group) }
+    let!(:editor) { create(:user, email: "editor_email1@va.gov") }
+    let!(:new_editor) { create(:user, email: "editor_email2@va.gov") }
+
+    before do
+      editor.add_role(:page_group_editor, page_group)
+      login_as(editor, scope: :user, run_callbacks: false)
+    end
+
+    context 'Updating editors' do
+      it 'successfully adds an editor to a PageGroup when there were none' do
+        visit edit_editor_page_group_path(page_group)
+        fill_in 'Add Community Editor(s)', with: new_editor.email
+        click_button 'Update Page group'
+
+        expect(page).to have_content('Page group was successfully updated.')
+        expect(page).to have_content("editor_email1@va.gov")
+        expect(page).to have_content("editor_email2@va.gov")
+        expect(page_group.reload.editors).to include(new_editor)
+      end
+
+      it "successfully adds an editor to a PageGroup's existing editors" do
+        visit edit_editor_page_group_path(page_group)
+        fill_in 'Add Community Editor(s)', with: new_editor.email
+        click_button 'Update Page group'
+
+        expect(page).to have_content('Page group was successfully updated.')
+        expect(page).to have_content("editor_email1@va.gov")
+        expect(page).to have_content("editor_email2@va.gov")
+        expect(page_group.editors).to include(editor, new_editor)
+      end
+
+      it "successfully removes an editor from a PageGroup's existing editors" do
+        editor.add_role(:page_group_editor, page_group)
+        new_editor.add_role(:page_group_editor, page_group)
+        visit edit_editor_page_group_path(page_group)
+
+        within("ul#current_editors") do
+          find("li", text: new_editor.email).find("input[type='checkbox']").set(true)
+        end
+
+        click_button 'Update Page group'
+
+        expect(page).to have_content('Page group was successfully updated.')
+        expect(page).to have_content(editor.email)
+        expect(page).not_to have_content(new_editor.email)
+        visit edit_editor_page_group_path(page_group)
+        expect(page).to have_content(editor.email)
+        expect(page).not_to have_content(new_editor.email)
+        expect(page_group.reload.editors).to include(editor)
+        expect(page_group.reload.editors).not_to include(new_editor)
+      end
+
+      it 'attempts to update a PageGroup with a nonexistent editor email' do
+        nonexistent_email = "nonexistent@va.gov"
+        visit edit_editor_page_group_path(page_group)
+        fill_in 'Add Community Editor(s)', with: nonexistent_email
+        click_button 'Update Page group'
+
+        expect(page).to have_content('User not found with email(s): nonexistent@va.gov')
+        expect(page_group.reload.editors).not_to include(nonexistent_email)
+      end
+    end
+  end
+end

--- a/spec/features/editor/editor_page_spec.rb
+++ b/spec/features/editor/editor_page_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe 'Page Builder', type: :feature, js: true do
+describe 'Page Management', type: :feature, js: true do
   let!(:admin) { create(:user, :admin) }
   let!(:editor) { create(:user) }
   let!(:page_group) { create(:page_group, name: 'programming') }


### PR DESCRIPTION
### JIRA issue link
https://agile6.atlassian.net/browse/DM-4702

## Description - what does this code do?
* Adds `page_groups` to Community Editor Portal
* Remove delete functionality from `editor/pages`

## Testing done - how did you test it/steps on how can another person can test it 
1. As admin add an editor to an existing `page_group`
2. Log in as that editor and visit `/editor`
3. Verify you can see and access the "Page Groups" tab
4. Verify you can add and delete editors from `page_group`s

## Screenshots, Gifs, Videos from application (if applicable)
<img width="1724" alt="Screenshot 2024-04-25 at 3 18 49 PM" src="https://github.com/department-of-veterans-affairs/diffusion-marketplace/assets/65036872/8e15f71f-69e1-40e2-a609-f0cb624099f1">

<img width="828" alt="Screenshot 2024-04-25 at 3 18 31 PM" src="https://github.com/department-of-veterans-affairs/diffusion-marketplace/assets/65036872/2a3a061b-d6f9-4d9a-a142-bdec65478d48">


## Link to mock-ups/mock ups (image file if you have it) (if applicable)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Unit tests written (if applicable)
- [ ] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating JIRA issue
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs