### PR TITLE
dm-4748 redirect editors from admin

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -21,6 +21,14 @@ class ApplicationController < ActionController::Base
     reset_revision_cache if @reload_turbolinks
   end
 
+  def redirect_editor_from_admin_dashboard
+    is_in_admin_namespace = request.fullpath.starts_with?('/admin')
+
+    if current_user.has_role?(:page_group_editor, :any) && !current_user.has_role?(:admin) && is_in_admin_namespace
+      redirect_to editor_root_path
+    end
+  end
+
   def authenticate_active_admin_user!
     authenticate_user!
 

--- a/config/initializers/active_admin.rb
+++ b/config/initializers/active_admin.rb
@@ -54,6 +54,7 @@ ActiveAdmin.setup do |config|
   #
   # This setting changes the method which Active Admin calls
   # within the application controller.
+  config.before_action :redirect_editor_from_admin_dashboard
   config.authentication_method = :authenticate_active_admin_user!
 
   # == User Authorization

--- a/spec/features/admin/admin_spec.rb
+++ b/spec/features/admin/admin_spec.rb
@@ -71,6 +71,16 @@ describe 'The admin dashboard', type: :feature do
       expect(page).to have_content('Unauthorized access!')
     end
 
+    it 'if logged in as a page_group_editor, should be redirected to editor dashboard' do
+      @user.add_role(:page_group_editor)
+
+      login_as(@user, scope: :user, run_callbacks: false)
+      visit '/admin'
+
+      expect(page).to be_accessible.according_to :wcag2a, :section508
+      expect(page).to have_current_path(editor_root_path)
+    end
+
     it 'should show the admin dashboard if logged in as an admin' do
       login_as(@admin, scope: :user, run_callbacks: false)
       visit '/admin'


### PR DESCRIPTION
### JIRA issue link
https://agile6.atlassian.net/browse/DM-4748

## Description - what does this code do?
* add redirect_editor_from_admin_dashboard method to ApplicationController, call as before_action for `activeadmin` requests

## Testing done - how did you test it/steps on how can another person can test it 
1. As a user with a `page_group_editor` role, try and access the admin dashboard
2. Verify you are redirected to the Community Editor Portal

## Screenshots, Gifs, Videos from application (if applicable)


## Link to mock-ups/mock ups (image file if you have it) (if applicable)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Unit tests written (if applicable)
- [x] e2e/accessibility tests written (if applicable)
- [x] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating JIRA issue
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs