### PR TITLE
dm-4749 add user roles to report

### DIFF
--- a/app/admin/users.rb
+++ b/app/admin/users.rb
@@ -29,7 +29,13 @@ ActiveAdmin.register User do
       row :visn
       row :created_at
       row :confirmed_at
-      row :roles
+      row "Admin" do |user|
+        user.has_role?(:admin)
+      end
+      row "PageGroup Editor Roles" do |user|
+        page_group_roles = user.roles.where(name: 'page_group_editor').map(&:resource_id).join(', ')
+        page_group_roles.present? ? page_group_roles : nil
+      end
       row :disabled
     end
     active_admin_comments

--- a/app/admin/users.rb
+++ b/app/admin/users.rb
@@ -71,4 +71,25 @@ ActiveAdmin.register User do
       super
     end
   end
+
+  csv do
+    column :email
+    column :last_sign_in_at
+    column :created_at
+    column :sign_in_count
+    column :first_name
+    column :last_name
+    column :job_title
+    column "Admin" do |user|
+      user.has_role?(:admin) ? 'TRUE' : 'FALSE'
+    end
+     column "PageGroup Editor Roles" do |user|
+      roles = user.roles.where(name: 'page_group_editor').map(&:resource_id)
+      if roles.empty?
+        ''
+      else
+        "\uFEFF" + roles.join(', ')
+      end
+    end
+  end
 end

--- a/app/admin/users.rb
+++ b/app/admin/users.rb
@@ -55,8 +55,8 @@ ActiveAdmin.register User do
       f.input :skip_va_validation
       f.input :password
       f.input :password_confirmation
-      # instance-scoped editor roles should be left out of the collection as they are handled in the
-      # given instance's edit form:
+      # instance-scoped editor roles should be left out of the collection as they are managed in the
+      # given page_group's edit form:
       f.input :roles, as: :check_boxes, collection: Role.where(name: ['admin'])
       f.input :disabled
     end

--- a/app/admin/users.rb
+++ b/app/admin/users.rb
@@ -33,8 +33,10 @@ ActiveAdmin.register User do
         user.has_role?(:admin)
       end
       row "PageGroup Editor Roles" do |user|
-        page_group_roles = user.roles.where(name: 'page_group_editor').map(&:resource_id).join(', ')
-        page_group_roles.present? ? page_group_roles : nil
+        page_group_roles = user.roles.where(name: 'page_group_editor').map do |role|
+          role.resource.try(:name)
+        end.compact
+        page_group_roles.empty? ? nil : page_group_roles.join(', ')
       end
       row :disabled
     end
@@ -83,13 +85,11 @@ ActiveAdmin.register User do
     column "Admin" do |user|
       user.has_role?(:admin) ? 'TRUE' : 'FALSE'
     end
-     column "PageGroup Editor Roles" do |user|
-      roles = user.roles.where(name: 'page_group_editor').map(&:resource_id)
-      if roles.empty?
-        ''
-      else
-        "\uFEFF" + roles.join(', ')
+    column "PageGroup Editor Roles" do |user|
+      roles = user.roles.where(name: 'page_group_editor').map do |role|
+        role.resource.name
       end
+      roles.compact.empty? ? '' : roles.join(', ')
     end
   end
 end

--- a/spec/features/admin/admin_spec.rb
+++ b/spec/features/admin/admin_spec.rb
@@ -611,7 +611,7 @@ describe 'The admin dashboard', type: :feature do
       execute_script("document.getElementById('user_role_ids_1').checked = true;")
       click_button('Update User')
       expect(page).to have_current_path(admin_user_path(User.last))
-      expect(page).to have_content('admin')
+      expect(page).to have_css('tr.row.row-admin', text: 'YES')
     end
   end
 


### PR DESCRIPTION
### JIRA issue link
https://agile6.atlassian.net/browse/DM-4749

## Description - what does this code do?
* Adds "Admin" and "PageGroup Editor Roles" to both the csv export and `show` configuration for `admin/users`

## Testing done - how did you test it/steps on how can another person can test it 
1. As admin, add a user to a few `page_group`s
2. Verify that when you "view" a user from the `admin/users` page (`/admin/users/{id})` you see the "PageGroup Editor Roles" row with the names of the `page_group`s the user is an editor for listed
3. Also verify there is an "Admin" role that populates with AA's "yes" or "no" colored boxes indicating the presence of an `:admin` role for the user.
4. Go back to the `admin/users` pages and utilize "Download: CSV" button to the bottom left of the index
5. Verify the output includes 2 columns coinciding with the new rows from step 2, but for the "Admin" value there will populate "TRUE" or "FALSE". Verify the rest of the columns are "Email", "Last sign in at", "Created at", "Sign in count", "First name", "Last name", "Job title". 

## Screenshots, Gifs, Videos from application (if applicable)
<img width="1725" alt="Screenshot 2024-04-26 at 2 43 15 PM" src="https://github.com/department-of-veterans-affairs/diffusion-marketplace/assets/65036872/87bbeedf-502f-466f-83d9-7dcb07678847">

<img width="1254" alt="Screenshot 2024-04-26 at 2 57 49 PM" src="https://github.com/department-of-veterans-affairs/diffusion-marketplace/assets/65036872/cce7e2e3-d1d1-41aa-96d5-d82684879ed9">

## Link to mock-ups/mock ups (image file if you have it) (if applicable)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Unit tests written (if applicable)
- [ ] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating JIRA issue
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs