### PR TITLE
dm-4764 fix mass assignment warning

### DIFF
--- a/app/controllers/practices_controller.rb
+++ b/app/controllers/practices_controller.rb
@@ -602,13 +602,14 @@ class PracticesController < ApplicationController # rubocop:disable Metrics/Clas
                                      additional_documents_attributes: [:id, :_destroy, :attachment, :title, :position],
                                      practice_permissions_attributes: [:id, :_destroy, :position, :name, :description],
                                      department: {},
+                                     department_practices_attributes: {},
                                      category: {},
                                      practice_award: {},
-                                     practice_resources_attributes: {},
-                                     practice_problem_resources_attributes: {},
-                                     practice_solution_resources_attributes: {},
-                                     practice_results_resources_attributes: {},
-                                     practice_multimedia_attributes: {},
+                                     practice_resources_attributes:  permitted_dynamic_keys(params[:practice][:practice_resources_attributes]),
+                                     practice_problem_resources_attributes: permitted_dynamic_keys(params[:practice][:practice_problem_resources_attributes]),
+                                     practice_solution_resources_attributes: permitted_dynamic_keys(params[:practice][:practice_solution_resources_attributes]),
+                                     practice_results_resources_attributes: permitted_dynamic_keys(params[:practice][:practice_results_resources_attributes]),
+                                     practice_multimedia_attributes: permitted_dynamic_keys(params[:practice][:practice_multimedia_attributes]),
                                      practice_email: {},
                                      practice_testimonials_attributes: [:id, :_destroy, :testimonial, :author, :position],
                                      practice_awards_attributes: [:id, :_destroy, :name],
@@ -621,6 +622,31 @@ class PracticesController < ApplicationController # rubocop:disable Metrics/Clas
                                      practice_partner_practices_attributes:  [:id, :practice_partner_id, :_destroy]
 
     )
+  end
+
+  def permitted_dynamic_keys(params)
+    return {} unless params
+    params.keys.each_with_object({}) do |key, result|
+      result[key] = [
+        :id,
+        :link_url,
+        :attachment_file_name,
+        :description,
+        :position,
+        :resource,
+        :resource_type_label,
+        :resource_type,
+        :media_type,
+        :crop_x,
+        :crop_y,
+        :crop_w,
+        :crop_h,
+        :name,
+        :image_alt_text,
+        :attachment,
+        :_destroy
+      ]
+    end
   end
 
   def can_view_practice
@@ -715,8 +741,12 @@ class PracticesController < ApplicationController # rubocop:disable Metrics/Clas
           initiating_facility_params_error = e
         end
       end
-
-      pr_params = {practice: @practice, practice_params: practice_params, current_endpoint: current_endpoint}
+      binding.pry
+      pr_params = {
+        practice: @practice,
+        practice_params: practice_params,
+        current_endpoint: current_endpoint,
+      }
 
       updated = initiating_facility_params_error.present? ? initiating_facility_params_error : SavePracticeService.new(pr_params).save_practice
       clear_origin_facilities if facility_type != "facility" && current_endpoint == 'introduction' && !updated.is_a?(StandardError)

--- a/app/controllers/practices_controller.rb
+++ b/app/controllers/practices_controller.rb
@@ -602,7 +602,7 @@ class PracticesController < ApplicationController # rubocop:disable Metrics/Clas
                                      additional_documents_attributes: [:id, :_destroy, :attachment, :title, :position],
                                      practice_permissions_attributes: [:id, :_destroy, :position, :name, :description],
                                      department: permitted_dynamic_keys(params[:practice][:department]),
-                                     category: [:value],
+                                     category: permitted_dynamic_keys(params[:practice][:category]),
                                      practice_award: permitted_dynamic_keys(params[:practice][:practice_award]),
                                      practice_resources_attributes: permitted_dynamic_keys(params[:practice][:practice_resources_attributes]),
                                      practice_problem_resources_attributes: permitted_dynamic_keys(params[:practice][:practice_problem_resources_attributes]),

--- a/app/controllers/practices_controller.rb
+++ b/app/controllers/practices_controller.rb
@@ -601,23 +601,20 @@ class PracticesController < ApplicationController # rubocop:disable Metrics/Clas
                                      publications_attributes: [:id, :_destroy, :title, :link, :position],
                                      additional_documents_attributes: [:id, :_destroy, :attachment, :title, :position],
                                      practice_permissions_attributes: [:id, :_destroy, :position, :name, :description],
-                                     department: {},
-                                     department_practices_attributes: {},
-                                     category: {},
-                                     practice_award: {},
-                                     practice_resources_attributes:  permitted_dynamic_keys(params[:practice][:practice_resources_attributes]),
+                                     department: permitted_dynamic_keys(params[:practice][:department]),
+                                     category: [:value],
+                                     practice_award: permitted_dynamic_keys(params[:practice][:practice_award]),
+                                     practice_resources_attributes: permitted_dynamic_keys(params[:practice][:practice_resources_attributes]),
                                      practice_problem_resources_attributes: permitted_dynamic_keys(params[:practice][:practice_problem_resources_attributes]),
                                      practice_solution_resources_attributes: permitted_dynamic_keys(params[:practice][:practice_solution_resources_attributes]),
                                      practice_results_resources_attributes: permitted_dynamic_keys(params[:practice][:practice_results_resources_attributes]),
                                      practice_multimedia_attributes: permitted_dynamic_keys(params[:practice][:practice_multimedia_attributes]),
-                                     practice_email: {},
                                      practice_testimonials_attributes: [:id, :_destroy, :testimonial, :author, :position],
                                      practice_awards_attributes: [:id, :_destroy, :name],
                                      categories_attributes: [:id, :_destroy, :name, :parent_category_id, :is_other],
                                      practice_origin_facilities_attributes: [:id, :_destroy, :facility_id, :va_facility_id, :clinical_resource_hub_id, :facility_type_and_id],
                                      practice_metrics_attributes: [:id, :_destroy, :description],
                                      practice_emails_attributes: [:id, :address, :_destroy],
-                                     duration: {},
                                      practice_editors_attributes: [:id, :email, :_destroy],
                                      practice_partner_practices_attributes:  [:id, :practice_partner_id, :_destroy]
 
@@ -626,8 +623,13 @@ class PracticesController < ApplicationController # rubocop:disable Metrics/Clas
 
   def permitted_dynamic_keys(params)
     return {} unless params
-    params.keys.each_with_object({}) do |key, result|
-      result[key] = [
+
+    params.transform_keys! do |key|
+      key.match?(/^\d+$/) ? "#{key}_resource" : key
+    end
+
+    params.keys.index_with do |_key|
+      [
         :id,
         :link_url,
         :attachment_file_name,
@@ -644,7 +646,8 @@ class PracticesController < ApplicationController # rubocop:disable Metrics/Clas
         :name,
         :image_alt_text,
         :attachment,
-        :_destroy
+        :_destroy,
+        :value
       ]
     end
   end
@@ -741,7 +744,7 @@ class PracticesController < ApplicationController # rubocop:disable Metrics/Clas
           initiating_facility_params_error = e
         end
       end
-      binding.pry
+
       pr_params = {
         practice: @practice,
         practice_params: practice_params,

--- a/app/services/save_practice_service.rb
+++ b/app/services/save_practice_service.rb
@@ -199,7 +199,7 @@ class SavePracticeService
     end
     if category_params.present?
       category_attribute_params = @practice_params[:categories_attributes]
-      cat_keys = category_params.keys
+      cat_keys = category_params.keys.map {|key| key.gsub("_resource", "")}
 
       cat_keys.each do |key|
         if practice_categories.ids.exclude?(key.to_i) && !key.include?('other')
@@ -237,7 +237,7 @@ class SavePracticeService
         other_parent_cat_options = ['other-clinical', 'other-operational', 'other-strategic']
         other_parent_cat_options.each do |opc|
           parent_cat = Category.get_category_by_name(opc.split('-').pop).first
-          if cat_keys.exclude?(opc)
+          if parent_cat && cat_keys.exclude?(opc)
             other_practice_categories.each do |oc|
               if oc.parent_category == parent_cat && CategoryPractice.where(category: oc).where('practice_id != ?', @practice.id).blank?
                 oc.destroy


### PR DESCRIPTION
### JIRA issue link
https://agile6.atlassian.net/browse/DM-4765

## Description - what does this code do?

Updates strong params in `PracticesController` to whitelist attrs as per [codeql alert](https://github.com/department-of-veterans-affairs/diffusion-marketplace/security/code-scanning/335) - difficult due to the dynamic nature of the param keys within the nested attributes, the keys need to be dynamic due to the javascript involved with the form for adding and removing fields but rails disallows strong params with integers as keys (even if in string form, if there is only ints in the string as the key it throws out the entirety of that nested attribute, thank you @aurora-a-k-a-lightning for shedding light on this). In order to get around this the keys needed to be updated to include alpha chars.

## Testing done - how did you test it/steps on how can another person can test it 
This touched many pieces of the Innovation editor workflow and so each needs to be tested to ensure full functionality remains in tact.

As editor of an innovation go through the edit workflow and add / remove / update the following components which can be found on the "Introduction", "Overview", and "Implementation" tabs:

1. Categories - test both "Clinical" and "Operational",  make sure to test adding and removing "Other" categories - Intro tab
2. Awards and recognition - Intro tab
3. Resources - problem, solution, results, add and remove text and attachments for each - Overview tab
4. Multimedia - test adding images and video links
5. Departments - Implementation tab
6. Core / Optional / Support resources and attachments, test each attachment type for each category - Implementation tab

## Screenshots, Gifs, Videos from application (if applicable)


## Link to mock-ups/mock ups (image file if you have it) (if applicable)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Unit tests written (if applicable)
- [ ] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating JIRA issue
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs