### PR TITLE
Change news component image ratio to 6:5

### DIFF
--- a/app/assets/stylesheets/dm/components/page_component.scss
+++ b/app/assets/stylesheets/dm/components/page_component.scss
@@ -203,6 +203,7 @@
     overflow: hidden;
 
     img {
+      object-fit: cover;
       flex-shrink: 0;
       min-height: 100%;
       min-width: 100%;

--- a/app/assets/stylesheets/dm/components/page_component.scss
+++ b/app/assets/stylesheets/dm/components/page_component.scss
@@ -196,8 +196,7 @@
 
   // replicates .dm-practice-card-img-container
   .dm-news-img-container {
-    max-height: 165px;
-    min-width: 100%;
+    aspect-ratio: 6/5;
     display: flex;
     justify-content: center;
     align-items: center;


### PR DESCRIPTION
### JIRA issue link
[DM-4744](https://agile6.atlassian.net/browse/DM-4744)

## Description - what does this code do?
Tweaks the CSS on the news component to set News Component images to a 6:5 ratio instead of a (? 516: 395) ratio

## Testing done - how did you test it/steps on how can another person can test it 
1. Create three news components with titles and descriptions.
2. Upload 3 types of images: 
- portrait (longer than wide)
- square 
- landscape (wider than long)
3. Confirm that when rendered, images are cropped to similar proportions.

## Screenshots, Gifs, Videos from application (if applicable)
![Screenshot 2024-05-08 at 3 45 22 PM](https://github.com/department-of-veterans-affairs/diffusion-marketplace/assets/5402927/92fc057e-aa0a-4c7d-a51b-7e97c3759c01)
![Screenshot 2024-05-08 at 3 46 14 PM](https://github.com/department-of-veterans-affairs/diffusion-marketplace/assets/5402927/de9177f7-653f-47af-a80f-0d8f3ff87566)

