### PR TITLE
Dm 4626 reorder communities dropdown

### DIFF
--- a/app/helpers/navbar_helper.rb
+++ b/app/helpers/navbar_helper.rb
@@ -30,14 +30,12 @@ module NavbarHelper
   end
 
   def assemble_page_group_hash(query)
-    query.each_with_object({}) do |page_group, acc|
-      key = page_group.name
-      home_page = page_group.pages.first
-      home_page_published = home_page.published?
-      if !home_page_published
-        key += " - Preview"
-      end
-      acc[key] = page_group.slug
+    communities = query.sort_by{|page_group| PageGroup::COMMUNITIES.index(page_group.name)}
+
+    communities.each_with_object({}) do |community, communities_hash|
+      key = community.name
+      key += " - Preview" if !community.pages.first&.published?
+      communities_hash[key] = community.slug
     end
   end
 end

--- a/app/models/page_group.rb
+++ b/app/models/page_group.rb
@@ -1,8 +1,8 @@
 class PageGroup < ApplicationRecord
   COMMUNITIES = [
+		"Age-Friendly",
     "VA Immersive",
-		"Suicide Prevention",
-		"Age-Friendly"
+		"Suicide Prevention"
   ]
   extend FriendlyId
   friendly_id :name, use: :slugged


### PR DESCRIPTION
### JIRA issue link
https://agile6.atlassian.net/browse/DM-4626

## Description - what does this code do?
Updates `PageGroup::COMMUNITIES` ordering as per design

Updates `NavbarHelper#assemble_page_group_hash` so that the `page_groups` being returned in the hash are ordered according to `PageGroup::COMMUNITIES`

## Testing done - how did you test it/steps on how can another person can test it 
1. Add the "Age-Friendly", "VA Immersive", and "Suicide Prevention" page groups, make sure to add their home pages
2. Verify they appear in order regardless of their published or public status (if not public they should only appear for logged-in va users and if not published they should only appear for admins or editors of the given `page_group` with " - Preview" added to the link in the "Communities" dropdown)

## Screenshots, Gifs, Videos from application (if applicable)
![Screenshot 2024-05-09 at 12 21 12 PM](https://github.com/department-of-veterans-affairs/diffusion-marketplace/assets/65036872/d14a6818-236c-4a3f-b851-20357d4716e3)

## Link to mock-ups/mock ups (image file if you have it) (if applicable)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Unit tests written (if applicable)
- [ ] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating JIRA issue
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs