### PR TITLE
DM-4810: Hide "Implementation" section from innovation#show if no fields are filled out

### DIFF
--- a/app/views/practices/show/show.html.erb
+++ b/app/views/practices/show/show.html.erb
@@ -4,6 +4,7 @@
     <%= render partial: 'practices/show/ahoy_event_tracking', formats: [:js] if current_user.present? %>
   <% end %>
 <% end %>
+<% implementation_data_present = @practice.timelines.any? || @practice.department_practices.any? || @practice.practice_resources.any? || @practice.risk_mitigations.any? %>
 <% provide :footer_classes, 'practice-show' %>
 
 <section class="usa-section padding-y-0 margin-bottom-1 margin-top-0">
@@ -28,9 +29,11 @@
       <li class="usa-sidenav__item">
         <a href="#overview" class="top-tab scroll-to sidebar-overview" data-target="#overview" data-turbolinks="false">Overview</a>
       </li>
-      <li class="usa-sidenav__item">
-        <a href="#implementation" class="bottom-tab scroll-to sidebar-implementation" data-target="#implementation" data-turbolinks="false">Implementation</a>
-      </li>
+      <% if implementation_data_present %>
+        <li class="usa-sidenav__item">
+          <a href="#implementation" class="bottom-tab scroll-to sidebar-implementation" data-target="#implementation" data-turbolinks="false">Implementation</a>
+        </li>
+      <% end %>
       <li class="usa-sidenav__item">
         <a href="#contact" class="bottom-tab scroll-to sidebar-contact" data-target="#contact" data-turbolinks="false">Contact</a>
       </li>
@@ -146,7 +149,7 @@
 <% end %>
 
 <!-- Implementation section -->
-<% if @practice.timelines.any? || @practice.department_practices.any? || @practice.practice_resources.any? || @practice.risk_mitigations.any? %>
+<% if implementation_data_present %>
   <section id="implementation" class="grid-container nav-header">
     <div class="grid-row grid-gap-2">
       <div class="desktop:grid-col-3 desktop:grid-col-auto desktop:z-bottom desktop:display-block display-none">&nbsp;</div>

--- a/app/views/practices/show/show.html.erb
+++ b/app/views/practices/show/show.html.erb
@@ -146,37 +146,39 @@
 <% end %>
 
 <!-- Implementation section -->
-<section id="implementation" class="grid-container nav-header">
-  <div class="grid-row grid-gap-2">
-    <div class="desktop:grid-col-3 desktop:grid-col-auto desktop:z-bottom desktop:display-block display-none">&nbsp;</div>
-    <div class="desktop:grid-col-9 grid-col-12 padding-top-10">
-      <div class="practice-editor-long-rect-svg border-top-05 border-primary-dark"></div>
-      <h2 class="font-sans-xl line-height-37px margin-top-2 margin-bottom-10">Implementation</h2>
-      <div class="metric-section practice-section margin-bottom-5">
-        <% if @practice.timelines.any? %>
-          <section id="dm-implementation-timeline" class="margin-bottom-5">
-            <%= render partial: 'practices/show/implementation/timelines' %>
-          </section>
-        <% end %>
-        <% if @practice.department_practices.any? %>
-          <section id="dm-implementation-departments" class="margin-bottom-5">
-            <%= render partial: 'practices/show/implementation/departments' %>
-          </section>
-        <% end %>
-        <% if @practice.practice_resources.any? %>
-          <section id="dm-implementation-show-resources">
-            <%= render partial: 'practices/show/implementation/show_resources' %>
-          </section>
-        <% end %>
-        <% if @practice.risk_mitigations.any? %>
-          <section id="dm-implementation-risk-mitigations" class="margin-bottom-5">
-            <%= render partial: 'practices/show/implementation/risks_and_mitigations' %>
-          </section>
-        <% end %>
+<% if @practice.timelines.any? || @practice.department_practices.any? || @practice.practice_resources.any? || @practice.risk_mitigations.any? %>
+  <section id="implementation" class="grid-container nav-header">
+    <div class="grid-row grid-gap-2">
+      <div class="desktop:grid-col-3 desktop:grid-col-auto desktop:z-bottom desktop:display-block display-none">&nbsp;</div>
+      <div class="desktop:grid-col-9 grid-col-12 padding-top-10">
+        <div class="practice-editor-long-rect-svg border-top-05 border-primary-dark"></div>
+        <h2 class="font-sans-xl line-height-37px margin-top-2 margin-bottom-10">Implementation</h2>
+        <div class="metric-section practice-section margin-bottom-5">
+          <% if @practice.timelines.any? %>
+            <section id="dm-implementation-timeline" class="margin-bottom-5">
+              <%= render partial: 'practices/show/implementation/timelines' %>
+            </section>
+          <% end %>
+          <% if @practice.department_practices.any? %>
+            <section id="dm-implementation-departments" class="margin-bottom-5">
+              <%= render partial: 'practices/show/implementation/departments' %>
+            </section>
+          <% end %>
+          <% if @practice.practice_resources.any? %>
+            <section id="dm-implementation-show-resources">
+              <%= render partial: 'practices/show/implementation/show_resources' %>
+            </section>
+          <% end %>
+          <% if @practice.risk_mitigations.any? %>
+            <section id="dm-implementation-risk-mitigations" class="margin-bottom-5">
+              <%= render partial: 'practices/show/implementation/risks_and_mitigations' %>
+            </section>
+          <% end %>
+        </div>
       </div>
     </div>
-  </div>
-</section>
+  </section>
+<% end %>
 
 
 <!-- Contact Section-->

--- a/spec/features/practice_editor/implementation/department_spec.rb
+++ b/spec/features/practice_editor/implementation/department_spec.rb
@@ -28,14 +28,9 @@ describe 'Practice', type: :feature, js: true do
     end
 
     it 'should allow the user to update the departments for the practice' do
-      # no departments should be there
+      # the implementation section should not render if there is no implementation data
       visit practice_path(@practice)
-      within(:css, '#implementation') do
-        expect(page).to have_no_content('Departments')
-        expect(page).to have_no_content('Admissions')
-        expect(page).to have_no_content('Anesthetics')
-        expect(page).to have_no_content('Chaplaincy')
-      end
+      expect(page).to have_no_css('#implementation')
 
       # navigate to the PE Implementation form
       click_link('Edit')


### PR DESCRIPTION
### JIRA issue link
https://agile6.atlassian.net/browse/DM-4810

## Description - what does this code do?
adds conditional in innovation show view to check for presence of implementation data in order to render section

## Testing done - how did you test it/steps on how can another person can test it 
1. Create or edit an existing practice
2. Leave all fields in the "Implementation" tab of the editor workflow blank
3. Verify the "Implementation" header and side nav tab don't appear in the show view
4. Verify the "Implementation" header and side nav tab do appear for Innovations with any data input in the "Implementation" tab of the editor workflow.

## Screenshots, Gifs, Videos from application (if applicable)
before:
![Screenshot 2024-05-14 at 5 16 53 PM](https://github.com/department-of-veterans-affairs/diffusion-marketplace/assets/65036872/c76bb2a0-57c5-48b7-b87d-d787df9b3387)

after:
![Screenshot 2024-05-14 at 5 16 24 PM](https://github.com/department-of-veterans-affairs/diffusion-marketplace/assets/65036872/16bceee2-f59d-4428-8d02-161b34ea177a)

## Link to mock-ups/mock ups (image file if you have it) (if applicable)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Unit tests written (if applicable)
- [ ] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating JIRA issue
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs