### PR TITLE
add Mission Daybreak awards to awards const in Practice model

### DIFF
--- a/app/models/practice.rb
+++ b/app/models/practice.rb
@@ -153,6 +153,9 @@ class Practice < ApplicationRecord
         'QUERI Partnered Evaluation Initiative',
         'Rural Promising Practice',
         'VHA Shark Tank Winner',
+        'Mission Daybreak Grand challenge winner',
+        'Mission Daybreak Grand challenge finalist',
+        'Mission Daybreak Grand challenge Promise Award recipient',
         'Other'
       ]
 


### PR DESCRIPTION
### JIRA issue link
https://agile6.atlassian.net/browse/DM-4811

## Description - what does this code do?
adds 3 new awards to `Practice::PRACTICE_EDITOR_AWARDS_AND_RECOGNITION`

## Testing done - how did you test it/steps on how can another person can test it 
1. Verify the 3 new "Mission Daybreak" awards are selectable in the Innovation editor workflow under the "Introduction" tab
2. Verify that when selected they render under the "AWARDS AND RECOGNITION" section of the given Innovations show page

## Screenshots, Gifs, Videos from application (if applicable)
<img width="969" alt="Screenshot 2024-05-14 at 4 00 45 PM" src="https://github.com/department-of-veterans-affairs/diffusion-marketplace/assets/65036872/9cdf7f7d-7065-438a-8fc8-0dc3b137b3be">
<img width="1098" alt="Screenshot 2024-05-14 at 4 02 56 PM" src="https://github.com/department-of-veterans-affairs/diffusion-marketplace/assets/65036872/aabce7fe-c1e5-41a7-9922-5b99c5a6f514">

## Link to mock-ups/mock ups (image file if you have it) (if applicable)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Unit tests written (if applicable)
- [ ] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating JIRA issue
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs