### PR TITLE
DM-4742: Update news and event component layouts to use 3 columns

### DIFF
--- a/app/controllers/page_controller.rb
+++ b/app/controllers/page_controller.rb
@@ -138,7 +138,7 @@ class PageController < ApplicationController
 
 
     set_pagy_practice_list_array(practice_lists) if practice_lists.present?
-    paginate_components(events, "events", 2) if events.present?
+    paginate_components(events, "events", 3) if events.present?
     paginate_components(news_items, "news", 6) if news_items.present?
     paginate_components(publications, "publications", 10) if publications.present?
   end

--- a/app/controllers/page_controller.rb
+++ b/app/controllers/page_controller.rb
@@ -138,7 +138,7 @@ class PageController < ApplicationController
 
 
     set_pagy_practice_list_array(practice_lists) if practice_lists.present?
-    paginate_components(events, "events", 3) if events.present?
+    paginate_components(events, "events", PageEventComponent::PAGINATION) if events.present?
     paginate_components(news_items, "news", 6) if news_items.present?
     paginate_components(publications, "publications", 10) if publications.present?
   end

--- a/app/controllers/page_controller.rb
+++ b/app/controllers/page_controller.rb
@@ -139,7 +139,7 @@ class PageController < ApplicationController
 
     set_pagy_practice_list_array(practice_lists) if practice_lists.present?
     paginate_components(events, "events", 2) if events.present?
-    paginate_components(news_items, "news", 4) if news_items.present?
+    paginate_components(news_items, "news", 6) if news_items.present?
     paginate_components(publications, "publications", 10) if publications.present?
   end
 

--- a/app/models/page_event_component.rb
+++ b/app/models/page_event_component.rb
@@ -1,6 +1,8 @@
 class PageEventComponent < ApplicationRecord
   has_one :page_component, as: :component, autosave: true
 
+  PAGINATION = 3.freeze
+
   FORM_FIELDS = { # Fields and labels in .arb form
     title: 'Title',
     url: 'URL',

--- a/app/views/page/_events_list.html.erb
+++ b/app/views/page/_events_list.html.erb
@@ -1,5 +1,5 @@
 <% events.each do |event|%>
-    <li class="page-event-component usa-card tablet:grid-col-6">
+    <li class="page-event-component usa-card tablet:grid-col-4">
         <div class="usa-card__container">
             <div class="usa-card__header">
                 <h3 class="event-title">

--- a/app/views/page/_news_items_list.html.erb
+++ b/app/views/page/_news_items_list.html.erb
@@ -1,5 +1,5 @@
 <% news_items.each do |news_item| %>
-    <li class="page-news-component usa-card tablet:grid-col-6">
+    <li class="page-news-component usa-card tablet:grid-col-4">
         <div class="usa-card__container">
             <% if news_item.image.present? %>
                 <div class="usa-card__media--inset">

--- a/app/views/page/_news_items_list.html.erb
+++ b/app/views/page/_news_items_list.html.erb
@@ -1,6 +1,6 @@
 <% news_items.each do |news_item| %>
     <li class="page-news-component usa-card tablet:grid-col-4">
-        <div class="usa-card__container">
+        <div class="usa-card__container margin-top-5">
             <% if news_item.image.present? %>
                 <div class="usa-card__media--inset">
                     <div class="dm-news-img-container">

--- a/app/views/page/show.html.erb
+++ b/app/views/page/show.html.erb
@@ -164,10 +164,10 @@
             %>
             <% unless elc[:events].all?(&:passed_and_hidden) %>
               <div class="grid-container">
-                <ul class="event-component-list usa-card-group dm-paginated-<%= component_index %>-events margin-bottom-4 <%= page_narrow_classes %><%= ' margin-bottom-0' if last_component === index %>">
+                <ul class="event-component-list grid-row grid-gap usa-card-group dm-paginated-<%= component_index %>-events margin-bottom-4 <%= page_narrow_classes %><%= ' margin-bottom-0' if last_component === index %>">
                   <%= render(partial: 'events_list', locals: {events: elc[:events]}) %>
                 </ul>
-                <% if elc[:pagy].count > 2  %>
+                <% if elc[:pagy].count > 3  %>
                   <div class="text-center dm-load-more-events-<%= component_index %>-btn-container margin-bottom-4">
                     <% link = pagy_link_proc(elc[:pagy]) %>
                     <%=  link.call(elc[:pagy].vars[:page] + 1, 'Load more').html_safe %>

--- a/app/views/page/show.html.erb
+++ b/app/views/page/show.html.erb
@@ -214,7 +214,7 @@
                 <%= render partial:'news_items_list', locals: {news_items: nic[:news]} %>
               </ul>
               <% if nic[:pagy].count > 6 %>
-                <div class="text-center dm-load-more-news-<%= component_index %>-btn-container" >
+                <div class="text-center dm-load-more-news-<%= component_index %>-btn-container margin-top-5" >
                   <% link = pagy_link_proc(nic[:pagy]) %>
                   <%=  link.call(nic[:pagy].vars[:page] + 1, 'Load more').html_safe %>
                 </div>

--- a/app/views/page/show.html.erb
+++ b/app/views/page/show.html.erb
@@ -210,7 +210,7 @@
               @news_list_component_index = component_index + 1
             %>
             <div class="grid-container margin-bottom-5 <%= ' margin-bottom-0' if last_component === index %>">
-              <ul class="usa-card-group news-component-list dm-paginated-<%= component_index %>-news <%= page_narrow_classes %>">
+              <ul class="usa-card-group grid-row grid-gap news-component-list dm-paginated-<%= component_index %>-news <%= page_narrow_classes %>">
                 <%= render partial:'news_items_list', locals: {news_items: nic[:news]} %>
               </ul>
               <% if nic[:pagy].count > 6 %>

--- a/app/views/page/show.html.erb
+++ b/app/views/page/show.html.erb
@@ -213,7 +213,7 @@
               <ul class="usa-card-group news-component-list dm-paginated-<%= component_index %>-news <%= page_narrow_classes %>">
                 <%= render partial:'news_items_list', locals: {news_items: nic[:news]} %>
               </ul>
-              <% if nic[:pagy].count > 4 %>
+              <% if nic[:pagy].count > 6 %>
                 <div class="text-center dm-load-more-news-<%= component_index %>-btn-container" >
                   <% link = pagy_link_proc(nic[:pagy]) %>
                   <%=  link.call(nic[:pagy].vars[:page] + 1, 'Load more').html_safe %>

--- a/app/views/page/show.html.erb
+++ b/app/views/page/show.html.erb
@@ -167,7 +167,7 @@
                 <ul class="event-component-list grid-row grid-gap usa-card-group dm-paginated-<%= component_index %>-events margin-bottom-4 <%= page_narrow_classes %><%= ' margin-bottom-0' if last_component === index %>">
                   <%= render(partial: 'events_list', locals: {events: elc[:events]}) %>
                 </ul>
-                <% if elc[:pagy].count > 3  %>
+                <% if elc[:pagy].count > PageEventComponent::PAGINATION  %>
                   <div class="text-center dm-load-more-events-<%= component_index %>-btn-container margin-bottom-4">
                     <% link = pagy_link_proc(elc[:pagy]) %>
                     <%=  link.call(elc[:pagy].vars[:page] + 1, 'Load more').html_safe %>

--- a/spec/features/pages/event_component_spec.rb
+++ b/spec/features/pages/event_component_spec.rb
@@ -3,103 +3,95 @@ describe 'Page Builder - Show - Events', type: :feature, js: true do
   before do
     page_group = create(:page_group, name: 'programming', slug: 'programming', description: 'Pages about programming go in this group.')
     @page = create(:page, page_group: page_group, title: 'ruby', description: 'what a gem', slug: 'ruby-rocks', has_chrome_warning_banner: true, created_at: Time.now, published: Time.now)
-    @today = Date.current
-
-    @h1 = create(:page_header2_component,subtopic_title: "Visible Upcoming Events")
-    create(:page_component, page: @page, component: @h1, position: 1)
-    @e1 = create(:page_event_component, title: "upcoming event1", start_date: @today + 5.days, end_date: @today + 7.days, hide_after_date: true)
-    create(:page_component, page: @page, component: @e1, position: 2)
-    @e2 = create(:page_event_component, title: "upcoming event2", start_date: @today + 5.days, end_date: @today + 7.days, hide_after_date: true)
-    create(:page_component, page: @page, component: @e2, position: 3)
-    @e3 = create(:page_event_component, title: "upcoming event3", start_date: @today + 5.days, end_date: @today + 7.days, hide_after_date: true)
-    create(:page_component, page: @page, component: @e3, position: 4)
-    @u4 = create(:page_event_component, title: "upcoming event4", start_date: @today + 5.days, end_date: @today + 7.days, hide_after_date: true)
-    create(:page_component, page: @page, component: @u4, position: 5)
-
-    @h2 = create(:page_header2_component,subtopic_title: "Past Events")
-    create(:page_component, page: @page, component: @h2, position: 6)
-    @e4 = create(:page_event_component, title: "past event1", start_date: @today - 2.days, end_date: @today - 1.days, hide_after_date: false)
-    create(:page_component, page: @page, component: @e4, position: 7)
-    @e5 = create(:page_event_component, title: "past event2", start_date: @today - 2.days, end_date: @today - 1.days, hide_after_date: false)
-    create(:page_component, page: @page, component: @e5, position: 8)
-    @e6 = create(:page_event_component, title: "past event3", start_date: @today - 2.days, end_date: @today - 1.days, hide_after_date: false)
-    create(:page_component, page: @page, component: @e6, position: 9)
-    @p7 = create(:page_event_component, title: "past event4", start_date: @today - 2.days, end_date: @today - 1.days, hide_after_date: false)
-    create(:page_component, page: @page, component: @p7, position: 10)
-    
+    @event_pagination_size = 3
 
     user = create(:user)
     login_as(user, scope: :user, run_callbacks: false)
   end
 
   context 'Hide events after date' do
-
     it 'displays events correctly with pagination functionality' do
-      visit 'programming/ruby-rocks'
+      @h1 = create(:page_header2_component,subtopic_title: "Visible Upcoming Events")
+      PageComponent.create(page: @page, component: @h1)
+      upcoming_events = create_list(:page_event_component, @event_pagination_size + 1) do |event, i| 
+        event.title = "upcoming event #{i + 1}"
+        event.start_date = 5.days.from_now
+        event.end_date = 7.days.from_now
+        event.hide_after_date = true
+        event.save
+        PageComponent.create(page: @page, component: event)
+      end
 
-      expect(page).to have_content(@h1.subtopic_title)
-      expect(page).to have_content(@e1.title)
-      expect(page).to have_content(@e2.title)
-      expect(page).to have_content(@e3.title)
-      expect(page).not_to have_content(@u4.title)
-      page.has_link?('Load more', href: /events-0=2/)
-      find('a', text: 'Load more', match: :first).click
-      expect(page).to have_content(@u4.title)
-
-      expect(page).to have_content(@h2.subtopic_title)
-      expect(page).to have_content(@e4.title)
-      expect(page).to have_content(@e5.title)
-      expect(page).to have_content(@e6.title)
-      expect(page).not_to have_content(@p7.title)
-      page.has_link?('Load more', href: /events-1=2/)
-      find('a', text: 'Load more', match: :first).click
-      expect(page).to have_content(@p7.title)
-    end
-
-    it 'hides events once they have passed and are marked as auto-hide and updates pagination' do
-      @e3.update!(start_date: @today - 3.days, end_date: @today - 2.days)
-
-      visit 'programming/ruby-rocks'
-
-      expect(page).to have_content(@h1.subtopic_title)
-      expect(page).to have_content(@e1.title)
-      expect(page).to have_content(@e2.title)
-      expect(page).not_to have_content(@e3.title)
-      expect(page).to have_content(@u4.title)
-      expect(page).to have_no_link('Load more', href: /events-0=2/)
-
-      expect(page).to have_content(@h2.subtopic_title)
-      expect(page).to have_content(@e4.title)
-      expect(page).to have_content(@e5.title)
-      expect(page).to have_content(@e6.title)
-      expect(page).not_to have_content(@p7.title)
-      page.has_link?('Load more', href: /events-1=2/)
-      find('a', text: 'Load more', match: :first).click
-      expect(page).to have_content(@p7.title)
-    end
-
-    it 'displays text if all events in a group are passed and hidden' do
-      [@e1, @e2, @e3, @u4].each do |e|
-        e.update(start_date: @today - 3.days, end_date: @today - 2.days)
+      @h2 = create(:page_header2_component,subtopic_title: "Past Events")
+      PageComponent.create(page: @page, component: @h2)
+      past_events = create_list(:page_event_component, @event_pagination_size + 1) do |event, i|
+        event.title = "past event #{i + 1}"
+        event.start_date = 3.days.ago
+        event.end_date = 2.days.ago
+        event.hide_after_date = false
+        event.save
+        PageComponent.create(page: @page, component: event)
       end
 
       visit 'programming/ruby-rocks'
 
-      expect(page).to have_content(@h1.subtopic_title)
-      expect(page).not_to have_content(@e1.title)
-      expect(page).not_to have_content(@e2.title)
-      expect(page).not_to have_content(@e3.title)
-      expect(page).not_to have_content(@u4.title)
-      expect(page).to have_no_link('Load more', href: /events-0=2/)
+      @event_pagination_size.times do |i| 
+        expect(page).to have_content ("upcoming event #{i + 1}")
+        expect(page).to have_content ("past event #{i + 1}")
+      end
 
-      expect(page).to have_content(@h2.subtopic_title)
-      expect(page).to have_content(@e4.title)
-      expect(page).to have_content(@e5.title)
-      expect(page).to have_content(@e6.title)
-      expect(page).not_to have_content(@p7.title)
+      expect(page).not_to have_content("upcoming event #{@event_pagination_size + 1}")
+      page.has_link?('Load more', href: /events-0=2/)
+      find('a', text: 'Load more', match: :first).click
+      expect(page).to have_content("upcoming event #{@event_pagination_size + 1}")
+
+      expect(page).not_to have_content("past event #{@event_pagination_size + 1}")
       page.has_link?('Load more', href: /events-1=2/)
       find('a', text: 'Load more', match: :first).click
-      expect(page).to have_content(@p7.title)
+      expect(page).to have_content("past event #{@event_pagination_size + 1}")
+    end
+
+    it 'hides events once they have passed and are marked as auto-hide and updates pagination' do
+      @h1 = create(:page_header2_component,subtopic_title: "Visible Upcoming Events")
+      PageComponent.create(page: @page, component: @h1)
+      expired_event = create(:page_event_component, hide_after_date: true, title: "expired event", start_date: 3.days.ago, end_date: 2.days.ago)
+      PageComponent.create(page: @page, component: @expired_event)
+
+      create_list(:page_event_component, @event_pagination_size) do |event, i| # zero index
+        event.title = "upcoming event #{i + 1}"
+        event.start_date = 5.days.from_now
+        event.end_date = 7.days.from_now
+        event.hide_after_date = true
+        event.save!
+        PageComponent.create(page: @page, component: event)
+      end
+
+      visit 'programming/ruby-rocks'
+
+      expect(page).not_to have_content(expired_event.title)
+      @event_pagination_size.times {|i| expect(page).to have_content("upcoming event #{i + 1}")}
+      expect(page).to have_no_link('Load more', href: /events-0=2/)
+    end
+
+    it 'displays text if all events in a group are passed and hidden' do
+      @h1 = create(:page_header2_component,subtopic_title: "Visible Upcoming Events")
+      PageComponent.create(page: @page, component: @h1)
+
+      past_events = create_list(:page_event_component, @event_pagination_size + 1) do |event, i|
+        event.title = "expired event #{i + 1}"
+        event.start_date = 3.days.ago
+        event.end_date = 2.days.ago
+        event.hide_after_date = true
+        event.save
+        PageComponent.create(page: @page, component: event)
+      end
+
+      (@event_pagination_size + 1).times { |i| PageComponent.create(page: @page, component: @expired_event)}
+
+      visit 'programming/ruby-rocks'
+      expect(page).not_to have_content("expired event")
+      expect(page).to have_no_link('Load more', href: /events-0=2/)
+      expect(page).to have_content('Please check back for more events soon!')
     end
   end
 end

--- a/spec/features/pages/event_component_spec.rb
+++ b/spec/features/pages/event_component_spec.rb
@@ -1,5 +1,5 @@
 require 'rails_helper'
-describe 'Page Builder - Show - Paginated Components - Events', type: :feature, js: true do
+describe 'Page Builder - Show - Events', type: :feature, js: true do
   before do
     page_group = create(:page_group, name: 'programming', slug: 'programming', description: 'Pages about programming go in this group.')
     @page = create(:page, page_group: page_group, title: 'ruby', description: 'what a gem', slug: 'ruby-rocks', has_chrome_warning_banner: true, created_at: Time.now, published: Time.now)
@@ -13,80 +13,94 @@ describe 'Page Builder - Show - Paginated Components - Events', type: :feature, 
     create(:page_component, page: @page, component: @e2, position: 3)
     @e3 = create(:page_event_component, title: "upcoming event3", start_date: @today + 5.days, end_date: @today + 7.days, hide_after_date: true)
     create(:page_component, page: @page, component: @e3, position: 4)
+    @u4 = create(:page_event_component, title: "upcoming event4", start_date: @today + 5.days, end_date: @today + 7.days, hide_after_date: true)
+    create(:page_component, page: @page, component: @u4, position: 5)
 
     @h2 = create(:page_header2_component,subtopic_title: "Past Events")
-    create(:page_component, page: @page, component: @h2, position: 5)
+    create(:page_component, page: @page, component: @h2, position: 6)
     @e4 = create(:page_event_component, title: "past event1", start_date: @today - 2.days, end_date: @today - 1.days, hide_after_date: false)
-    create(:page_component, page: @page, component: @e4, position: 6)
+    create(:page_component, page: @page, component: @e4, position: 7)
     @e5 = create(:page_event_component, title: "past event2", start_date: @today - 2.days, end_date: @today - 1.days, hide_after_date: false)
-    create(:page_component, page: @page, component: @e5, position: 7)
+    create(:page_component, page: @page, component: @e5, position: 8)
     @e6 = create(:page_event_component, title: "past event3", start_date: @today - 2.days, end_date: @today - 1.days, hide_after_date: false)
-    create(:page_component, page: @page, component: @e6, position: 8)
+    create(:page_component, page: @page, component: @e6, position: 9)
+    @p7 = create(:page_event_component, title: "past event4", start_date: @today - 2.days, end_date: @today - 1.days, hide_after_date: false)
+    create(:page_component, page: @page, component: @p7, position: 10)
+    
 
     user = create(:user)
     login_as(user, scope: :user, run_callbacks: false)
   end
 
-  it 'displays events correctly with pagination functionality' do
-    visit 'programming/ruby-rocks'
+  context 'Hide events after date' do
 
-    expect(page).to have_content(@h1.subtopic_title)
-    expect(page).to have_content(@e1.title)
-    expect(page).to have_content(@e2.title)
-    expect(page).not_to have_content(@e3.title)
-    page.has_link?('Load more', href: /events-0=2/)
-    find('a', text: 'Load more', match: :first).click
-    expect(page).to have_content(@e3.title)
+    it 'displays events correctly with pagination functionality' do
+      visit 'programming/ruby-rocks'
 
-    expect(page).to have_content(@h2.subtopic_title)
-    expect(page).to have_content(@e4.title)
-    expect(page).to have_content(@e5.title)
-    expect(page).not_to have_content(@e6.title)
-    page.has_link?('Load more', href: /events-1=2/)
-    find('a', text: 'Load more', match: :first).click
-    expect(page).to have_content(@e6.title)
-  end
+      expect(page).to have_content(@h1.subtopic_title)
+      expect(page).to have_content(@e1.title)
+      expect(page).to have_content(@e2.title)
+      expect(page).to have_content(@e3.title)
+      expect(page).not_to have_content(@u4.title)
+      page.has_link?('Load more', href: /events-0=2/)
+      find('a', text: 'Load more', match: :first).click
+      expect(page).to have_content(@u4.title)
 
-  it 'hides events once they have passed and are marked as auto-hide and updates pagination' do
-    @e3.update!(start_date: @today - 3.days, end_date: @today - 2.days)
-
-    visit 'programming/ruby-rocks'
-
-    expect(page).to have_content(@h1.subtopic_title)
-    expect(page).to have_content(@e1.title)
-    expect(page).to have_content(@e2.title)
-    expect(page).not_to have_content(@e3.title)
-    expect(page).to have_no_link('Load more', href: /events-0=2/)
-
-    expect(page).to have_content(@h2.subtopic_title)
-    expect(page).to have_content(@e4.title)
-    expect(page).to have_content(@e5.title)
-    expect(page).not_to have_content(@e6.title)
-    page.has_link?('Load more', href: /events-1=2/)
-    find('a', text: 'Load more', match: :first).click
-    expect(page).to have_content(@e6.title)
-  end
-
-  it 'displays text if all events in a group are passed and hidden' do
-    [@e1, @e2, @e3].each do |e|
-      e.update(start_date: @today - 3.days, end_date: @today - 2.days)
+      expect(page).to have_content(@h2.subtopic_title)
+      expect(page).to have_content(@e4.title)
+      expect(page).to have_content(@e5.title)
+      expect(page).to have_content(@e6.title)
+      expect(page).not_to have_content(@p7.title)
+      page.has_link?('Load more', href: /events-1=2/)
+      find('a', text: 'Load more', match: :first).click
+      expect(page).to have_content(@p7.title)
     end
 
-    visit 'programming/ruby-rocks'
+    it 'hides events once they have passed and are marked as auto-hide and updates pagination' do
+      @e3.update!(start_date: @today - 3.days, end_date: @today - 2.days)
 
-    expect(page).to have_content(@h1.subtopic_title)
-    expect(page).not_to have_content(@e1.title)
-    expect(page).not_to have_content(@e2.title)
-    expect(page).not_to have_content(@e3.title)
-    expect(page).to have_no_link('Load more', href: /events-0=2/)
+      visit 'programming/ruby-rocks'
 
-    expect(page).to have_content(@h2.subtopic_title)
-    expect(page).to have_content(@e4.title)
-    expect(page).to have_content(@e5.title)
-    expect(page).not_to have_content(@e6.title)
-    page.has_link?('Load more', href: /events-1=2/)
-    find('a', text: 'Load more', match: :first).click
-    expect(page).to have_content(@e6.title)
+      expect(page).to have_content(@h1.subtopic_title)
+      expect(page).to have_content(@e1.title)
+      expect(page).to have_content(@e2.title)
+      expect(page).not_to have_content(@e3.title)
+      expect(page).to have_content(@u4.title)
+      expect(page).to have_no_link('Load more', href: /events-0=2/)
+
+      expect(page).to have_content(@h2.subtopic_title)
+      expect(page).to have_content(@e4.title)
+      expect(page).to have_content(@e5.title)
+      expect(page).to have_content(@e6.title)
+      expect(page).not_to have_content(@p7.title)
+      page.has_link?('Load more', href: /events-1=2/)
+      find('a', text: 'Load more', match: :first).click
+      expect(page).to have_content(@p7.title)
+    end
+
+    it 'displays text if all events in a group are passed and hidden' do
+      [@e1, @e2, @e3, @u4].each do |e|
+        e.update(start_date: @today - 3.days, end_date: @today - 2.days)
+      end
+
+      visit 'programming/ruby-rocks'
+
+      expect(page).to have_content(@h1.subtopic_title)
+      expect(page).not_to have_content(@e1.title)
+      expect(page).not_to have_content(@e2.title)
+      expect(page).not_to have_content(@e3.title)
+      expect(page).not_to have_content(@u4.title)
+      expect(page).to have_no_link('Load more', href: /events-0=2/)
+
+      expect(page).to have_content(@h2.subtopic_title)
+      expect(page).to have_content(@e4.title)
+      expect(page).to have_content(@e5.title)
+      expect(page).to have_content(@e6.title)
+      expect(page).not_to have_content(@p7.title)
+      page.has_link?('Load more', href: /events-1=2/)
+      find('a', text: 'Load more', match: :first).click
+      expect(page).to have_content(@p7.title)
+    end
   end
 end
 

--- a/spec/features/pages/event_component_spec.rb
+++ b/spec/features/pages/event_component_spec.rb
@@ -3,7 +3,7 @@ describe 'Page Builder - Show - Events', type: :feature, js: true do
   before do
     page_group = create(:page_group, name: 'programming', slug: 'programming', description: 'Pages about programming go in this group.')
     @page = create(:page, page_group: page_group, title: 'ruby', description: 'what a gem', slug: 'ruby-rocks', has_chrome_warning_banner: true, created_at: Time.now, published: Time.now)
-    @event_pagination_size = 3
+    @event_pagination_size = PageEventComponent::PAGINATION
 
     user = create(:user)
     login_as(user, scope: :user, run_callbacks: false)

--- a/spec/features/pages/news_component_spec.rb
+++ b/spec/features/pages/news_component_spec.rb
@@ -1,5 +1,5 @@
 require 'rails_helper'
-describe 'Page Builder - Show - Paginated Components', type: :feature do
+describe 'Page Builder - Show - News Components', type: :feature do
   before do
     page_group = create(:page_group, name: 'programming', slug: 'programming', description: 'Pages about programming go in this group.')
     @page = create(:page, page_group: page_group, title: 'ruby', description: 'what a gem', slug: 'ruby-rocks', has_chrome_warning_banner: true, created_at: Time.now, published: Time.now)

--- a/spec/features/pages/paginated_components_spec.rb
+++ b/spec/features/pages/paginated_components_spec.rb
@@ -6,7 +6,7 @@ describe 'Page Builder - Show - Paginated Components', type: :feature do
     @user.add_role(:admin)
     @page_group = PageGroup.create(name: 'programming', slug: 'programming', description: 'Pages about programming go in this group.')
     @paragraph_component = PageParagraphComponent.create(text: "<div><p>Just some filler text</p></div>")
-    @event_pagination_size = 3
+    @event_pagination_size = PageEventComponent::PAGINATION
     @news_pagination_size = 6
 
 

--- a/spec/features/pages/paginated_components_spec.rb
+++ b/spec/features/pages/paginated_components_spec.rb
@@ -6,8 +6,8 @@ describe 'Page Builder - Show - Paginated Components', type: :feature do
     @user.add_role(:admin)
     @page_group = PageGroup.create(name: 'programming', slug: 'programming', description: 'Pages about programming go in this group.')
     @paragraph_component = PageParagraphComponent.create(text: "<div><p>Just some filler text</p></div>")
-    @event_pagination_size = 2
-    @news_pagination_size = 4
+    @event_pagination_size = 3
+    @news_pagination_size = 6
 
 
     # must be logged in to view pages


### PR DESCRIPTION
### JIRA issue link
[DM-4745](https://agile6.atlassian.net/browse/DM-4745)
[DM-4559](https://agile6.atlassian.net/browse/DM-4559)

## Description - what does this code do?
- Updates News and Events components to use a 3 column layout
  - tweak the margin between columns
- Updates specs for event components so that they're easier to rewrite if pagination thresholds change
  - Uses some factorybot methods to deal with repetitive fixture creation 

## Testing done - how did you test it/steps on how can another person can test it 
1. Log in as an admin.
1. Create a page group
1. Create a page
1. Create 7 News components
1. Create 4 Events components
1. Confirm that news components are paginated after 6 
1. Confirm that event components are paginated after 4

## Screenshots, Gifs, Videos from application (if applicable)
### Before
![Screenshot 2024-05-20 at 5 22 22 PM](https://github.com/department-of-veterans-affairs/diffusion-marketplace/assets/5402927/2b285d0e-3470-44b8-b8dc-a695ecf714ca)
### After
![Screenshot 2024-05-20 at 5 21 38 PM](https://github.com/department-of-veterans-affairs/diffusion-marketplace/assets/5402927/0dcbcced-5ec8-431a-9219-da501f0cb740)

### Before
![Screenshot 2024-05-20 at 5 22 19 PM](https://github.com/department-of-veterans-affairs/diffusion-marketplace/assets/5402927/f3bc759f-0dd3-40d5-ada0-3857382cb7b3)

### After
![Screenshot 2024-05-20 at 5 21 30 PM](https://github.com/department-of-veterans-affairs/diffusion-marketplace/assets/5402927/05a31cbc-e493-4ff8-96a5-6f8e17ca05c4)

