### PR TITLE
DM-4742: Move links out of Event, News, and Publication component titles

### DIFF
--- a/app/models/page_event_component.rb
+++ b/app/models/page_event_component.rb
@@ -5,7 +5,8 @@ class PageEventComponent < ApplicationRecord
 
   FORM_FIELDS = { # Fields and labels in .arb form
     title: 'Title',
-    url: 'URL',
+    url: 'Link URL',
+    url_link_text: 'Link Title',
     presented_by: 'Presented by',
     start_date: 'Start date',
     end_date: 'End date',

--- a/app/models/page_news_component.rb
+++ b/app/models/page_news_component.rb
@@ -4,7 +4,8 @@ class PageNewsComponent < ApplicationRecord
 
   FORM_FIELDS = {
     title: 'Title',
-    url: 'URL',
+    url: 'Link URL',
+    url_link_text: 'Link text',
     published_date: 'Publication date',
     authors: 'Author(s)',
     text: 'Description',

--- a/app/views/active_admin/resource/_page_event_component_form.html.arb
+++ b/app/views/active_admin/resource/_page_event_component_form.html.arb
@@ -92,7 +92,7 @@ html = Arbre::Context.new do
           input value: component&.url_link_text || nil, type: 'text',
                 id: "page_page_components_attributes_#{placeholder}_component_attributes_url_link_text",
                 name: "page[page_components_attributes][#{placeholder}][component_attributes][url_link_text]"
-          para 'URL used for event title link, e.g. https://va.gov', class: 'inline-hints'
+          para 'Add a call to action, e.g. "Register", "Join Webinar", View Event"', class: 'inline-hints'
         end
 
         li class: 'string input optional stringish', id: "page_page_components_attributes_#{placeholder}_component_attributes_url_input" do

--- a/app/views/active_admin/resource/_page_event_component_form.html.arb
+++ b/app/views/active_admin/resource/_page_event_component_form.html.arb
@@ -31,14 +31,6 @@ html = Arbre::Context.new do
           para 'Event title styled as an H3', class: 'inline-hints'
         end
 
-        li class: 'string input optional stringish', id: "page_page_components_attributes_#{placeholder}_component_attributes_url_input" do
-          label 'URL', for: "page_page_components_attributes_event_#{placeholder}_component_attributes_url", class: 'label'
-          input value: component&.url || nil, type: 'text',
-                id: "page_page_components_attributes_#{placeholder}_component_attributes_url",
-                name: "page[page_components_attributes][#{placeholder}][component_attributes][url]"
-          para 'URL used for event title link, e.g. https://va.gov', class: 'inline-hints'
-        end
-
         li class: 'string input optional stringish', id: "page_page_components_attributes_#{placeholder}_component_attributes_presented_by_input" do
           label 'Presented by', for: "page_page_components_attributes_event_#{placeholder}_component_attributes_presented_by", class: 'label'
           input value: component&.presented_by || nil, type: 'text',
@@ -93,6 +85,22 @@ html = Arbre::Context.new do
             component&.send(:text).try :html_safe
           end
           para '', class: 'inline-hints'
+        end
+
+        li class: 'string input optional stringish', id: "page_page_components_attributes_#{placeholder}_component_attributes_url_link_text_input" do
+          label 'Link Title', for: "page_page_components_attributes_event_#{placeholder}_component_attributes_url_link_text", class: 'label'
+          input value: component&.url_link_text || nil, type: 'text',
+                id: "page_page_components_attributes_#{placeholder}_component_attributes_url_link_text",
+                name: "page[page_components_attributes][#{placeholder}][component_attributes][url_link_text]"
+          para 'URL used for event title link, e.g. https://va.gov', class: 'inline-hints'
+        end
+
+        li class: 'string input optional stringish', id: "page_page_components_attributes_#{placeholder}_component_attributes_url_input" do
+          label 'Link URL', for: "page_page_components_attributes_event_#{placeholder}_component_attributes_url", class: 'label'
+          input value: component&.url || nil, type: 'text',
+                id: "page_page_components_attributes_#{placeholder}_component_attributes_url",
+                name: "page[page_components_attributes][#{placeholder}][component_attributes][url]"
+          para 'URL used for event title link, e.g. https://va.gov', class: 'inline-hints'
         end
       end
     end

--- a/app/views/active_admin/resource/_page_news_component_form.html.arb
+++ b/app/views/active_admin/resource/_page_news_component_form.html.arb
@@ -23,28 +23,40 @@ html = Arbre::Context.new do
       a 'Move to Top', href: '#', class: 'move-to-top float-right', id: component&.page_component&.id
 
       ol do
+        li class: 'file input optional', id: "page_page_components_attributes_#{placeholder}_component_attributes_image_input" do
+          label 'Image', for: "page_page_components_attributes_#{placeholder}_component_attributes_image", class: 'label'
+          input value: component&.image || nil, type: 'file', accept: '.jpg, .jpeg, .png',
+                id: "page_page_components_attributes_#{placeholder}_component_attributes_image",
+                name: "page[page_components_attributes][#{placeholder}][component_attributes][image]"
+          para 'File types allowed: jpg, png. Max file size: 25MB', class: 'inline-hints'
+        end
+
+        if component&.image.present?
+          li do
+            div class: 'page-image-preview-container no-padding' do
+              div class: 'placeholder'
+              div class: 'page-image-container' do
+                img class: 'page-image', src: component.image_s3_presigned_url, alt: component.image_alt_text
+                para "Current image name: #{component.image_file_name}"
+              end
+            end
+          end
+        end
+
+        li class: 'string input required stringish', id: "page_page_components_attributes_#{placeholder}_component_attributes_image_alt_text_input" do
+          label 'Alternative Text', for: "page_page_components_attributes_#{placeholder}_component_attributes_image_alt_text", class: 'label'
+          input value: component&.image_alt_text || nil, type: 'text', required: 'required',
+                id: "page_page_components_attributes_#{placeholder}_component_attributes_image_alt_text",
+                name: "page[page_components_attributes][#{placeholder}][component_attributes][image_alt_text]"
+          para 'Alternate text that gets rendered in case the image cannot load.', class: 'inline-hints'
+        end
+
         li class: 'string input optional stringish', id: "page_page_components_attributes_#{placeholder}_component_attributes_title_input" do
           label 'Title', for: "page_page_components_attributes_news_#{placeholder}_component_attributes_text", class: 'label'
           input value: component&.title || nil, type: 'text',
                 id: "page_page_components_attributes_#{placeholder}_component_attributes_title",
                 name: "page[page_components_attributes][#{placeholder}][component_attributes][title]"
           para 'News item title styled as an /"H3"', class: 'inline-hints'
-        end
-
-        li class: 'string input optional stringish', id: "page_page_components_attributes_#{placeholder}_component_attributes_url_input" do
-          label 'Link URL', for: "page_page_components_attributes_news_#{placeholder}_component_attributes_text", class: 'label'
-          input value: component&.url || nil, type: 'text',
-                id: "page_page_components_attributes_#{placeholder}_component_attributes_url",
-                name: "page[page_components_attributes][#{placeholder}][component_attributes][url]"
-          para 'Link to news item hosted elsewhere, e.g. https://va.gov', class: 'inline-hints'
-        end
-
-        li class: 'string input optional stringish', id: "page_page_components_attributes_#{placeholder}_component_attributes_url_link_text_input" do
-          label 'Link title', for: "page_page_components_attributes_news_#{placeholder}_component_attributes_text", class: 'label'
-          input value: component&.url_link_text || nil, type: 'text',
-                id: "page_page_components_attributes_#{placeholder}_component_attributes_url_link_text",
-                name: "page[page_components_attributes][#{placeholder}][component_attributes][url_link_text]"
-          para 'Link to news item hosted elsewhere, e.g. https://va.gov', class: 'inline-hints'
         end
 
         li class: 'date input optional', id: "page_page_components_attributes_#{placeholder}_component_attributes_published_date_input" do
@@ -75,32 +87,20 @@ html = Arbre::Context.new do
           para '', class: 'inline-hints'
         end
 
-        li class: 'file input optional', id: "page_page_components_attributes_#{placeholder}_component_attributes_image_input" do
-          label 'Image', for: "page_page_components_attributes_#{placeholder}_component_attributes_image", class: 'label'
-          input value: component&.image || nil, type: 'file', accept: '.jpg, .jpeg, .png',
-                id: "page_page_components_attributes_#{placeholder}_component_attributes_image",
-                name: "page[page_components_attributes][#{placeholder}][component_attributes][image]"
-          para 'File types allowed: jpg, png. Max file size: 25MB', class: 'inline-hints'
+        li class: 'string input optional stringish', id: "page_page_components_attributes_#{placeholder}_component_attributes_url_input" do
+          label 'Link URL', for: "page_page_components_attributes_news_#{placeholder}_component_attributes_text", class: 'label'
+          input value: component&.url || nil, type: 'text',
+                id: "page_page_components_attributes_#{placeholder}_component_attributes_url",
+                name: "page[page_components_attributes][#{placeholder}][component_attributes][url]"
+          para 'Link to news item hosted elsewhere, e.g. https://va.gov', class: 'inline-hints'
         end
 
-        if component&.image.present?
-          li do
-            div class: 'page-image-preview-container no-padding' do
-              div class: 'placeholder'
-              div class: 'page-image-container' do
-                img class: 'page-image', src: component.image_s3_presigned_url, alt: component.image_alt_text
-                para "Current image name: #{component.image_file_name}"
-              end
-            end
-          end
-        end
-
-        li class: 'string input required stringish', id: "page_page_components_attributes_#{placeholder}_component_attributes_image_alt_text_input" do
-          label 'Alternative Text', for: "page_page_components_attributes_#{placeholder}_component_attributes_image_alt_text", class: 'label'
-          input value: component&.image_alt_text || nil, type: 'text', required: 'required',
-                id: "page_page_components_attributes_#{placeholder}_component_attributes_image_alt_text",
-                name: "page[page_components_attributes][#{placeholder}][component_attributes][image_alt_text]"
-          para 'Alternate text that gets rendered in case the image cannot load.', class: 'inline-hints'
+        li class: 'string input optional stringish', id: "page_page_components_attributes_#{placeholder}_component_attributes_url_link_text_input" do
+          label 'Link Title', for: "page_page_components_attributes_news_#{placeholder}_component_attributes_text", class: 'label'
+          input value: component&.url_link_text || nil, type: 'text',
+                id: "page_page_components_attributes_#{placeholder}_component_attributes_url_link_text",
+                name: "page[page_components_attributes][#{placeholder}][component_attributes][url_link_text]"
+          para 'Link to news item hosted elsewhere, e.g. https://va.gov', class: 'inline-hints'
         end
       end
     end

--- a/app/views/active_admin/resource/_page_news_component_form.html.arb
+++ b/app/views/active_admin/resource/_page_news_component_form.html.arb
@@ -87,19 +87,19 @@ html = Arbre::Context.new do
           para '', class: 'inline-hints'
         end
 
-        li class: 'string input optional stringish', id: "page_page_components_attributes_#{placeholder}_component_attributes_url_input" do
-          label 'Link URL', for: "page_page_components_attributes_news_#{placeholder}_component_attributes_text", class: 'label'
-          input value: component&.url || nil, type: 'text',
-                id: "page_page_components_attributes_#{placeholder}_component_attributes_url",
-                name: "page[page_components_attributes][#{placeholder}][component_attributes][url]"
-          para 'Link to news item hosted elsewhere, e.g. https://va.gov', class: 'inline-hints'
-        end
-
         li class: 'string input optional stringish', id: "page_page_components_attributes_#{placeholder}_component_attributes_url_link_text_input" do
           label 'Link Title', for: "page_page_components_attributes_news_#{placeholder}_component_attributes_text", class: 'label'
           input value: component&.url_link_text || nil, type: 'text',
                 id: "page_page_components_attributes_#{placeholder}_component_attributes_url_link_text",
                 name: "page[page_components_attributes][#{placeholder}][component_attributes][url_link_text]"
+          para 'e.g. "View Article", "View Blog"', class: 'inline-hints'
+        end
+
+        li class: 'string input optional stringish', id: "page_page_components_attributes_#{placeholder}_component_attributes_url_input" do
+          label 'Link URL', for: "page_page_components_attributes_news_#{placeholder}_component_attributes_text", class: 'label'
+          input value: component&.url || nil, type: 'text',
+                id: "page_page_components_attributes_#{placeholder}_component_attributes_url",
+                name: "page[page_components_attributes][#{placeholder}][component_attributes][url]"
           para 'Link to news item hosted elsewhere, e.g. https://va.gov', class: 'inline-hints'
         end
       end

--- a/app/views/active_admin/resource/_page_news_component_form.html.arb
+++ b/app/views/active_admin/resource/_page_news_component_form.html.arb
@@ -32,10 +32,18 @@ html = Arbre::Context.new do
         end
 
         li class: 'string input optional stringish', id: "page_page_components_attributes_#{placeholder}_component_attributes_url_input" do
-          label 'URL', for: "page_page_components_attributes_news_#{placeholder}_component_attributes_text", class: 'label'
+          label 'Link URL', for: "page_page_components_attributes_news_#{placeholder}_component_attributes_text", class: 'label'
           input value: component&.url || nil, type: 'text',
                 id: "page_page_components_attributes_#{placeholder}_component_attributes_url",
                 name: "page[page_components_attributes][#{placeholder}][component_attributes][url]"
+          para 'Link to news item hosted elsewhere, e.g. https://va.gov', class: 'inline-hints'
+        end
+
+        li class: 'string input optional stringish', id: "page_page_components_attributes_#{placeholder}_component_attributes_url_link_text_input" do
+          label 'Link title', for: "page_page_components_attributes_news_#{placeholder}_component_attributes_text", class: 'label'
+          input value: component&.url_link_text || nil, type: 'text',
+                id: "page_page_components_attributes_#{placeholder}_component_attributes_url_link_text",
+                name: "page[page_components_attributes][#{placeholder}][component_attributes][url_link_text]"
           para 'Link to news item hosted elsewhere, e.g. https://va.gov', class: 'inline-hints'
         end
 

--- a/app/views/active_admin/resource/_page_publication_component_form.html.arb
+++ b/app/views/active_admin/resource/_page_publication_component_form.html.arb
@@ -35,32 +35,6 @@ html = Arbre::Context.new do
           para 'Publication title styled as an /"H3"', class: 'inline-hints'
         end
 
-        # URL
-        li class: 'string input optional stringish', id: "page_page_components_attributes_#{placeholder}_component_attributes_url_input" do
-          label 'URL', for: "page_page_components_attributes_publication_#{placeholder}_component_attributes_url", class: 'label'
-          input value: component&.url || nil,
-                type: 'text',
-                id: "page_page_components_attributes_#{placeholder}_component_attributes_url",
-                name: "page[page_components_attributes][#{placeholder}][component_attributes][url]"
-          para 'Link to publication if hosted elsewhere, e.g. https://va.gov', class: 'inline-hints'
-        end
-
-        # Attachment
-        li class: 'file input optional', id: "page_page_components_attributes_#{placeholder}_component_attributes_attachment_input" do
-          label 'File', for: "page_page_components_attributes_#{placeholder}_component_attributes_attachment", class: 'label'
-          input value: component&.attachment || nil, type: 'file', accept: '.pdf,.doc,.docx',
-                id: "page_page_components_attributes_#{placeholder}_component_attributes_attachment",
-                name: "page[page_components_attributes][#{placeholder}][component_attributes][attachment]"
-          para 'File types allowed: .pdf, .doc, .docx.', class: 'inline-hints'
-            if component&.attachment != nil
-              para class: 'aa-downloadable-file-link' do
-                span 'Current uploaded file:'
-                a component&.attachment_file_name, href: "#{component&.attachment}", target: "_blank"
-              end
-            end
-          para 'Upload a publication file. Supports .pdf,.doc, or .docx', class: 'inline-hints'
-        end
-
         # Published on -  month
         li class: 'select input optional',
            id: "page_page_components_attributes_#{placeholder}_component_attributes_published_on_month_input" do
@@ -123,6 +97,42 @@ html = Arbre::Context.new do
                 id: "page_page_components_attributes_#{placeholder}_component_attributes_authors",
                 name: "page[page_components_attributes][#{placeholder}][component_attributes][authors]"
           para 'Enter with appropriate punctuation. e.g. "John, Joan, and Jill', class: 'inline-hints'
+        end
+
+        # Attachment
+        li class: 'file input optional', id: "page_page_components_attributes_#{placeholder}_component_attributes_attachment_input" do
+          label 'Linked File', for: "page_page_components_attributes_#{placeholder}_component_attributes_attachment", class: 'label'
+          input value: component&.attachment || nil, type: 'file', accept: '.pdf,.doc,.docx',
+                id: "page_page_components_attributes_#{placeholder}_component_attributes_attachment",
+                name: "page[page_components_attributes][#{placeholder}][component_attributes][attachment]"
+          para 'File types allowed: .pdf, .doc, .docx.', class: 'inline-hints'
+            if component&.attachment != nil
+              para class: 'aa-downloadable-file-link' do
+                span 'Current uploaded file:'
+                a component&.attachment_file_name, href: "#{component&.attachment}", target: "_blank"
+              end
+            end
+          para 'Upload a publication file. Supports .pdf,.doc, or .docx', class: 'inline-hints'
+        end
+
+        # URL
+        li class: 'string input optional stringish', id: "page_page_components_attributes_#{placeholder}_component_attributes_url_input" do
+          label 'Link URL', for: "page_page_components_attributes_publication_#{placeholder}_component_attributes_url", class: 'label'
+          input value: component&.url || nil,
+                type: 'text',
+                id: "page_page_components_attributes_#{placeholder}_component_attributes_url",
+                name: "page[page_components_attributes][#{placeholder}][component_attributes][url]"
+          para 'Link to publication if hosted elsewhere, e.g. https://va.gov', class: 'inline-hints'
+        end
+
+        # Link Text
+        li class: 'string input optional stringish', id: "page_page_components_attributes_#{placeholder}_component_attributes_url_link_text_input" do
+          label 'Link Title', for: "page_page_components_attributes_publication_#{placeholder}_component_attributes_url_link_text", class: 'label'
+          input value: component&.url_link_text || nil,
+                type: 'text',
+                id: "page_page_components_attributes_#{placeholder}_component_attributes_url_link_text",
+                name: "page[page_components_attributes][#{placeholder}][component_attributes][url_link_text]"
+          para 'Add a call to action. Default is "Read Publication"', class: 'inline-hints'
         end
       end
     end

--- a/app/views/page/_events_list.html.erb
+++ b/app/views/page/_events_list.html.erb
@@ -21,7 +21,8 @@
                 </div>
                 <p><%= event&.text&.html_safe %></p>
                 <% unless event.url.blank? %>
-                    <%= link_to(event.url_link_text.present? ? event.url_link_text : 'View Event', event.url, class: set_link_classes(event.url), target: get_link_target_attribute(event.url)) %>
+                    <% link_text = event.url_link_text.present? ? event.url_link_text : 'View Event' %>
+                    <%= link_to(link_text, event.url, 'aria-label': "#{link_text}: #{event.title}", class: set_link_classes(event.url), target: get_link_target_attribute(event.url)) %>
                 <% end %>
             </div>
         </div>

--- a/app/views/page/_events_list.html.erb
+++ b/app/views/page/_events_list.html.erb
@@ -20,7 +20,9 @@
                   <% end %>
                 </div>
                 <p><%= event&.text&.html_safe %></p>
-                <%= link_to_if(event.url_link_text.present? && event.url.present?, event.url_link_text, event.url, class: set_link_classes(event.url), target: get_link_target_attribute(event.url)) %>
+                <% unless event.url.blank? %>
+                    <%= link_to(event.url_link_text.present? ? event.url_link_text : 'View Event', event.url, class: set_link_classes(event.url), target: get_link_target_attribute(event.url)) %>
+                <% end %>
             </div>
         </div>
     </li>

--- a/app/views/page/_events_list.html.erb
+++ b/app/views/page/_events_list.html.erb
@@ -4,7 +4,7 @@
         <div class="usa-card__container">
             <div class="usa-card__header">
                 <h3 class="event-title">
-                    <%= link_to_if(event.title.present? && event.url.present?, event.title, event.url, class: set_link_classes(event.url), target: get_link_target_attribute(event.url)) %>
+                    <%= event&.title %>
                 </h3>
             </div>
             <div id="<%= event.id %>" class="event-item-description usa-prose usa-card__body">
@@ -20,6 +20,7 @@
                   <% end %>
                 </div>
                 <p><%= event&.text&.html_safe %></p>
+                <%= link_to_if(event.url_link_text.present? && event.url.present?, event.url_link_text, event.url, class: set_link_classes(event.url), target: get_link_target_attribute(event.url)) %>
             </div>
         </div>
     </li>

--- a/app/views/page/_news_items_list.html.erb
+++ b/app/views/page/_news_items_list.html.erb
@@ -14,7 +14,7 @@
             <% end %>
             <div class="usa-card__header">
                 <h3 class="news-item-title">
-                    <%= link_to_if(news_item.title.present? && news_item.url.present?, news_item.title, news_item.url, class: set_link_classes(news_item.url), target: get_link_target_attribute(news_item.url)) %>
+                    <%= news_item&.title %>
                 </h3>
             </div>
             <div id="<%= news_item.id %>" class="news-item-description usa-prose usa-card__body">
@@ -25,7 +25,9 @@
                 <% elsif news_item.authors.present? %>
                     <p>Published by <%= news_item&.authors %></p>
                 <% end %>
-                <div><%= news_item&.text&.html_safe %></div>
+                <div class="margin-bottom-3"><%= news_item&.text&.html_safe %></div>
+
+                <%= link_to_if(news_item.url_link_text.present? && news_item.url.present?, news_item.url_link_text, news_item.url, class: set_link_classes(news_item.url), target: get_link_target_attribute(news_item.url)) %>
             </div>
         </div>
     </li>

--- a/app/views/page/_news_items_list.html.erb
+++ b/app/views/page/_news_items_list.html.erb
@@ -26,8 +26,10 @@
                     <p>Published by <%= news_item&.authors %></p>
                 <% end %>
                 <div class="margin-bottom-3"><%= news_item&.text&.html_safe %></div>
-
-                <%= link_to_if(news_item.url_link_text.present? && news_item.url.present?, news_item.url_link_text, news_item.url, class: set_link_classes(news_item.url), target: get_link_target_attribute(news_item.url)) %>
+                <% unless news_item.url.blank? %>
+                    <% link_text = news_item.url_link_text.present? ? news_item.url_link_text : 'View News' %>
+                    <%= link_to(link_text, news_item.url, 'aria-label': "#{link_text}: #{news_item.title}", class: set_link_classes(news_item.url), target: get_link_target_attribute(news_item.url)) %>
+                <% end %>
             </div>
         </div>
     </li>

--- a/app/views/page/_publications_list.html.erb
+++ b/app/views/page/_publications_list.html.erb
@@ -1,20 +1,7 @@
 <% publications.each do |publication|%>
     <div class="page-publication-component">
         <h3 class="publication-title margin-bottom-3">
-            <% if publication.attachment? %>
-              <%= link_to publication.attachment_s3_presigned_url,
-              class: 'usa-link',
-              target: '_blank',
-              download: publication.attachment_file_name,
-              'data-resource-id': publication.id,
-              'data-resource-path': publication.attachment.path do %>
-                <i class="far fa-file margin-right-1"></i><%=publication.title %><span class="sr-only">Download <%= publication.attachment_file_name %>/span>
-              <% end %>
-            <% elsif publication.url? %>
-              <%= link_to(publication.title, publication.url, class: set_link_classes(publication.url), target: get_link_target_attribute(publication.url)) %>
-            <% else %>
-              <%= publication.title %>
-            <% end %>
+          <%= publication.title %>
         </h3>
         <p>
             <% if publication.published_in? || publication.published_on_year? %>
@@ -25,6 +12,22 @@
         </p>
         <p>
           <%= "By #{publication.authors}" if publication.authors.present? %>
+        </p>
+        <p>
+          <% if publication.attachment? || publication.url %>
+            <% link_text = publication.url_link_text.present? ? publication.url_link_text : "Read Publication" %>
+            <% if publication.attachment? %>
+              <% page_component = publication.page_component %>
+              <%= link_to page_resource_download_path(id: page_component.component_id, page_id: page_component.page.id.to_s),
+              class: 'usa-link',
+              target: '_blank',
+              'aria-label': "#{link_text}: #{publication.title}" do %>
+                <i class="far fa-file margin-right-1"></i><%= link_text %><span class="usa-sr-only">Download <%= publication.attachment_file_name %></span>
+              <% end %>
+            <% elsif publication.url? %>
+              <%= link_to( link_text, publication.url, 'aria-label': "#{link_text}: #{publication.title}", class: set_link_classes(publication.url), target: get_link_target_attribute(publication.url)) %>
+            <% end %>
+          <% end %>
         </p>
     </div>
 <% end %>

--- a/app/views/page/_publications_list_cards.html.erb
+++ b/app/views/page/_publications_list_cards.html.erb
@@ -4,18 +4,7 @@
     <div class="usa-card__container border-0">
         <div class="usa-card__header">
             <h3 class="publication-title">
-                <% if publication.attachment? %>
-                  <% page_component = publication.page_component %>
-                  <%= link_to page_resource_download_path(id: page_component.component_id, page_id: page_component.page.id.to_s),
-                  class: 'usa-link',
-                  target: '_blank' do %>
-                    <i class="far fa-file margin-right-1"></i><%=publication.title %><span class="usa-sr-only">Download <%= publication.attachment_file_name %></span>
-                  <% end %>
-                <% elsif publication.url? %>
-                  <%= link_to(publication.title, publication.url, class: set_link_classes(publication.url), target: get_link_target_attribute(publication.url)) %>
-                <% else %>
-                  <%= publication.title %>
-                <% end %>
+              <%= publication&.title %>
             </h3>
         </div>
         <div id="<%= publication.id %>" class="publication-item-description usa-prose usa-card__body">
@@ -29,6 +18,18 @@
           <p>
             <%= "By #{publication.authors}" if publication.authors.present? %>
           </p>
+          <% if publication.attachment? || publication.url %>
+            <% if publication.attachment? %>
+              <% page_component = publication.page_component %>
+              <%= link_to page_resource_download_path(id: page_component.component_id, page_id: page_component.page.id.to_s),
+              class: 'usa-link',
+              target: '_blank' do %>
+                <i class="far fa-file margin-right-1"></i><%= "View Publication" %><span class="usa-sr-only">Download <%= publication.attachment_file_name %></span>
+              <% end %>
+            <% elsif publication.url? %>
+              <%= link_to( "View Publication", publication.url, class: set_link_classes(publication.url), target: get_link_target_attribute(publication.url)) %>
+            <% end %>
+          <% end %>
         </div>
     </div>
   </li>

--- a/app/views/page/_publications_list_cards.html.erb
+++ b/app/views/page/_publications_list_cards.html.erb
@@ -19,15 +19,17 @@
             <%= "By #{publication.authors}" if publication.authors.present? %>
           </p>
           <% if publication.attachment? || publication.url %>
+            <% link_text = publication.url_link_text.present? ? publication.url_link_text : "Read Publication" %>
             <% if publication.attachment? %>
               <% page_component = publication.page_component %>
               <%= link_to page_resource_download_path(id: page_component.component_id, page_id: page_component.page.id.to_s),
               class: 'usa-link',
-              target: '_blank' do %>
-                <i class="far fa-file margin-right-1"></i><%= "View Publication" %><span class="usa-sr-only">Download <%= publication.attachment_file_name %></span>
+              target: '_blank',
+              'aria-label': "#{link_text}: #{publication.title}" do %>
+                <i class="far fa-file margin-right-1"></i><%= link_text %><span class="usa-sr-only">Download <%= publication.attachment_file_name %></span>
               <% end %>
             <% elsif publication.url? %>
-              <%= link_to( "View Publication", publication.url, class: set_link_classes(publication.url), target: get_link_target_attribute(publication.url)) %>
+              <%= link_to( link_text, publication.url, 'aria-label': "#{link_text}: #{publication.title}", class: set_link_classes(publication.url), target: get_link_target_attribute(publication.url)) %>
             <% end %>
           <% end %>
         </div>

--- a/app/views/page/show.html.erb
+++ b/app/views/page/show.html.erb
@@ -258,7 +258,7 @@
                 @publication_list_component_index = component_index + 1
                 publications_count = plc[:pagy].count
               %>
-              <% if publications_count <= 3 # use card styling for 2 or fewer  %>
+              <% if publications_count <= 3 # use card styling for 3 or fewer  %>
                 <ul class="publication-component-list-cards usa-card-group dm-paginated-<%= component_index %>-events margin-bottom-4 <%= page_narrow_classes %><%= ' margin-bottom-0' if last_component === index %>">
                   <%= render(partial: 'publications_list_cards', locals: {publications: plc[:publications], publications_count: publications_count}) %>
                 </ul>

--- a/db/migrate/20240517212034_add_url_link_text_to_page_news_components.rb
+++ b/db/migrate/20240517212034_add_url_link_text_to_page_news_components.rb
@@ -1,0 +1,5 @@
+class AddUrlLinkTextToPageNewsComponents < ActiveRecord::Migration[6.1]
+  def change
+    add_column :page_news_components, :url_link_text, :string
+  end
+end

--- a/db/migrate/20240517214134_add_url_link_text_to_page_event_components.rb
+++ b/db/migrate/20240517214134_add_url_link_text_to_page_event_components.rb
@@ -1,0 +1,5 @@
+class AddUrlLinkTextToPageEventComponents < ActiveRecord::Migration[6.1]
+  def change
+    add_column :page_event_components, :url_link_text, :string
+  end
+end

--- a/db/migrate/20240522201114_add_url_link_text_to_page_publication_component.rb
+++ b/db/migrate/20240522201114_add_url_link_text_to_page_publication_component.rb
@@ -1,0 +1,5 @@
+class AddUrlLinkTextToPagePublicationComponent < ActiveRecord::Migration[6.1]
+  def change
+    add_column :page_publication_components, :url_link_text, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_03_26_180328) do
+ActiveRecord::Schema.define(version: 2024_05_17_212034) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -663,6 +663,7 @@ ActiveRecord::Schema.define(version: 2024_03_26_180328) do
     t.string "image_content_type"
     t.bigint "image_file_size"
     t.datetime "image_updated_at"
+    t.string "url_link_text"
     t.index ["page_component_id"], name: "index_page_news_components_on_page_component_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_05_17_212034) do
+ActiveRecord::Schema.define(version: 2024_05_17_214134) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -572,6 +572,7 @@ ActiveRecord::Schema.define(version: 2024_05_17_212034) do
     t.string "location"
     t.string "presented_by"
     t.boolean "hide_after_date", default: false
+    t.string "url_link_text"
     t.index ["page_component_id"], name: "index_page_event_components_on_page_component_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_05_17_214134) do
+ActiveRecord::Schema.define(version: 2024_05_22_201114) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -715,6 +715,7 @@ ActiveRecord::Schema.define(version: 2024_05_17_214134) do
     t.integer "published_on_month"
     t.integer "published_on_day"
     t.integer "published_on_year"
+    t.string "url_link_text"
     t.index ["page_component_id"], name: "index_page_publication_components_on_page_component_id"
   end
 

--- a/spec/features/pages/event_component_spec.rb
+++ b/spec/features/pages/event_component_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
 describe 'Page Builder - Show - Events', type: :feature, js: true do
   before do
-    page_group = create(:page_group, name: 'programming', slug: 'programming', description: 'Pages about programming go in this group.')
-    @page = create(:page, page_group: page_group, title: 'ruby', description: 'what a gem', slug: 'ruby-rocks', has_chrome_warning_banner: true, created_at: Time.now, published: Time.now)
+    @page_group = create(:page_group, name: 'programming', slug: 'programming', description: 'Pages about programming go in this group.')
+    @page = create(:page, page_group: @page_group, title: 'ruby', description: 'what a gem', slug: 'ruby-rocks', has_chrome_warning_banner: true, created_at: Time.now, published: Time.now)
     @event_pagination_size = PageEventComponent::PAGINATION
 
     user = create(:user)

--- a/spec/features/pages/event_component_spec.rb
+++ b/spec/features/pages/event_component_spec.rb
@@ -1,92 +1,61 @@
 require 'rails_helper'
-describe 'Page Builder - Show - Paginated Components - Events', type: :feature, js: true do
+describe 'Page Builder - Show - Events', type: :feature, js: true do
   before do
-    @page_group = create(:page_group, name: 'programming', slug: 'programming', description: 'Pages about programming go in this group.')
-    @page = create(:page, page_group: @page_group, title: 'ruby', description: 'what a gem', slug: 'ruby-rocks', has_chrome_warning_banner: true, created_at: Time.now, published: Time.now)
-    @today = Date.current
-
-    @h1 = create(:page_header2_component,subtopic_title: "Visible Upcoming Events")
-    create(:page_component, page: @page, component: @h1, position: 1)
-    @e1 = create(:page_event_component, title: "upcoming event1", start_date: @today + 5.days, end_date: @today + 7.days, hide_after_date: true)
-    create(:page_component, page: @page, component: @e1, position: 2)
-    @e2 = create(:page_event_component, title: "upcoming event2", start_date: @today + 5.days, end_date: @today + 7.days, hide_after_date: true)
-    create(:page_component, page: @page, component: @e2, position: 3)
-    @e3 = create(:page_event_component, title: "upcoming event3", start_date: @today + 5.days, end_date: @today + 7.days, hide_after_date: true)
-    create(:page_component, page: @page, component: @e3, position: 4)
-
-    @h2 = create(:page_header2_component,subtopic_title: "Past Events")
-    create(:page_component, page: @page, component: @h2, position: 5)
-    @e4 = create(:page_event_component, title: "past event1", start_date: @today - 2.days, end_date: @today - 1.days, hide_after_date: false)
-    create(:page_component, page: @page, component: @e4, position: 6)
-    @e5 = create(:page_event_component, title: "past event2", start_date: @today - 2.days, end_date: @today - 1.days, hide_after_date: false)
-    create(:page_component, page: @page, component: @e5, position: 7)
-    @e6 = create(:page_event_component, title: "past event3", start_date: @today - 2.days, end_date: @today - 1.days, hide_after_date: false)
-    create(:page_component, page: @page, component: @e6, position: 8)
+    page_group = create(:page_group, name: 'programming', slug: 'programming', description: 'Pages about programming go in this group.')
+    @page = create(:page, page_group: page_group, title: 'ruby', description: 'what a gem', slug: 'ruby-rocks', has_chrome_warning_banner: true, created_at: Time.now, published: Time.now)
+    @event_pagination_size = PageEventComponent::PAGINATION
 
     user = create(:user)
     login_as(user, scope: :user, run_callbacks: false)
   end
 
-  it 'displays events correctly with pagination functionality' do
-    visit 'programming/ruby-rocks'
+  context 'Hide events after date' do
+    it 'displays events correctly with pagination functionality' do
+      upcoming_attrs = { start_date: 5.days.from_now, end_date: 7.days.from_now, hide_after_date: true }
+      create_events_list("upcoming event", upcoming_attrs)
 
-    expect(page).to have_content(@h1.subtopic_title)
-    expect(page).to have_content(@e1.title)
-    expect(page).to have_content(@e2.title)
-    expect(page).not_to have_content(@e3.title)
-    page.has_link?('Load more', href: /events-0=2/)
-    find('a', text: 'Load more', match: :first).click
-    expect(page).to have_content(@e3.title)
+      @divider = PageHrComponent.create
+      PageComponent.create(page: @page, component: @divider)
 
-    expect(page).to have_content(@h2.subtopic_title)
-    expect(page).to have_content(@e4.title)
-    expect(page).to have_content(@e5.title)
-    expect(page).not_to have_content(@e6.title)
-    page.has_link?('Load more', href: /events-1=2/)
-    find('a', text: 'Load more', match: :first).click
-    expect(page).to have_content(@e6.title)
-  end
+      past_attrs = { start_date: 3.days.ago, end_date: 2.days.ago, hide_after_date: false }
+      create_events_list("past event", past_attrs)
 
-  it 'hides events once they have passed and are marked as auto-hide and updates pagination' do
-    @e3.update!(start_date: @today - 3.days, end_date: @today - 2.days)
+      visit 'programming/ruby-rocks'
 
-    visit 'programming/ruby-rocks'
+      @event_pagination_size.times do |i| 
+        expect(page).to have_content ("upcoming event #{i + 1}")
+        expect(page).to have_content ("past event #{i + 1}")
+      end
 
-    expect(page).to have_content(@h1.subtopic_title)
-    expect(page).to have_content(@e1.title)
-    expect(page).to have_content(@e2.title)
-    expect(page).not_to have_content(@e3.title)
-    expect(page).to have_no_link('Load more', href: /events-0=2/)
-
-    expect(page).to have_content(@h2.subtopic_title)
-    expect(page).to have_content(@e4.title)
-    expect(page).to have_content(@e5.title)
-    expect(page).not_to have_content(@e6.title)
-    page.has_link?('Load more', href: /events-1=2/)
-    find('a', text: 'Load more', match: :first).click
-    expect(page).to have_content(@e6.title)
-  end
-
-  it 'displays text if all events in a group are passed and hidden' do
-    [@e1, @e2, @e3].each do |e|
-      e.update(start_date: @today - 3.days, end_date: @today - 2.days)
+      check_pagination('upcoming event',0)
+      check_pagination('past event',1)
     end
 
-    visit 'programming/ruby-rocks'
+    it 'hides expired events marked as auto-hide and updates pagination' do
+      expired_event = create(:page_event_component, hide_after_date: true, title: "expired event", start_date: 3.days.ago, end_date: 2.days.ago)
+      PageComponent.create(page: @page, component: @expired_event)
 
-    expect(page).to have_content(@h1.subtopic_title)
-    expect(page).not_to have_content(@e1.title)
-    expect(page).not_to have_content(@e2.title)
-    expect(page).not_to have_content(@e3.title)
-    expect(page).to have_no_link('Load more', href: /events-0=2/)
+      upcoming_attrs = { start_date: 5.days.from_now, end_date: 7.days.from_now, hide_after_date: true }
+      create_events_list('upcoming event', upcoming_attrs, 0)
 
-    expect(page).to have_content(@h2.subtopic_title)
-    expect(page).to have_content(@e4.title)
-    expect(page).to have_content(@e5.title)
-    expect(page).not_to have_content(@e6.title)
-    page.has_link?('Load more', href: /events-1=2/)
-    find('a', text: 'Load more', match: :first).click
-    expect(page).to have_content(@e6.title)
+      visit 'programming/ruby-rocks'
+
+      expect(page).not_to have_content(expired_event.title)
+      @event_pagination_size.times {|i| expect(page).to have_content("upcoming event #{i + 1}")}
+      expect(page).to have_no_link('Load more', href: /events-0=2/)
+    end
+
+    it 'displays text if all events in a group are passed and hidden' do
+      expired_attrs = { start_date: 3.days.ago, end_date: 2.days.ago, hide_after_date: true }
+      create_events_list('expired event', expired_attrs)
+
+      (@event_pagination_size + 1).times { |i| PageComponent.create(page: @page, component: @expired_event)}
+
+      visit 'programming/ruby-rocks'
+      expect(page).not_to have_content("expired event")
+      expect(page).to have_no_link('Load more', href: /events-0=2/)
+      expect(page).to have_content('Please check back for more events soon!')
+    end
   end
 
   context 'Link' do
@@ -126,6 +95,23 @@ describe 'Page Builder - Show - Paginated Components - Events', type: :feature, 
       expect(find_link('View Event')[:'aria-label']).to eq('View Event: Webinar')
       expect(find_link('Register now')[:'aria-label']).to eq('Register now: Conference')
     end
+  end
+
+    # create just enough components for a "Load more" button
+  def create_events_list(event_name, attrs_hash, num_over_pagy_threshold = 1)
+    create_list(:page_event_component, @event_pagination_size + num_over_pagy_threshold, attrs_hash) do |event, i|
+      event.title = "#{event_name} #{i + 1}"
+      event.save
+      PageComponent.create(page: @page, component: event)
+    end
+  end
+
+  # check that load more button shows hidden content
+  def check_pagination(event_name, index = 0)
+    expect(page).not_to have_content("#{event_name} #{@event_pagination_size + 1}")
+      page.has_link?('Load more', href: "/events-#{index}=2/")
+      find('a', text: 'Load more', match: :first).click
+      expect(page).to have_content("#{event_name} #{@event_pagination_size + 1}")
   end
 end
 

--- a/spec/features/pages/event_component_spec.rb
+++ b/spec/features/pages/event_component_spec.rb
@@ -1,78 +1,131 @@
 require 'rails_helper'
-describe 'Page Builder - Show - Events', type: :feature, js: true do
+describe 'Page Builder - Show - Paginated Components - Events', type: :feature, js: true do
   before do
-    page_group = create(:page_group, name: 'programming', slug: 'programming', description: 'Pages about programming go in this group.')
-    @page = create(:page, page_group: page_group, title: 'ruby', description: 'what a gem', slug: 'ruby-rocks', has_chrome_warning_banner: true, created_at: Time.now, published: Time.now)
-    @event_pagination_size = PageEventComponent::PAGINATION
+    @page_group = create(:page_group, name: 'programming', slug: 'programming', description: 'Pages about programming go in this group.')
+    @page = create(:page, page_group: @page_group, title: 'ruby', description: 'what a gem', slug: 'ruby-rocks', has_chrome_warning_banner: true, created_at: Time.now, published: Time.now)
+    @today = Date.current
+
+    @h1 = create(:page_header2_component,subtopic_title: "Visible Upcoming Events")
+    create(:page_component, page: @page, component: @h1, position: 1)
+    @e1 = create(:page_event_component, title: "upcoming event1", start_date: @today + 5.days, end_date: @today + 7.days, hide_after_date: true)
+    create(:page_component, page: @page, component: @e1, position: 2)
+    @e2 = create(:page_event_component, title: "upcoming event2", start_date: @today + 5.days, end_date: @today + 7.days, hide_after_date: true)
+    create(:page_component, page: @page, component: @e2, position: 3)
+    @e3 = create(:page_event_component, title: "upcoming event3", start_date: @today + 5.days, end_date: @today + 7.days, hide_after_date: true)
+    create(:page_component, page: @page, component: @e3, position: 4)
+
+    @h2 = create(:page_header2_component,subtopic_title: "Past Events")
+    create(:page_component, page: @page, component: @h2, position: 5)
+    @e4 = create(:page_event_component, title: "past event1", start_date: @today - 2.days, end_date: @today - 1.days, hide_after_date: false)
+    create(:page_component, page: @page, component: @e4, position: 6)
+    @e5 = create(:page_event_component, title: "past event2", start_date: @today - 2.days, end_date: @today - 1.days, hide_after_date: false)
+    create(:page_component, page: @page, component: @e5, position: 7)
+    @e6 = create(:page_event_component, title: "past event3", start_date: @today - 2.days, end_date: @today - 1.days, hide_after_date: false)
+    create(:page_component, page: @page, component: @e6, position: 8)
 
     user = create(:user)
     login_as(user, scope: :user, run_callbacks: false)
   end
 
-  context 'Hide events after date' do
-    it 'displays events correctly with pagination functionality' do
-      upcoming_attrs = { start_date: 5.days.from_now, end_date: 7.days.from_now, hide_after_date: true }
-      create_events_list("upcoming event", upcoming_attrs)
+  it 'displays events correctly with pagination functionality' do
+    visit 'programming/ruby-rocks'
 
-      @divider = PageHrComponent.create
-      PageComponent.create(page: @page, component: @divider)
+    expect(page).to have_content(@h1.subtopic_title)
+    expect(page).to have_content(@e1.title)
+    expect(page).to have_content(@e2.title)
+    expect(page).not_to have_content(@e3.title)
+    page.has_link?('Load more', href: /events-0=2/)
+    find('a', text: 'Load more', match: :first).click
+    expect(page).to have_content(@e3.title)
 
-      past_attrs = { start_date: 3.days.ago, end_date: 2.days.ago, hide_after_date: false }
-      create_events_list("past event", past_attrs)
-
-      visit 'programming/ruby-rocks'
-
-      @event_pagination_size.times do |i| 
-        expect(page).to have_content ("upcoming event #{i + 1}")
-        expect(page).to have_content ("past event #{i + 1}")
-      end
-
-      check_pagination('upcoming event',0)
-      check_pagination('past event',1)
-    end
-
-    it 'hides expired events marked as auto-hide and updates pagination' do
-      expired_event = create(:page_event_component, hide_after_date: true, title: "expired event", start_date: 3.days.ago, end_date: 2.days.ago)
-      PageComponent.create(page: @page, component: @expired_event)
-
-      upcoming_attrs = { start_date: 5.days.from_now, end_date: 7.days.from_now, hide_after_date: true }
-      create_events_list('upcoming event', upcoming_attrs, 0)
-
-      visit 'programming/ruby-rocks'
-
-      expect(page).not_to have_content(expired_event.title)
-      @event_pagination_size.times {|i| expect(page).to have_content("upcoming event #{i + 1}")}
-      expect(page).to have_no_link('Load more', href: /events-0=2/)
-    end
-
-    it 'displays text if all events in a group are passed and hidden' do
-      expired_attrs = { start_date: 3.days.ago, end_date: 2.days.ago, hide_after_date: true }
-      create_events_list('expired event', expired_attrs)
-
-      (@event_pagination_size + 1).times { |i| PageComponent.create(page: @page, component: @expired_event)}
-
-      visit 'programming/ruby-rocks'
-      expect(page).not_to have_content("expired event")
-      expect(page).to have_no_link('Load more', href: /events-0=2/)
-      expect(page).to have_content('Please check back for more events soon!')
-    end
+    expect(page).to have_content(@h2.subtopic_title)
+    expect(page).to have_content(@e4.title)
+    expect(page).to have_content(@e5.title)
+    expect(page).not_to have_content(@e6.title)
+    page.has_link?('Load more', href: /events-1=2/)
+    find('a', text: 'Load more', match: :first).click
+    expect(page).to have_content(@e6.title)
   end
 
-  # create just enough components for a "Load more" button
-  def create_events_list(event_name, attrs_hash, num_over_pagy_threshold = 1)
-    create_list(:page_event_component, @event_pagination_size + num_over_pagy_threshold, attrs_hash) do |event, i|
-      event.title = "#{event_name} #{i + 1}"
-      event.save
-      PageComponent.create(page: @page, component: event)
-    end
+  it 'hides events once they have passed and are marked as auto-hide and updates pagination' do
+    @e3.update!(start_date: @today - 3.days, end_date: @today - 2.days)
+
+    visit 'programming/ruby-rocks'
+
+    expect(page).to have_content(@h1.subtopic_title)
+    expect(page).to have_content(@e1.title)
+    expect(page).to have_content(@e2.title)
+    expect(page).not_to have_content(@e3.title)
+    expect(page).to have_no_link('Load more', href: /events-0=2/)
+
+    expect(page).to have_content(@h2.subtopic_title)
+    expect(page).to have_content(@e4.title)
+    expect(page).to have_content(@e5.title)
+    expect(page).not_to have_content(@e6.title)
+    page.has_link?('Load more', href: /events-1=2/)
+    find('a', text: 'Load more', match: :first).click
+    expect(page).to have_content(@e6.title)
   end
 
-  # check that load more button shows hidden content
-  def check_pagination(event_name, index = 0)
-    expect(page).not_to have_content("#{event_name} #{@event_pagination_size + 1}")
-      page.has_link?('Load more', href: "/events-#{index}=2/")
-      find('a', text: 'Load more', match: :first).click
-      expect(page).to have_content("#{event_name} #{@event_pagination_size + 1}")
+  it 'displays text if all events in a group are passed and hidden' do
+    [@e1, @e2, @e3].each do |e|
+      e.update(start_date: @today - 3.days, end_date: @today - 2.days)
+    end
+
+    visit 'programming/ruby-rocks'
+
+    expect(page).to have_content(@h1.subtopic_title)
+    expect(page).not_to have_content(@e1.title)
+    expect(page).not_to have_content(@e2.title)
+    expect(page).not_to have_content(@e3.title)
+    expect(page).to have_no_link('Load more', href: /events-0=2/)
+
+    expect(page).to have_content(@h2.subtopic_title)
+    expect(page).to have_content(@e4.title)
+    expect(page).to have_content(@e5.title)
+    expect(page).not_to have_content(@e6.title)
+    page.has_link?('Load more', href: /events-1=2/)
+    find('a', text: 'Load more', match: :first).click
+    expect(page).to have_content(@e6.title)
+  end
+
+  context 'Link' do
+    before do
+      @link_testing = @page = create(:page, page_group: @page_group, title: 'link testing', description: 'one component per page', slug: 'link-testing', has_chrome_warning_banner: true, created_at: Time.now, published: Time.now)
+    end
+
+    it 'renders nothing for empty URLs' do
+      event_component = create(:page_event_component, url: nil, url_link_text: nil)
+      PageComponent.create(page: @link_testing, component: event_component, created_at: Time.now,)
+      visit 'programming/link-testing'
+      expect(page).not_to have_link('View Event')
+    end
+
+    it 'renders generic link title if none is provided' do
+      event_component = create(:page_event_component, url: '/about', url_link_text: nil)
+      PageComponent.create(page: @link_testing, component: event_component, created_at: Time.now,)
+      visit 'programming/link-testing'
+      expect(page).to have_link('View Event', href: '/about')
+    end
+
+    it 'renders custom link title if provided' do
+      event_component = create(:page_event_component, url: '/about', url_link_text: 'Register now' )
+      PageComponent.create(page: @link_testing, component: event_component, created_at: Time.now,)
+      visit 'programming/link-testing'
+      expect(page).to have_link('Register now', href: '/about')
+      expect(page).not_to have_link('View Event')
+    end
+
+    it 'provides aria label with the component title for screenreaders' do
+      event_component = create(:page_event_component, title: "Webinar", url: '/about', url_link_text: nil)
+      PageComponent.create(page: @link_testing, component: event_component, created_at: Time.now,)
+      event_component = create(:page_event_component, title: "Conference", url: '/about', url_link_text: 'Register now' )
+      PageComponent.create(page: @link_testing, component: event_component, created_at: Time.now,)
+      visit 'programming/link-testing'
+
+      expect(find_link('View Event')[:'aria-label']).to eq('View Event: Webinar')
+      expect(find_link('Register now')[:'aria-label']).to eq('Register now: Conference')
+    end
   end
 end
 

--- a/spec/features/pages/news_component_spec.rb
+++ b/spec/features/pages/news_component_spec.rb
@@ -8,6 +8,8 @@ describe 'Page Builder - Show - News Components', type: :feature do
     login_as(user, scope: :user, run_callbacks: false)
   end
 
+  # See spec/features/pages/paginated_components_spec.rb for pagination threshold testing
+
   context 'Publication info' do
     it 'date only' do
       news_component = PageNewsComponent.create(title: 'Date only', published_date: Date.new(2023,05,16) )
@@ -43,6 +45,30 @@ describe 'Page Builder - Show - News Components', type: :feature do
 
       expect(page).to have_css("img[src*='#{news_component.image_s3_presigned_url}']")
       expect(page).to have_css("img[alt='Test Image']")
+    end
+  end
+
+  context 'Link' do
+    it 'renders nothing for empty URLs' do
+      news_component = PageNewsComponent.create(title: 'Date and author', published_date: Date.new(2023,05,16), authors: 'Bubbles, Blossom, and Buttercup', url: nil, text: nil )
+      PageComponent.create(page: @page, component: news_component, created_at: Time.now,)
+      visit 'programming/ruby-rocks'
+      expect(page).not_to have_link('View News')
+    end
+
+    it 'renders generic link title if none is provided' do
+      news_component = PageNewsComponent.create(title: 'Date and author', published_date: Date.new(2023,05,16), authors: 'Bubbles, Blossom, and Buttercup', url: '/about')
+      PageComponent.create(page: @page, component: news_component, created_at: Time.now,)
+      visit 'programming/ruby-rocks'
+      expect(page).to have_link('View News', href: '/about')
+    end
+
+    it 'renders custom link title if provided' do
+      news_component = PageNewsComponent.create(title: 'Date and author', published_date: Date.new(2023,05,16), authors: 'Bubbles, Blossom, and Buttercup', url: '/about', url_link_text: 'Register now' )
+      PageComponent.create(page: @page, component: news_component, created_at: Time.now,)
+      visit 'programming/ruby-rocks'
+      expect(page).to have_link('Register now', href: '/about')
+      expect(page).not_to have_link('View News')
     end
   end
 end

--- a/spec/features/pages/publication_component_spec.rb
+++ b/spec/features/pages/publication_component_spec.rb
@@ -30,35 +30,6 @@ describe 'Page Builder - Show - Paginated Components', type: :feature do
     end
   end
 
-  context 'Title' do
-    it 'links to uploaded PDFs' do
-      downloadable_file = File.new(File.join(Rails.root, '/spec/assets/dummy.pdf'))
-      publication_component = PagePublicationComponent.create(title: 'Journal article PDF', attachment: downloadable_file, published_in: 'The Journal of Science', published_on_day: 5, published_on_month: 5, published_on_year: 2022)
-      PageComponent.create(page: @page, component: publication_component, created_at: Time.now)
-      visit '/programming/ruby-rocks'
-
-      expect(page).to have_content('Journal article PDF')
-      expect(page).to have_css('.fa-file')
-    end
-
-    it 'links to external URLs' do
-      publication_component = PagePublicationComponent.create(title: 'External article link', url: 'https://wikipedia.org', published_in: 'Wikipedia', published_on_day: 5, published_on_month: 5, published_on_year: 2022)
-      PageComponent.create(page: @page, component: publication_component, created_at: Time.now)
-      visit '/programming/ruby-rocks'
-
-      expect(page).to have_content('External article link')
-      expect(page).to have_css('.usa-link--external')
-    end
-
-    it 'renders the title if no URL or attachment is provided' do
-      publication_component = PagePublicationComponent.create(title: 'Placeholder title', published_in: 'Wikipedia', published_on_day: 5, published_on_month: 5, published_on_year: 2022)
-      PageComponent.create(page: @page, component: publication_component, created_at: Time.now)
-      visit '/programming/ruby-rocks'
-
-      expect(page).to have_content('Placeholder title')
-    end
-  end
-
   context 'Published in' do
     it 'renders with appropriate prepositions' do
       publication_and_date = PagePublicationComponent.create(title: 'External article link', url: 'https://wikipedia.org', published_in: 'Wikipedia', published_on_day: 5, published_on_month: 5, published_on_year: 2022)
@@ -97,6 +68,37 @@ describe 'Page Builder - Show - Paginated Components', type: :feature do
       visit '/programming/ruby-rocks'
 
       expect(page).to have_content('Published in Wikipedia')
+    end
+  end
+
+  context 'Link' do
+    it 'links to uploaded PDFs' do
+      downloadable_file = File.new(File.join(Rails.root, '/spec/assets/dummy.pdf'))
+      publication_component = PagePublicationComponent.create(title: 'Journal article PDF', attachment: downloadable_file, published_in: 'The Journal of Science', published_on_day: 5, published_on_month: 5, published_on_year: 2022)
+      PageComponent.create(page: @page, component: publication_component, created_at: Time.now)
+      visit '/programming/ruby-rocks'
+
+      expect(page).to have_link('Read Publication')
+      expect(page).to have_css('.fa-file')
+      expect(find_link('Read Publication')[:'aria-label']).to eq('Read Publication: Journal article PDF')
+    end
+
+    it 'links to external URLs' do
+      publication_component = PagePublicationComponent.create(title: 'External article link', url: 'https://wikipedia.org', published_in: 'Wikipedia', published_on_day: 5, published_on_month: 5, published_on_year: 2022)
+      PageComponent.create(page: @page, component: publication_component, created_at: Time.now)
+      visit '/programming/ruby-rocks'
+
+      expect(page).to have_link('Read Publication', href: 'https://wikipedia.org')
+      expect(page).to have_css('.usa-link--external')
+      expect(find_link('Read Publication')[:'aria-label']).to eq('Read Publication: External article link')
+    end
+
+    it 'custom link text' do
+      publication_component = PagePublicationComponent.create(title: 'Placeholder title', url: '/about', url_link_text: 'Review the Study', published_in: 'Wikipedia', published_on_day: 5, published_on_month: 5, published_on_year: 2022)
+      PageComponent.create(page: @page, component: publication_component, created_at: Time.now)
+      visit '/programming/ruby-rocks'
+      expect(page).to have_link('Review the Study', href: '/about')
+      expect(find_link('Review the Study')[:'aria-label']).to eq('Review the Study: Placeholder title')
     end
   end
 end


### PR DESCRIPTION
### JIRA issue link
[DM-4742](https://agile6.atlassian.net/browse/DM-4742)

## Description - what does this code do?
- Moves links out of Event, News, and Publication component titles
- Adds a field for a link title to components and renders it at the bottom of the component
- If a title is supplied: render the custom link title
- If no title is supplied: render a generic link title (`View Event`, `View News`, `Read publication`)
- Adds an aria label concatenating link title + event / news item title to provide more info to screenreaders

## Testing done - how did you test it/steps on how can another person can test it 
1. Log in as an admin
2. Create a page group and page
3. Create an Event Component, a News Component, and a Publication component. Fill out title and any required fields.
4. Provide a URL for each component
5. Save.
6. Confirm that a link is provided for each component with generic text (`View Event`, `View News`, and `Read Publication`). 
7. Go back to the edit page and provide custom link titles for each component. Save.
8. Confirm that links were updated to reflect custom text.

