### PR TITLE
DM-4742: Add graceful fallbacks for paginated components with less than 3 items

### DIFF
--- a/app/models/page_event_component.rb
+++ b/app/models/page_event_component.rb
@@ -28,6 +28,17 @@ class PageEventComponent < ApplicationRecord
       start_date.present? && start_date < Date.current) && hide_after_date?
   end
 
+  def column_size(event_count)
+    case event_count
+    when 1
+      return 'tablet:grid-col-12'
+    when 2
+      return 'tablet:grid-col-6'
+    else
+      return 'tablet:grid-col-4'
+    end
+  end
+
   def rendered_date
     return if self.start_date.blank?
 

--- a/app/models/page_news_component.rb
+++ b/app/models/page_news_component.rb
@@ -25,4 +25,15 @@ class PageNewsComponent < ApplicationRecord
   def image_s3_presigned_url(style = nil)
     object_presigned_url(image, style)
   end
+
+  def column_size(news_item_count)
+    case news_item_count
+    when 1
+      return 'tablet:grid-col-12'
+    when 2
+      return 'tablet:grid-col-6'
+    else
+      return 'tablet:grid-col-4'
+    end
+  end
 end

--- a/app/models/page_publication_component.rb
+++ b/app/models/page_publication_component.rb
@@ -26,6 +26,17 @@ class PagePublicationComponent < ApplicationRecord
     object_presigned_url(attachment, style)
   end
 
+  def column_size(publications_count)
+    case publications_count
+    when 1
+      return 'tablet:grid-col-12'
+    when 2
+      return 'tablet:grid-col-6'
+    else
+      return 'tablet:grid-col-4'
+    end
+  end
+
   def publication_date
     if self.published_on_month? && self.published_on_day? && self.published_on_year? # on Month Day, Year
       return "on #{Date::MONTHNAMES[self.published_on_month]} #{self.published_on_day}, #{self.published_on_year}"

--- a/app/views/page/_events_list.html.erb
+++ b/app/views/page/_events_list.html.erb
@@ -1,3 +1,4 @@
+<% event_count = event_count %>
 <% events.each do |event|%>
     <li class="page-event-component usa-card <%= event.column_size(event_count) %>">
         <div class="usa-card__container">

--- a/app/views/page/_events_list.html.erb
+++ b/app/views/page/_events_list.html.erb
@@ -1,5 +1,5 @@
 <% events.each do |event|%>
-    <li class="page-event-component usa-card tablet:grid-col-4">
+    <li class="page-event-component usa-card <%= event.column_size(event_count) %>">
         <div class="usa-card__container">
             <div class="usa-card__header">
                 <h3 class="event-title">

--- a/app/views/page/_news_items_list.html.erb
+++ b/app/views/page/_news_items_list.html.erb
@@ -1,5 +1,5 @@
 <% news_items.each do |news_item| %>
-    <li class="page-news-component usa-card tablet:grid-col-4">
+    <li class="page-news-component usa-card <%= news_item.column_size(news_item_count) %>">
         <div class="usa-card__container margin-top-5">
             <% if news_item.image.present? %>
                 <div class="usa-card__media--inset">

--- a/app/views/page/_news_items_list.html.erb
+++ b/app/views/page/_news_items_list.html.erb
@@ -1,3 +1,4 @@
+<% news_item_count = news_item_count %>
 <% news_items.each do |news_item| %>
     <li class="page-news-component usa-card <%= news_item.column_size(news_item_count) %>">
         <div class="usa-card__container margin-top-5">

--- a/app/views/page/_publications_list_cards.html.erb
+++ b/app/views/page/_publications_list_cards.html.erb
@@ -1,5 +1,5 @@
 <% publications.each do |publication| %>
-  <li class="page-publication-component usa-card tablet:grid-col-6">
+  <li class="page-publication-component usa-card <%= publication.column_size(publications_count) %>">
     <div class="usa-card__container border-0">
         <div class="usa-card__header">
             <h3 class="publication-title">

--- a/app/views/page/_publications_list_cards.html.erb
+++ b/app/views/page/_publications_list_cards.html.erb
@@ -1,3 +1,4 @@
+<% publications_count = publications_count %>
 <% publications.each do |publication| %>
   <li class="page-publication-component usa-card <%= publication.column_size(publications_count) %>">
     <div class="usa-card__container border-0">

--- a/app/views/page/show.html.erb
+++ b/app/views/page/show.html.erb
@@ -161,13 +161,14 @@
               component_index = @event_list_component_index
               elc = @event_list_components[component_index]
               @event_list_component_index = component_index + 1
+              event_count = elc[:pagy].count
             %>
             <% unless elc[:events].all?(&:passed_and_hidden) %>
               <div class="grid-container">
                 <ul class="event-component-list grid-row grid-gap usa-card-group dm-paginated-<%= component_index %>-events margin-bottom-4 <%= page_narrow_classes %><%= ' margin-bottom-0' if last_component === index %>">
-                  <%= render(partial: 'events_list', locals: {events: elc[:events]}) %>
+                  <%= render(partial: 'events_list', locals: {events: elc[:events], event_count: event_count}) %>
                 </ul>
-                <% if elc[:pagy].count > PageEventComponent::PAGINATION  %>
+                <% if event_count > PageEventComponent::PAGINATION  %>
                   <div class="text-center dm-load-more-events-<%= component_index %>-btn-container margin-bottom-4">
                     <% link = pagy_link_proc(elc[:pagy]) %>
                     <%=  link.call(elc[:pagy].vars[:page] + 1, 'Load more').html_safe %>
@@ -208,12 +209,13 @@
               component_index = @news_list_component_index
               nic = @news_items_components[component_index]
               @news_list_component_index = component_index + 1
+              news_item_count = nic[:pagy].count
             %>
             <div class="grid-container margin-bottom-5 <%= ' margin-bottom-0' if last_component === index %>">
               <ul class="usa-card-group grid-row grid-gap news-component-list dm-paginated-<%= component_index %>-news <%= page_narrow_classes %>">
-                <%= render partial:'news_items_list', locals: {news_items: nic[:news]} %>
+                <%= render partial:'news_items_list', locals: { news_items: nic[:news], news_item_count: news_item_count} %>
               </ul>
-              <% if nic[:pagy].count > 6 %>
+              <% if news_item_count > 6 %>
                 <div class="text-center dm-load-more-news-<%= component_index %>-btn-container margin-top-5" >
                   <% link = pagy_link_proc(nic[:pagy]) %>
                   <%=  link.call(nic[:pagy].vars[:page] + 1, 'Load more').html_safe %>
@@ -254,16 +256,17 @@
                 component_index = @publication_list_component_index
                 plc = @publication_list_components[component_index]
                 @publication_list_component_index = component_index + 1
+                publications_count = plc[:pagy].count
               %>
-              <% if plc[:pagy].count <= 2 # use card styling for 2 or fewer  %>
+              <% if publications_count <= 3 # use card styling for 2 or fewer  %>
                 <ul class="publication-component-list-cards usa-card-group dm-paginated-<%= component_index %>-events margin-bottom-4 <%= page_narrow_classes %><%= ' margin-bottom-0' if last_component === index %>">
-                  <%= render(partial: 'publications_list_cards', locals: {publications: plc[:publications]}) %>
+                  <%= render(partial: 'publications_list_cards', locals: {publications: plc[:publications], publications_count: publications_count}) %>
                 </ul>
-              <% elsif plc[:pagy].count > 2 # use list styling for all other card lists %>
+              <% elsif publications_count > 3 # use list styling for all other card lists %>
                 <div class="publication-component-list dm-paginated-<%= component_index %>-publications margin-bottom-4 <%= page_narrow_classes %><%= ' margin-bottom-0' if last_component === index %>">
                   <%= render(partial: 'publications_list', locals: {publications: plc[:publications]}) %>
                 </div>
-                <% if plc[:pagy].count > 10 # Load more button %>
+                <% if publications_count > 10 # Load more button %>
                   <div class="text-center dm-load-more-publications-<%= component_index %>-btn-container">
                     <% link = pagy_link_proc(plc[:pagy]) %>
                     <%=  link.call(plc[:pagy].vars[:page] + 1, 'Load more').html_safe %>

--- a/spec/features/pages/publication_component_spec.rb
+++ b/spec/features/pages/publication_component_spec.rb
@@ -8,18 +8,18 @@ describe 'Page Builder - Show - Paginated Components', type: :feature do
     login_as(user, scope: :user, run_callbacks: false)
   end
 
-  context '2 or fewer publications' do
+  context '3 or fewer publications' do
     it 'applies card styling' do
-      create_publication_components(2, @page)
+      create_publication_components(3, @page)
       visit '/programming/ruby-rocks'
 
-      expect(page).to have_css('.page-publication-component', count: 2)
+      expect(page).to have_css('.page-publication-component', count: 3)
       expect(page).to have_css '.usa-card__container'
       expect(page).not_to have_content('Load more')
     end
   end
 
-  context '3 or more publications' do
+  context '4 or more publications' do
     it 'applies list styling' do
       create_publication_components(11, @page)
       visit '/programming/ruby-rocks'


### PR DESCRIPTION
### JIRA issue link
[DM-4742](https://agile6.atlassian.net/browse/DM-4559?focusedCommentId=12037)

## Description - what does this code do?
- Adjusts component column sizes when fewer than 3 items are provided. This is to provide a graceful fallback for legacy content that used only 2 items.
- Updates publications to use 3 column card layout for 3 or fewer items

## Testing done - how did you test it/steps on how can another person can test it 


## Screenshots, Gifs, Videos from application (if applicable)
### After
![Screenshot 2024-05-21 at 5 04 50 PM](https://github.com/department-of-veterans-affairs/diffusion-marketplace/assets/5402927/42761324-76e2-4b12-9732-75fc97eeb59c)
### Before
![Screenshot 2024-05-21 at 5 04 17 PM](https://github.com/department-of-veterans-affairs/diffusion-marketplace/assets/5402927/c9ae8887-2b3d-41e1-8d1d-a803e79ab422)
![Screenshot 2024-05-21 at 4 34 18 PM](https://github.com/department-of-veterans-affairs/diffusion-marketplace/assets/5402927/c0717d01-c04b-429d-a280-4b9d2127dede)
