### PR TITLE
Move 2:1 component link below body text

### DIFF
--- a/app/views/page/_two_to_one_image_component.html.erb
+++ b/app/views/page/_two_to_one_image_component.html.erb
@@ -5,6 +5,9 @@
         <%= component.title %>
       </h3>
     <% end %>
+    <% if component.text.present? %>
+      <p><%= component.text.html_safe %></p>
+    <% end %>
     <% if component.url.present? && component.url_link_text.present? %>
       <a href="<%= component.url %>"
           target="<%= get_link_target_attribute(component.url) %>"
@@ -12,9 +15,6 @@
           class="<%= set_link_classes(component.url) %> display-inline-block">
         <%= component.url_link_text %>
       </a>
-    <% end %>
-    <% if component.text.present? %>
-      <p><%= component.text.html_safe %></p>
     <% end %>
   </div>
   <div class="grid-item-image <%= component.flipped_ratio? ? 'tablet:grid-col-4' : 'tablet:grid-col-8' %> display-flex flex-align-center">


### PR DESCRIPTION
## Description - what does this code do?
- Moves 2:1 Text to Image component link below body text to match PB design patterns

## Screenshots, Gifs, Videos from application (if applicable)
### Before
<img width="602" alt="Screenshot 2024-05-22 at 5 09 31 PM" src="https://github.com/department-of-veterans-affairs/diffusion-marketplace/assets/5402927/b085d2b8-6cd0-4d6a-85fd-5d232ff8d54f">

### After
<img width="1023" alt="Screenshot 2024-05-22 at 5 10 20 PM" src="https://github.com/department-of-veterans-affairs/diffusion-marketplace/assets/5402927/ca380cb7-4683-4484-a53c-1c3d8c7e50d3">

