### PR TITLE
DM-4830: Footer headings and minor style tweaks

### DIFF
--- a/app/assets/stylesheets/dm/components/_links.scss
+++ b/app/assets/stylesheets/dm/components/_links.scss
@@ -1,29 +1,3 @@
-.dm-footer-link {
-  color: color($theme-color-secondary-darker);
-  @include u-text('normal');
-  text-decoration: underline;
-
-  &:hover {
-    color: color($theme-color-secondary-darkest);
-    text-decoration: underline;
-  }
-
-  &:visited {
-    color: color($theme-color-secondary-darker);
-    text-decoration: underline;
-
-    &:hover {
-      color: color($theme-color-secondary-darkest);
-      text-decoration: underline;
-    }
-  }
-
-  &:active {
-    color: color($theme-color-secondary-darkest);
-    text-decoration: underline;
-  }
-}
-
 .dm-alt-link {
   &-gold {
     color: color($theme-color-accent-warm) !important;

--- a/app/assets/stylesheets/dm/pages/_partials/_footer.scss
+++ b/app/assets/stylesheets/dm/pages/_partials/_footer.scss
@@ -1,14 +1,15 @@
 footer {
   .dm-footer-heading {
-    color: color('white');
+    color: color($theme-color-base-lighter);
   }
 
   .dm-footer-link {
       @include u-text('normal');
-      color: color('white');
+      color: color($theme-color-base-lighter);
       text-decoration: none;
 
       &:hover, &:focus, &:active {
+        color: color($theme-color-secondary-darker);
         text-decoration: underline;
       }
   }

--- a/app/assets/stylesheets/dm/pages/_partials/_footer.scss
+++ b/app/assets/stylesheets/dm/pages/_partials/_footer.scss
@@ -1,4 +1,18 @@
 footer {
+  .dm-footer-heading {
+    color: color('white');
+  }
+
+  .dm-footer-link {
+      @include u-text('normal');
+      color: color('white');
+      text-decoration: none;
+
+      &:hover, &:focus, &:active {
+        text-decoration: underline;
+      }
+  }
+
   .usa-footer__return-to-top {
     @include u-padding-top(0, !important);
     padding-bottom: 32px !important;

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -130,7 +130,7 @@
                 <input type="email" name="email" id="email" value="" class="usa-input margin-top-2" required="required" />
               </div>
               <div class="grid-col-12 desktop:grid-col-3 subscribe-button-container margin-top-2 margin-bottom-4 desktop:margin-top-0 desktop:margin-bottom-0">
-                <button name="commit" class="dm-button--outline-white margin-right-0 margin-top-0 newsletter-subscribe-button">Subscribe today</button>
+                <button name="commit" class="dm-button--outline-white margin-right-0 margin-top-0 newsletter-subscribe-button">Subscribe</button>
               </div>
             </div>
           </fieldset>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -18,6 +18,11 @@
         <div class="grid-row margin-bottom-8">
           <div class="grid-col-12 desktop:grid-col-3">
             <ul class="add-list-reset">
+              <li class="grid-row dm-footer-heading">
+                <h3 class="usa-prose-h3">
+                  Visit
+                </h3>
+              </li>
               <li class="grid-row">
                 <%= link_to 'Home',
                             root_path,
@@ -44,6 +49,11 @@
           </div>
           <div class="grid-col-12 desktop:grid-col-3">
             <ul class="add-list-reset">
+              <li class="grid-row dm-footer-heading">
+                <h3 class="usa-prose-h3">
+                  Support
+                </h3>
+              </li>
               <li class="grid-row">
                 <a class="dm-footer-link margin-bottom-2" href="https://www.va.gov/ABOUT_VA/index.asp">
                   About VA
@@ -68,6 +78,11 @@
           </div>
           <div class="grid-col-12 desktop:grid-col-3">
             <ul class="add-list-reset">
+              <li class="grid-row dm-footer-heading">
+                <h3 class="usa-prose-h3">
+                  Legal
+                </h3>
+              </li>
               <li class="grid-row">
                 <a class="dm-footer-link margin-bottom-2" href="https://www.va.gov/web/standards/disclaimer.cfm">
                   Disclaimers
@@ -93,6 +108,11 @@
           </div>
           <div class="grid-col-12 desktop:grid-col-3">
             <ul class="add-list-reset">
+              <li class="grid-row dm-footer-heading">
+                <h3 class="usa-prose-h3">
+                  Resources
+                </h3>
+              </li>
               <li class="grid-row">
                 <a class="dm-footer-link margin-bottom-2" href="https://www.va.gov/ormdi/NOFEAR_Select.asp">
                   No FEAR Act data

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -16,7 +16,7 @@
           </p>
         </div>
         <div class="grid-row margin-bottom-8">
-          <div class="grid-col-12 desktop:grid-col-3">
+          <div class="grid-col-12 tablet:grid-col-6 desktop:grid-col-3">
             <ul class="add-list-reset" aria-labelledby="footer-visit">
               <li class="grid-row dm-footer-heading">
                 <h3 id="footer-visit" class="usa-prose-h3">
@@ -47,7 +47,7 @@
               </li>
             </ul>
           </div>
-          <div class="grid-col-12 desktop:grid-col-3">
+          <div class="grid-col-12 tablet:grid-col-6 desktop:grid-col-3">
             <ul class="add-list-reset" aria-labelledby="footer-support">
               <li class="grid-row dm-footer-heading">
                 <h3 id="footer-support" class="usa-prose-h3">
@@ -76,7 +76,7 @@
               </li>
             </ul>
           </div>
-          <div class="grid-col-12 desktop:grid-col-3">
+          <div class="grid-col-12 tablet:grid-col-6 desktop:grid-col-3">
             <ul class="add-list-reset" aria-labelledby="footer-legal">
               <li class="grid-row dm-footer-heading">
                 <h3 id="footer-legal" class="usa-prose-h3">
@@ -106,7 +106,7 @@
               </li>
             </ul>
           </div>
-          <div class="grid-col-12 desktop:grid-col-3">
+          <div class="grid-col-12 tablet:grid-col-6 desktop:grid-col-3">
             <ul class="add-list-reset" aria-labelledby="footer-resources">
               <li class="grid-row dm-footer-heading">
                 <h3 id="footer-resources" class="usa-prose-h3">

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -17,9 +17,9 @@
         </div>
         <div class="grid-row margin-bottom-8">
           <div class="grid-col-12 desktop:grid-col-3">
-            <ul class="add-list-reset">
+            <ul class="add-list-reset" aria-labelledby="footer-visit">
               <li class="grid-row dm-footer-heading">
-                <h3 class="usa-prose-h3">
+                <h3 id="footer-visit" class="usa-prose-h3">
                   Visit
                 </h3>
               </li>
@@ -48,9 +48,9 @@
             </ul>
           </div>
           <div class="grid-col-12 desktop:grid-col-3">
-            <ul class="add-list-reset">
+            <ul class="add-list-reset" aria-labelledby="footer-support">
               <li class="grid-row dm-footer-heading">
-                <h3 class="usa-prose-h3">
+                <h3 id="footer-support" class="usa-prose-h3">
                   Support
                 </h3>
               </li>
@@ -77,9 +77,9 @@
             </ul>
           </div>
           <div class="grid-col-12 desktop:grid-col-3">
-            <ul class="add-list-reset">
+            <ul class="add-list-reset" aria-labelledby="footer-legal">
               <li class="grid-row dm-footer-heading">
-                <h3 class="usa-prose-h3">
+                <h3 id="footer-legal" class="usa-prose-h3">
                   Legal
                 </h3>
               </li>
@@ -107,9 +107,9 @@
             </ul>
           </div>
           <div class="grid-col-12 desktop:grid-col-3">
-            <ul class="add-list-reset">
+            <ul class="add-list-reset" aria-labelledby="footer-resources">
               <li class="grid-row dm-footer-heading">
-                <h3 class="usa-prose-h3">
+                <h3 id="footer-resources" class="usa-prose-h3">
                   Resources
                 </h3>
               </li>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -8,7 +8,7 @@
 
   <div class="usa-footer__primary-section bg-primary-darker padding-y-4 desktop:padding-x-7">
     <nav class="usa-footer__nav margin-x-auto padding-0" aria-label="Footer navigation">
-      <section class="usa-footer__primary-content usa-footer__primary-content--collapsible">
+      <section class="usa-footer__primary-content usa-footer__primary-content--collapsible grid-container">
         <img src="<%= asset_path( 'dm-footer-logo.svg' ) %>" alt="VA Diffusion Marketplace"/>
         <div class="grid-row text-white margin-bottom-5">
           <p class="font-sans-md line-height-sans-6">

--- a/spec/features/homepage_spec.rb
+++ b/spec/features/homepage_spec.rb
@@ -94,7 +94,7 @@ describe 'Homepage', type: :feature do
   it 'allows the user to subscribe to the DM newsletter by taking them to the GovDelivery site' do
     fill_in('Your email address', with: 'vladilena.milize@test.com')
 
-    new_window = window_opened_by { click_button('Subscribe today') }
+    new_window = window_opened_by { click_button('Subscribe') }
 
     within_window new_window do
       wait_time = Capybara.default_max_wait_time


### PR DESCRIPTION
### JIRA issue link
[DM-4830](https://agile6.atlassian.net/browse/DM-4830) and a few items from [DM-4578](https://agile6.atlassian.net/browse/DM-4578)

## Description - what does this code do?
- add headings to sections of the footer
- adjust font color + hover styles for footer links 
- adds an `aria-describedby` property to describe the lists via their headings
- move the footer into a `grid-container` so that it fits within the page margins
- adjust responsive behavior for tablets

## Testing done - how did you test it/steps on how can another person can test it 
### `aria-describedby`
1. Open VoiceOver on a Mac.
1. Open the Voiceover menu and the arrow keys to open the Lists menu
1. Confirm that each of the footer links is described by their heading

### responsive behavior
1. open the website at desktop width and confirm that the footer links are spread across 4 columns
2. narrow the browser window to tablet width. Confirm that links are now split into 2 rows of 2 columns
3. narrow the browser window to mobile width. Confirm that links are now displayed in a single column

![responsive-footer](https://github.com/department-of-veterans-affairs/diffusion-marketplace/assets/5402927/367814f6-2dc4-424a-affc-a76375833df8)

## Screenshots, Gifs, Videos from application (if applicable)
### Before
![Screenshot 2024-05-23 at 6 42 01 PM](https://github.com/department-of-veterans-affairs/diffusion-marketplace/assets/5402927/f0cc3026-21ef-4d84-8742-f2131dd325db)

### After
![Screenshot 2024-05-23 at 6 42 16 PM](https://github.com/department-of-veterans-affairs/diffusion-marketplace/assets/5402927/b184d5c2-292d-4e3b-99fa-36f611d3d3cd)

