### PR TITLE
DM-4830: Remove 'Featured topic' and 'Featured innovation' headings

### DIFF
--- a/app/views/home/_featured_section.html.erb
+++ b/app/views/home/_featured_section.html.erb
@@ -18,7 +18,7 @@
       <p class="usa-prose-body margin-bottom-2">
         <%= featured_body_text %>
       </p>
-      <a href="<%= featured_topic_url %>" class="usa-link"><%= featured_link_text %></a>
+      <a href="<%= featured_topic_url %>" class="usa-link" aria-label="<%= featured_link_text %>: <%= featured_h2 %>"><%= featured_link_text %></a>
     </div>
   </div>
 </section>

--- a/app/views/home/_featured_section.html.erb
+++ b/app/views/home/_featured_section.html.erb
@@ -1,4 +1,4 @@
-<section class="featured-<%= section_name %> margin-bottom-8 grid-container" role="region" aria-label="Featured <%= section_name %> section">
+<section class="featured-<%= section_name %> margin-bottom-8 grid-container" role="region" aria-label="Featured <%= section_name %>">
   <div class="grid-row desktop:grid-gap-3 featured-<%= section_name %>-content-container">
     <div class="grid-col-12 margin-bottom-4 desktop:margin-bottom-0 desktop:grid-col-5 homepage-featured-<%= section_name %>-image-container">
       <a href="<%= featured_topic_url %>">
@@ -14,7 +14,6 @@
     </div>
     <div class="display-none desktop:display-block desktop:grid-col-1"></div>
     <div class="grid-col-12 desktop:grid-col-6">
-      <h6 class="usa-prose-h6 margin-top-0 margin-bottom-2">Featured <%= section_name %></h6>
       <h2 class="usa-prose-h2 margin-top-0 margin-bottom-2"><%= featured_h2 %></h2>
       <p class="usa-prose-body margin-bottom-2">
         <%= featured_body_text %>

--- a/spec/features/admin/admin_topics_spec.rb
+++ b/spec/features/admin/admin_topics_spec.rb
@@ -25,7 +25,6 @@ describe 'Admin Topics Tab', type: :feature do
     expect(page).to have_content('/diffusion-map')
     expect(featured_col_values.last.text).to eq "NO"
     visit '/'
-    expect(page).to have_content('FEATURED TOPIC')
     expect(page).to have_content('Mock topic two')
     expect(page).to have_content('Description for mock topic 2')
     expect(page).to have_link('Click here for Veterans Affairs website', href: 'https://www.va.gov')
@@ -53,7 +52,6 @@ describe 'Admin Topics Tab', type: :feature do
     expect(featured_col_values.first.text).to eq "YES"
     expect(featured_col_values[1].text).to eq "NO"
     visit '/'
-    expect(page).to have_content('FEATURED TOPIC')
     expect(page).to have_content('Mock topic three')
     expect(page).to have_content('Description for mock topic 3')
     expect(page).to have_link('Go see VISNs here', href: visns_path)
@@ -63,7 +61,7 @@ describe 'Admin Topics Tab', type: :feature do
     expect(page).to have_content("Topic with ID 3 is now unfeatured.")
     expect(featured_col_values.first.text).to eq "NO"
     visit '/'
-    expect(page).to have_no_content('FEATURED TOPIC')
+    expect(page).to have_no_content('Mock topic three')
   end
 
   it 'allow editing and deleting an existing topic' do
@@ -75,7 +73,6 @@ describe 'Admin Topics Tab', type: :feature do
     click_button('Update Topic')
     expect(page).to have_content('Topic was successfully updated.')
     visit '/'
-    expect(page).to have_content('FEATURED TOPIC')
     expect(page).to have_content('Mock updated topic two')
     visit '/admin'
     click_link 'Topics'
@@ -83,7 +80,7 @@ describe 'Admin Topics Tab', type: :feature do
     page.accept_alert
     expect(page).to have_content('Topic was successfully destroyed.')
     visit '/'
-    expect(page).to have_no_content('FEATURED TOPIC')
+    expect(page).to have_no_content('Mock updated topic two')
   end
 
   it 'disallows an invalid attachment type and displays error message' do


### PR DESCRIPTION
### JIRA issue link
[DM-4830](https://agile6.atlassian.net/browse/DM-4830)

## Description - what does this code do?
- Removes `h6` tags for `Featured topic` and `Featured innovation`
- Add an aria-label with concatenated title to avoid vague links for screenreader users

## Testing done - how did you test it/steps on how can another person can test it 
### `aria-label`
1. Log in as an admin and add a featured innovation and featured topic
1. Open VoiceOver on a Mac.
1. Open the Voiceover menu and the arrow keys to open the Links menu
1. Confirm that the link for each featured item renders both link text and the section title. e.g. `View Innovation: Innovation Title`.


## Screenshots, Gifs, Videos from application (if applicable)
### Before
![Screenshot 2024-05-23 at 7 18 46 PM](https://github.com/department-of-veterans-affairs/diffusion-marketplace/assets/5402927/c905fb7c-41a8-4d2e-b15d-cb9b35b43145)

### After
![Screenshot 2024-05-23 at 7 19 12 PM](https://github.com/department-of-veterans-affairs/diffusion-marketplace/assets/5402927/3cd478d2-877d-428e-88ba-630a3fda439d)
