### PR TITLE
Apply usa-link styles to some stray links

### DIFF
--- a/app/assets/stylesheets/dm/components/_breadcrumbs.scss
+++ b/app/assets/stylesheets/dm/components/_breadcrumbs.scss
@@ -1,5 +1,6 @@
 // `usa-breadcrumb` OVERRIDES
 .usa-breadcrumb {
+  @extend .usa-link;
   @include u-bg('transparent', !important);
   .fas {
     font-size: 13px;
@@ -13,7 +14,7 @@
     }
 
     &:visited {
-      @include u-text('primary-vivid', !important);
+      color: color($theme-link-color);
     }
   }
 

--- a/app/assets/stylesheets/dm/pages/_facilities.scss
+++ b/app/assets/stylesheets/dm/pages/_facilities.scss
@@ -98,11 +98,6 @@
 
 // show page
 #dm-va-facilities-show {
-  .facility-phone-number {
-    text-decoration: none;
-    color: color($theme-color-primary);
-  }
-
   .usa-combo-box__select {
     margin-top: 0;
 

--- a/app/views/home/_featured_section.html.erb
+++ b/app/views/home/_featured_section.html.erb
@@ -18,7 +18,7 @@
       <p class="usa-prose-body margin-bottom-2">
         <%= featured_body_text %>
       </p>
-      <a href="<%= featured_topic_url %>" class="usa-link"><%= featured_link_text %></a>
+      <a href="<%= featured_topic_url %>" class="usa-link" aria-label="<%= featured_link_text %>: <%= featured_h2 %>"><%= featured_link_text %></a>
     </div>
   </div>
 </section>

--- a/app/views/home/_featured_section.html.erb
+++ b/app/views/home/_featured_section.html.erb
@@ -1,4 +1,4 @@
-<section class="featured-<%= section_name %> margin-bottom-8 grid-container" role="region" aria-label="Featured <%= section_name %> section">
+<section class="featured-<%= section_name %> margin-bottom-8 grid-container" role="region" aria-label="Featured <%= section_name %>">
   <div class="grid-row desktop:grid-gap-3 featured-<%= section_name %>-content-container">
     <div class="grid-col-12 margin-bottom-4 desktop:margin-bottom-0 desktop:grid-col-5 homepage-featured-<%= section_name %>-image-container">
       <a href="<%= featured_topic_url %>">
@@ -14,7 +14,6 @@
     </div>
     <div class="display-none desktop:display-block desktop:grid-col-1"></div>
     <div class="grid-col-12 desktop:grid-col-6">
-      <h6 class="usa-prose-h6 margin-top-0 margin-bottom-2">Featured <%= section_name %></h6>
       <h2 class="usa-prose-h2 margin-top-0 margin-bottom-2"><%= featured_h2 %></h2>
       <p class="usa-prose-body margin-bottom-2">
         <%= featured_body_text %>

--- a/app/views/shared/_breadcrumbs.html.erb
+++ b/app/views/shared/_breadcrumbs.html.erb
@@ -52,7 +52,7 @@
             %>
             <li class="usa-breadcrumb__list-item<%= ' page-builder-breadcrumb position-static' if @page %>">
               <i class='fas fa-arrow-left margin-right-05 <%= heading.present? ? 'text-white' : 'text-gray-50' %>'></i>
-              <%= link_to(breadcrumb_display, breadcrumb_path, class: 'usa-breadcrumb__link padding-left-05 font-sans-sm') %>
+              <%= link_to(breadcrumb_display, breadcrumb_path, class: 'usa-link usa-breadcrumb__link padding-left-05 font-sans-sm') %>
             </li>
           <% else %>
             <% breadcrumbs.each do |b| %>

--- a/app/views/va_facilities/show.html.erb
+++ b/app/views/va_facilities/show.html.erb
@@ -47,7 +47,7 @@
           <% else %>
             <% ph_number = @va_facility.station_phone_number %>
           <% end %>
-          Main number: <a class="facility-phone-number" href="tel:<%= ph_number %>"><%= ph_number %></a>
+          Main number: <a class="usa-link" href="tel:<%= ph_number %>"><%= ph_number %></a>
         </div>
       </div>
       <div class="grid-col-6">

--- a/spec/features/admin/admin_topics_spec.rb
+++ b/spec/features/admin/admin_topics_spec.rb
@@ -25,7 +25,6 @@ describe 'Admin Topics Tab', type: :feature do
     expect(page).to have_content('/diffusion-map')
     expect(featured_col_values.last.text).to eq "NO"
     visit '/'
-    expect(page).to have_content('FEATURED TOPIC')
     expect(page).to have_content('Mock topic two')
     expect(page).to have_content('Description for mock topic 2')
     expect(page).to have_link('Click here for Veterans Affairs website', href: 'https://www.va.gov')
@@ -53,7 +52,6 @@ describe 'Admin Topics Tab', type: :feature do
     expect(featured_col_values.first.text).to eq "YES"
     expect(featured_col_values[1].text).to eq "NO"
     visit '/'
-    expect(page).to have_content('FEATURED TOPIC')
     expect(page).to have_content('Mock topic three')
     expect(page).to have_content('Description for mock topic 3')
     expect(page).to have_link('Go see VISNs here', href: visns_path)
@@ -63,7 +61,7 @@ describe 'Admin Topics Tab', type: :feature do
     expect(page).to have_content("Topic with ID 3 is now unfeatured.")
     expect(featured_col_values.first.text).to eq "NO"
     visit '/'
-    expect(page).to have_no_content('FEATURED TOPIC')
+    expect(page).to have_no_content('Mock topic three')
   end
 
   it 'allow editing and deleting an existing topic' do
@@ -75,7 +73,6 @@ describe 'Admin Topics Tab', type: :feature do
     click_button('Update Topic')
     expect(page).to have_content('Topic was successfully updated.')
     visit '/'
-    expect(page).to have_content('FEATURED TOPIC')
     expect(page).to have_content('Mock updated topic two')
     visit '/admin'
     click_link 'Topics'
@@ -83,7 +80,7 @@ describe 'Admin Topics Tab', type: :feature do
     page.accept_alert
     expect(page).to have_content('Topic was successfully destroyed.')
     visit '/'
-    expect(page).to have_no_content('FEATURED TOPIC')
+    expect(page).to have_no_content('Mock updated topic two')
   end
 
   it 'disallows an invalid attachment type and displays error message' do


### PR DESCRIPTION
### JIRA issue link
Folllow up to DM-4583 / #886

## Description - what does this code do?
Unsets SCSS color values and applies USWDS theme link styles to:
- breadcrumb links
- facility phone numbers

## Screenshots, Gifs, Videos from application (if applicable)
### Before
![Screenshot 2024-05-23 at 7 37 50 PM](https://github.com/department-of-veterans-affairs/diffusion-marketplace/assets/5402927/30665645-4bf9-4864-b8f4-49addff7a0fe)

### After
![Screenshot 2024-05-23 at 7 45 52 PM](https://github.com/department-of-veterans-affairs/diffusion-marketplace/assets/5402927/d507b1ed-18ed-4430-a681-fa28662746ee)
