### PR TITLE
Adjust aspec ratio for homepage featured topic / innovation images

### DIFF
--- a/app/assets/stylesheets/dm/pages/_home.scss
+++ b/app/assets/stylesheets/dm/pages/_home.scss
@@ -10,11 +10,7 @@
       @include u-height('full');
       @include u-width('full');
       object-fit: cover;
-      height: 174px !important;
-
-      @media screen and (min-width: 1024px) {
-        height: 223px !important;
-      }
+      aspect-ratio: 58 / 39;
 
       @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
         @include u-display('none', !important);


### PR DESCRIPTION
## Description - what does this code do?
- Adjusts homepage image ratio. Taller images make for less weird image crops

## Screenshots, Gifs, Videos from application (if applicable)
### Before
![Screenshot 2024-05-23 at 7 51 15 PM](https://github.com/department-of-veterans-affairs/diffusion-marketplace/assets/5402927/b100b01d-6c58-440c-b675-bfc1c87d86f4)

### After
![Screenshot 2024-05-23 at 7 51 03 PM](https://github.com/department-of-veterans-affairs/diffusion-marketplace/assets/5402927/237594ae-deaa-4cef-ac59-6f2fc7722024)

## Link to mock-ups/mock ups (image file if you have it) (if applicable)
https://www.figma.com/design/D16fyBygVx88HpyczTuqXs/Diffusion-Marketplace-(2024)%2B?node-id=1469-853&t=PglSnRrycuWId9J2-1