### PR TITLE
Paginated component cleanup

### DIFF
--- a/app/controllers/page_controller.rb
+++ b/app/controllers/page_controller.rb
@@ -183,9 +183,9 @@ class PageController < ApplicationController
       practices = helpers.is_user_a_guest? ? Practice.where(id: practices_ids).public_facing.sort_by_retired.sort_a_to_z : Practice.where(id: practices_ids).published_enabled_approved.sort_by_retired.sort_a_to_z
 
       if @practice_list_components[page_practice_list_index].present?
-        @practice_list_components[page_practice_list_index][:pagy], @practice_list_components[page_practice_list_index][:paginated] = get_pagy_array(practices, page_practice_list_index, params_index, 6, "practices")
+        @practice_list_components[page_practice_list_index][:pagy], @practice_list_components[page_practice_list_index][:paginated] = get_pagy_array(practices, page_practice_list_index, params_index, PagePracticeListComponent::PAGINATION, "practices")
       else
-        pagy_practices, paginated_practices = get_pagy_array(practices, page_practice_list_index, params_index, 6, "practices")
+        pagy_practices, paginated_practices = get_pagy_array(practices, page_practice_list_index, params_index, PagePracticeListComponent::PAGINATION, "practices")
         practice_list_pagy = { pagy: pagy_practices, practices: paginated_practices}
         @practice_list_components.push(practice_list_pagy)
       end

--- a/app/controllers/page_controller.rb
+++ b/app/controllers/page_controller.rb
@@ -139,7 +139,7 @@ class PageController < ApplicationController
 
     set_pagy_practice_list_array(practice_lists) if practice_lists.present?
     paginate_components(events, "events", PageEventComponent::PAGINATION) if events.present?
-    paginate_components(news_items, "news", 6) if news_items.present?
+    paginate_components(news_items, "news", PageNewsComponent::PAGINATION) if news_items.present?
     paginate_components(publications, "publications", PagePublicationComponent::PAGINATION) if publications.present?
   end
 

--- a/app/controllers/page_controller.rb
+++ b/app/controllers/page_controller.rb
@@ -140,7 +140,7 @@ class PageController < ApplicationController
     set_pagy_practice_list_array(practice_lists) if practice_lists.present?
     paginate_components(events, "events", PageEventComponent::PAGINATION) if events.present?
     paginate_components(news_items, "news", 6) if news_items.present?
-    paginate_components(publications, "publications", 10) if publications.present?
+    paginate_components(publications, "publications", PagePublicationComponent::PAGINATION) if publications.present?
   end
 
   # Paginate adjacent news or event components

--- a/app/models/page_news_component.rb
+++ b/app/models/page_news_component.rb
@@ -13,6 +13,8 @@ class PageNewsComponent < ApplicationRecord
     image_alt_text: 'Alternative Text'
   }.freeze
 
+  PAGINATION = 6.freeze
+
   validates_with InternalUrlValidator,
                  on: [:create, :update],
                  if: Proc.new { |component| component.url.present? && component.url.chars.first === '/' }

--- a/app/models/page_practice_list_component.rb
+++ b/app/models/page_practice_list_component.rb
@@ -4,4 +4,6 @@ class PagePracticeListComponent < ApplicationRecord
   FORM_FIELDS = { # Fields and labels in .arb form
     practices: 'Innovations'
   }.freeze
+
+  PAGINATION = 6.freeze
 end

--- a/app/models/page_publication_component.rb
+++ b/app/models/page_publication_component.rb
@@ -22,6 +22,8 @@ class PagePublicationComponent < ApplicationRecord
     authors: 'Authors'
   }.freeze
 
+  PAGINATION = 10.freeze
+
   def attachment_s3_presigned_url(style = nil)
     object_presigned_url(attachment, style)
   end

--- a/app/views/page/show.html.erb
+++ b/app/views/page/show.html.erb
@@ -238,7 +238,7 @@
                 <div class="dm-practice-card-list dm-paginated-<%= component_index %>-practices">
                   <%= render partial: 'shared/practice_cards_row', locals: { practices: pplc[:practices] } %>
                 </div>
-                <% if pplc[:pagy].count > 6 %>
+                <% if pplc[:pagy].count > PagePracticeListComponent::PAGINATION %>
                   <div class="text-center dm-load-more-practices-<%= component_index %>-btn-container" >
                     <% link = pagy_link_proc(pplc[:pagy]) %>
                     <%=  link.call(pplc[:pagy].vars[:page] + 1, 'Load more').html_safe %>

--- a/app/views/page/show.html.erb
+++ b/app/views/page/show.html.erb
@@ -215,7 +215,7 @@
               <ul class="usa-card-group grid-row grid-gap news-component-list dm-paginated-<%= component_index %>-news <%= page_narrow_classes %>">
                 <%= render partial:'news_items_list', locals: { news_items: nic[:news], news_item_count: news_item_count} %>
               </ul>
-              <% if news_item_count > 6 %>
+              <% if news_item_count > PageNewsComponent::PAGINATION %>
                 <div class="text-center dm-load-more-news-<%= component_index %>-btn-container margin-top-5" >
                   <% link = pagy_link_proc(nic[:pagy]) %>
                   <%=  link.call(nic[:pagy].vars[:page] + 1, 'Load more').html_safe %>

--- a/app/views/page/show.html.erb
+++ b/app/views/page/show.html.erb
@@ -266,7 +266,7 @@
                 <div class="publication-component-list dm-paginated-<%= component_index %>-publications margin-bottom-4 <%= page_narrow_classes %><%= ' margin-bottom-0' if last_component === index %>">
                   <%= render(partial: 'publications_list', locals: {publications: plc[:publications]}) %>
                 </div>
-                <% if publications_count > 10 # Load more button %>
+                <% if publications_count > PagePublicationComponent::PAGINATION # Load more button %>
                   <div class="text-center dm-load-more-publications-<%= component_index %>-btn-container">
                     <% link = pagy_link_proc(plc[:pagy]) %>
                     <%=  link.call(plc[:pagy].vars[:page] + 1, 'Load more').html_safe %>

--- a/spec/features/pages/paginated_components_spec.rb
+++ b/spec/features/pages/paginated_components_spec.rb
@@ -7,7 +7,7 @@ describe 'Page Builder - Show - Paginated Components', type: :feature do
     @page_group = PageGroup.create(name: 'programming', slug: 'programming', description: 'Pages about programming go in this group.')
     @paragraph_component = PageParagraphComponent.create(text: "<div><p>Just some filler text</p></div>")
     @event_pagination_size = PageEventComponent::PAGINATION
-    @news_pagination_size = 6
+    @news_pagination_size = PageNewsComponent::PAGINATION
 
 
     # must be logged in to view pages


### PR DESCRIPTION
### JIRA issue link
Some cleanup after #881 / DM-4742

## Description - what does this code do?
- applies the same pattern used for Events to other paginated components. In the past, we've experienced bugs because component pagination changes were applied in the view but not in the controller. Unifying the pagination threshold in one place eliminates this type of bug from happening in the future