### PR TITLE
dm-4562 enable community subnav management

### DIFF
--- a/app/admin/editor/page_group.rb
+++ b/app/admin/editor/page_group.rb
@@ -14,9 +14,9 @@ ActiveAdmin.register PageGroup, namespace: :editor do
         editors = f.object.editors
 
         li do
-          label "Current Editors", for: "current-editors", class: "label"
+          label "Current Editors", for: "current-editors-list", class: "label"
           if editors.any?
-            ul id: 'current-editors', class: 'current-editors margin-left-3' do
+            ul id: 'current-editors-list', class: 'current-editors margin-left-3' do
               editors.each do |editor|
                 li class: 'margin-bottom-1' do
                   span editor.email

--- a/app/admin/editor/page_group.rb
+++ b/app/admin/editor/page_group.rb
@@ -39,12 +39,12 @@ ActiveAdmin.register PageGroup, namespace: :editor do
               hint: "Enter VA emails as a comma-separated list, e.g. marketplace@va.gov, test@va.gov"
     end
 
-    f.inputs 'Pages', class: 'inputs' do
-      if f.object.persisted?
+    if f.object.persisted?
+      f.inputs 'Pages', class: 'inputs' do
         community_pages = f.object.pages.community_pages.to_a
 
         li class: 'padding-bottom-2 margin-bottom-2 border-bottom-1px border-base-light' do
-          label "Community sub-nav link ordering", for: "current-pages text-no-wrap", class: "label"
+          label "Community Sub-Navigation Order", for: "current-pages text-no-wrap", class: "label"
           if community_pages.any?
             ul id: 'current-pages', class: 'margin-x-3 display-flex' do
               community_pages.each_with_index do |page, index|
@@ -61,8 +61,8 @@ ActiveAdmin.register PageGroup, namespace: :editor do
                 end
               end
             end
-            span "Drag and drop to adjust position of links as seen in community sub-nav", class: 'drag-position-hint display-block text-italic text-base-dark'
-            span "Uses Page's TITLE as link text if SHORT NAME is blank", class: 'drag-position-hint display-block text-italic text-base-dark padding-bottom-1'
+            span "Drag and drop to adjust the position of pages as seen in the community's sub-navigation.", class: 'drag-position-hint display-block text-italic text-base-dark'
+            span "Note that sub-navigation title will default to the original page title, rather than to a nickname, if the page nickname is left blank.", class: 'drag-position-hint display-block text-italic text-base-dark padding-bottom-1'
           else
             span "No pages assigned", class: 'no-community-pages display-block text-italic text-base-dark padding-bottom-1'
           end
@@ -70,7 +70,7 @@ ActiveAdmin.register PageGroup, namespace: :editor do
 
         li class: 'margin-top-1'do
           non_community_pages = f.object.pages.where(position: nil)
-          label "Pages not in community sub-nav", for: "unpositioned-pages", class: "label"
+          label "Pages Not In the Community Sub-Navigation", for: "unpositioned-pages", class: "label"
           if non_community_pages.any?
             ul class: 'unpositioned-pages' do
               non_community_pages.each do |page|
@@ -79,7 +79,7 @@ ActiveAdmin.register PageGroup, namespace: :editor do
                 end
               end
             end
-            span "Visit a Page's edit screen to add or remove as link in community sub-nav", class: 'unpositioned-page-hint display-block margin-top-1 text-italic text-base-dark'
+            span "Visit a page's edit screen to add it to / remove it from the community sub-navigation.", class: 'unpositioned-page-hint display-block margin-top-1 text-italic text-base-dark'
           else
             span "No pages assigned", class: 'no-unpositioned-pages display-block margin-top-1 text-italic text-base-dark'
           end

--- a/app/admin/editor/page_group.rb
+++ b/app/admin/editor/page_group.rb
@@ -37,6 +37,8 @@ ActiveAdmin.register PageGroup, namespace: :editor do
               hint: "Enter VA emails as a comma-separated list, e.g. marketplace@va.gov, test@va.gov"
     end
 
+    # TODO: condense 'Editors' and 'Pages' parts of this form into partials to be shared with
+    # admin/editor/page_group form
     f.inputs 'Pages', class: 'inputs' do
       if f.object.persisted?
         community_pages = f.object.pages.community_pages.to_a
@@ -50,8 +52,8 @@ ActiveAdmin.register PageGroup, namespace: :editor do
                   span class: 'handle' do
                     span page.short_name.present? ? page.short_name : page.title
                     span class: "fa fa-stack" do
-                      i class: "fa fa-caret-up"
-                      i class: "fa fa-caret-down"
+                      i class: "fa fa-caret-left"
+                      i class: "fa fa-caret-right"
                     end
                   end
                   f.hidden_field :id, value: page.id, name: "page_group[pages_attributes][#{index}][id]"
@@ -59,8 +61,8 @@ ActiveAdmin.register PageGroup, namespace: :editor do
                 end
               end
             end
-            span "Drag to adjust position of links as seen in community sub-nav", class: 'drag-position-hint'
-            span "Uses Page's TITLE as link text if COMMUNITY SUBNAV LINK TEXT is blank, update in Page's edit form", class: 'drag-position-hint'
+            span "Drag and drop to adjust position of links as seen in community sub-nav", class: 'drag-position-hint'
+            span "Uses Page's TITLE as link text if SHORT NAME is blank", class: 'drag-position-hint'
           else
             span "No pages assigned", class: 'no-community-pages'
           end

--- a/app/admin/editor/page_group.rb
+++ b/app/admin/editor/page_group.rb
@@ -7,14 +7,16 @@ ActiveAdmin.register PageGroup, namespace: :editor do
   permit_params :name, :description, :slug, :has_landing_page, :new_editors, :pages_attributes
 
   form do |f|
+    # TODO: condense 'Editors' and 'Pages' parts of this form into partials to be shared with
+    # admin/editor/page_group form
     f.inputs "Editors", class: 'inputs' do
       if f.object.persisted?
         editors = f.object.editors
 
         li do
-          label "Current Editors", for: "current_editors", class: "label"
+          label "Current Editors", for: "current-editors", class: "label"
           if editors.any?
-            ul id: 'current_editors', class: 'page_group_editors-list' do
+            ul id: 'current-editors', class: 'current-editors margin-left-3' do
               editors.each do |editor|
                 li class: 'margin-bottom-1' do
                   span editor.email
@@ -26,7 +28,7 @@ ActiveAdmin.register PageGroup, namespace: :editor do
               end
             end
           else
-            span "No editors assigned", class: 'placeholder'
+            span "No editors assigned", class: 'no-editors-assigned display-block margin-top-1 text-italic text-base-dark'
           end
         end
       end
@@ -37,23 +39,21 @@ ActiveAdmin.register PageGroup, namespace: :editor do
               hint: "Enter VA emails as a comma-separated list, e.g. marketplace@va.gov, test@va.gov"
     end
 
-    # TODO: condense 'Editors' and 'Pages' parts of this form into partials to be shared with
-    # admin/editor/page_group form
     f.inputs 'Pages', class: 'inputs' do
       if f.object.persisted?
         community_pages = f.object.pages.community_pages.to_a
 
-        li class: 'community-nav-section' do
-          label "Community sub-nav link ordering", for: "current_pages", class: "label"
+        li class: 'padding-bottom-2 margin-bottom-2 border-bottom-1px border-base-light' do
+          label "Community sub-nav link ordering", for: "current-pages text-no-wrap", class: "label"
           if community_pages.any?
-            ul id: 'current_pages', class: 'community-nav-pages-list' do
+            ul id: 'current-pages', class: 'margin-x-3 display-flex' do
               community_pages.each_with_index do |page, index|
-                li class: 'margin-bottom-1', data: { page_id: page.id } do
-                  span class: 'handle' do
+                li class: 'margin-bottom-1 margin-right-1', data: { page_id: page.id } do
+                  span class: 'handle text-no-wrap' do
                     span page.short_name.present? ? page.short_name : page.title
-                    span class: "fa fa-stack" do
-                      i class: "fa fa-caret-left"
-                      i class: "fa fa-caret-right"
+                    span class: "fa fa-stack margin-left-05" do
+                      i class: "fa fa-caret-left margin-left-05"
+                      i class: "fa fa-caret-right margin-left-05"
                     end
                   end
                   f.hidden_field :id, value: page.id, name: "page_group[pages_attributes][#{index}][id]"
@@ -61,27 +61,27 @@ ActiveAdmin.register PageGroup, namespace: :editor do
                 end
               end
             end
-            span "Drag and drop to adjust position of links as seen in community sub-nav", class: 'drag-position-hint'
-            span "Uses Page's TITLE as link text if SHORT NAME is blank", class: 'drag-position-hint'
+            span "Drag and drop to adjust position of links as seen in community sub-nav", class: 'drag-position-hint display-block text-italic text-base-dark'
+            span "Uses Page's TITLE as link text if SHORT NAME is blank", class: 'drag-position-hint display-block text-italic text-base-dark padding-bottom-1'
           else
-            span "No pages assigned", class: 'no-community-pages'
+            span "No pages assigned", class: 'no-community-pages display-block text-italic text-base-dark padding-bottom-1'
           end
         end
 
-        li do
+        li class: 'margin-top-1'do
           non_community_pages = f.object.pages.where(position: nil)
-          label "Pages not in community sub-nav", for: "unpositioned_pages", class: "label"
+          label "Pages not in community sub-nav", for: "unpositioned-pages", class: "label"
           if non_community_pages.any?
-            ul id: 'unpositioned_pages', class: 'community-nav-pages-list' do
+            ul class: 'unpositioned-pages' do
               non_community_pages.each do |page|
                 li class: 'margin-bottom-1' do
                   link_to page.title, edit_editor_page_path(page)
                 end
               end
             end
-            span "Visit a Page's edit screen to add or remove as link in community sub-nav", class: 'unpositioned-page-hint'
+            span "Visit a Page's edit screen to add or remove as link in community sub-nav", class: 'unpositioned-page-hint display-block margin-top-1 text-italic text-base-dark'
           else
-            span "No pages assigned", class: 'no-unpositioned-pages'
+            span "No pages assigned", class: 'no-unpositioned-pages display-block margin-top-1 text-italic text-base-dark'
           end
         end
       end

--- a/app/admin/editor/page_group.rb
+++ b/app/admin/editor/page_group.rb
@@ -41,13 +41,13 @@ ActiveAdmin.register PageGroup, namespace: :editor do
 
     if f.object.persisted?
       f.inputs 'Pages', class: 'inputs' do
-        community_pages = f.object.pages.community_pages.to_a
+        subnav_pages = f.object.pages.subnav_pages.to_a
 
         li class: 'padding-bottom-2 margin-bottom-2 border-bottom-1px border-base-light' do
           label "Community Sub-Navigation Order", for: "current-pages text-no-wrap", class: "label"
-          if community_pages.any?
+          if subnav_pages.any?
             ul id: 'current-pages', class: 'margin-x-3 display-flex' do
-              community_pages.each_with_index do |page, index|
+              subnav_pages.each_with_index do |page, index|
                 li class: 'margin-bottom-1 margin-right-1', data: { page_id: page.id } do
                   span class: 'handle text-no-wrap' do
                     span page.short_name.present? ? page.short_name : page.title
@@ -69,11 +69,11 @@ ActiveAdmin.register PageGroup, namespace: :editor do
         end
 
         li class: 'margin-top-1'do
-          non_community_pages = f.object.pages.where(position: nil)
+          non_subnav_pages = f.object.pages.where(position: nil)
           label "Pages Not In the Community Sub-Navigation", for: "unpositioned-pages", class: "label"
-          if non_community_pages.any?
+          if non_subnav_pages.any?
             ul class: 'unpositioned-pages' do
-              non_community_pages.each do |page|
+              non_subnav_pages.each do |page|
                 li class: 'margin-bottom-1' do
                   link_to page.title, edit_editor_page_path(page)
                 end
@@ -105,18 +105,18 @@ ActiveAdmin.register PageGroup, namespace: :editor do
         end
       end
       row "Community Pages" do |pg|
-        community_pages = pg.pages.where.not(position: nil).to_a
+        subnav_pages = pg.pages.where.not(position: nil).to_a
         ul do
-          community_pages.each do |page|
+          subnav_pages.each do |page|
             li link_to page.title, edit_admin_page_path(page)
           end
         end
       end
 
       row "Non-Community Pages" do |pg|
-        non_community_pages = pg.pages.where(position: nil)
+        non_subnav_pages = pg.pages.where(position: nil)
         ul do
-          non_community_pages.each do |page|
+          non_subnav_pages.each do |page|
             li link_to page.title, edit_admin_page_path(page)
           end
         end

--- a/app/admin/editor/page_group.rb
+++ b/app/admin/editor/page_group.rb
@@ -213,9 +213,11 @@ ActiveAdmin.register PageGroup, namespace: :editor do
     end
 
     def update_pages
-      params[:page_group][:pages_attributes].each do |_, page_params|
-        page = @page_group.pages.find(page_params[:id])
-        page.update(position: page_params[:position])
+      if params[:page_group][:pages_attributes].present?
+        params[:page_group][:pages_attributes].each do |_, page_params|
+          page = @page_group.pages.find(page_params[:id])
+          page.update(position: page_params[:position])
+        end
       end
       true
     end

--- a/app/admin/editor/page_group.rb
+++ b/app/admin/editor/page_group.rb
@@ -39,7 +39,7 @@ ActiveAdmin.register PageGroup, namespace: :editor do
 
     f.inputs 'Pages', class: 'inputs' do
       if f.object.persisted?
-        community_pages = f.object.pages.where.not(position: nil).to_a
+        community_pages = f.object.pages.community_pages.to_a
 
         li class: 'community-nav-section' do
           label "Community sub-nav link ordering", for: "current_pages", class: "label"

--- a/app/admin/editor/pages.rb
+++ b/app/admin/editor/pages.rb
@@ -19,6 +19,8 @@ ActiveAdmin.register Page, namespace: :editor do
                 :image,
                 :image_alt_text,
                 :delete_image_and_alt_text,
+                :included_in_community_subnav,
+                :short_name,
                 page_components_attributes: [
                   :id,
                   :component_type,
@@ -104,8 +106,10 @@ ActiveAdmin.register Page, namespace: :editor do
       }
       row :page_group
       row :slug
+      row :included_in_community_subnav
       row :template_type
       row :title
+      row :short_name
       row :description
       row :has_chrome_warning_banner
       row :published
@@ -182,6 +186,12 @@ ActiveAdmin.register Page, namespace: :editor do
       end
       f.input :template_type
       f.input :title, label: 'Title', hint: 'The main heading/"H1" of the page.'
+      f.input :included_in_community_subnav,
+              label: 'Include in community sub-nav',
+              as: :boolean,
+              hint: 'Add or remove from community sub-nav links'
+      f.input :short_name,
+              hint: 'Overrides title for use as link text in sub-nav'
       f.input :description, label: 'Description', hint: 'Overall purpose of the page.'
       f.input :image,
               value: f.resource.image_file_name,
@@ -235,9 +245,7 @@ ActiveAdmin.register Page, namespace: :editor do
 
 
   controller do
-    skip_before_action :set_communities_for_header
     before_action :set_page,
-                  :delete_page_image_and_alt_text,
                   only: [:create, :update]
     rescue_from ActiveRecord::RecordInvalid, with: :handle_record_invalid
 
@@ -267,14 +275,16 @@ ActiveAdmin.register Page, namespace: :editor do
     end
 
     def create_or_update_page
-      page_params = permitted_params[:page]
-
       ActiveRecord::Base.transaction do
         @page ||= Page.new
+
+        delete_page_image_and_alt_text
+        page_params = permitted_params[:page]
         @page.update!(page_params)
+        update_page_group_position
       end
 
-      redirect_to editor_page_path(@page), notice: "Page was successfully #{action_name == 'create' ? 'created' : 'updated'}."
+      redirect_to admin_page_path(@page), notice: "Page was successfully #{action_name == 'create' ? 'created' : 'updated'}."
     end
 
     def validate_page_description_length(description)
@@ -327,6 +337,14 @@ ActiveAdmin.register Page, namespace: :editor do
 
         params[:page][:image] = nil
         params[:page][:image_alt_text] = nil
+      end
+    end
+
+    def update_page_group_position
+      include_in_community_subnav = (params[:page][:included_in_community_subnav] == "1")
+
+      if include_in_community_subnav != @page.included_in_community_subnav
+        @page.add_or_remove_from_community_subnav
       end
     end
   end

--- a/app/admin/editor/pages.rb
+++ b/app/admin/editor/pages.rb
@@ -187,10 +187,10 @@ ActiveAdmin.register Page, namespace: :editor do
       f.input :template_type
       f.input :title, label: 'Title', hint: 'The main heading/"H1" of the page.'
       f.input :is_community_page,
-              label: "Include as link in #{f.object.page_group&.name || "Community"} sub-nav?",
+              label: "Should we include this page in the #{f.object.page_group&.name || "Community"} sub-navigation?",
               as: :boolean
       f.input :short_name,
-              hint: "Overrides TITLE for use as link text in #{f.object.page_group&.name || "Community"} sub-nav"
+              hint: "This is the page's nickname for the #{f.object.page_group&.name || "Community"} sub-navigation. Needs to be short – 1 to 2 words maximum."
       f.input :description, label: 'Description', hint: 'Overall purpose of the page.'
       f.input :image,
               value: f.resource.image_file_name,

--- a/app/admin/editor/pages.rb
+++ b/app/admin/editor/pages.rb
@@ -284,7 +284,7 @@ ActiveAdmin.register Page, namespace: :editor do
         update_page_group_position
       end
 
-      redirect_to admin_page_path(@page), notice: "Page was successfully #{action_name == 'create' ? 'created' : 'updated'}."
+      redirect_to editor_page_path(@page), notice: "Page was successfully #{action_name == 'create' ? 'created' : 'updated'}."
     end
 
     def validate_page_description_length(description)

--- a/app/admin/editor/pages.rb
+++ b/app/admin/editor/pages.rb
@@ -189,9 +189,9 @@ ActiveAdmin.register Page, namespace: :editor do
       f.input :is_community_page,
               label: 'Community page?',
               as: :boolean,
-              hint: 'Add or remove from community sub-nav links'
+              hint: "Include as link in #{f.object.page_group&.name || "Community"} sub-nav?"
       f.input :short_name,
-              hint: 'Overrides title for use as link text in community sub-nav'
+              hint: "Overrides TITLE for use as link text in #{f.object.page_group&.name || "Community"} sub-nav"
       f.input :description, label: 'Description', hint: 'Overall purpose of the page.'
       f.input :image,
               value: f.resource.image_file_name,

--- a/app/admin/editor/pages.rb
+++ b/app/admin/editor/pages.rb
@@ -19,7 +19,7 @@ ActiveAdmin.register Page, namespace: :editor do
                 :image,
                 :image_alt_text,
                 :delete_image_and_alt_text,
-                :included_in_community_subnav,
+                :is_community_page,
                 :short_name,
                 page_components_attributes: [
                   :id,
@@ -106,7 +106,7 @@ ActiveAdmin.register Page, namespace: :editor do
       }
       row :page_group
       row :slug
-      row :included_in_community_subnav
+      row :is_community_page
       row :template_type
       row :title
       row :short_name
@@ -186,8 +186,8 @@ ActiveAdmin.register Page, namespace: :editor do
       end
       f.input :template_type
       f.input :title, label: 'Title', hint: 'The main heading/"H1" of the page.'
-      f.input :included_in_community_subnav,
-              label: 'Include in community sub-nav',
+      f.input :is_community_page,
+              label: 'Community page?',
               as: :boolean,
               hint: 'Add or remove from community sub-nav links'
       f.input :short_name,
@@ -341,9 +341,9 @@ ActiveAdmin.register Page, namespace: :editor do
     end
 
     def update_page_group_position
-      include_in_community_subnav = (params[:page][:included_in_community_subnav] == "1")
+      include_in_community_subnav = (params[:page][:is_community_page] == "1")
 
-      if include_in_community_subnav != @page.included_in_community_subnav
+      if include_in_community_subnav != @page.is_community_page
         @page.add_or_remove_from_community_subnav
       end
     end

--- a/app/admin/editor/pages.rb
+++ b/app/admin/editor/pages.rb
@@ -191,7 +191,7 @@ ActiveAdmin.register Page, namespace: :editor do
               as: :boolean,
               hint: 'Add or remove from community sub-nav links'
       f.input :short_name,
-              hint: 'Overrides title for use as link text in sub-nav'
+              hint: 'Overrides title for use as link text in community sub-nav'
       f.input :description, label: 'Description', hint: 'Overall purpose of the page.'
       f.input :image,
               value: f.resource.image_file_name,

--- a/app/admin/editor/pages.rb
+++ b/app/admin/editor/pages.rb
@@ -19,7 +19,7 @@ ActiveAdmin.register Page, namespace: :editor do
                 :image,
                 :image_alt_text,
                 :delete_image_and_alt_text,
-                :is_community_page,
+                :is_subnav_page,
                 :short_name,
                 page_components_attributes: [
                   :id,
@@ -106,7 +106,7 @@ ActiveAdmin.register Page, namespace: :editor do
       }
       row :page_group
       row :slug
-      row :is_community_page
+      row :is_subnav_page
       row :template_type
       row :title
       row :short_name
@@ -186,7 +186,7 @@ ActiveAdmin.register Page, namespace: :editor do
       end
       f.input :template_type
       f.input :title, label: 'Title', hint: 'The main heading/"H1" of the page.'
-      f.input :is_community_page,
+      f.input :is_subnav_page,
               label: "Should we include this page in the #{f.object.page_group&.name || "Community"} sub-navigation?",
               as: :boolean
       f.input :short_name,
@@ -341,9 +341,9 @@ ActiveAdmin.register Page, namespace: :editor do
     end
 
     def update_page_group_position
-      include_in_community_subnav = (params[:page][:is_community_page] == "1")
+      include_in_community_subnav = (params[:page][:is_subnav_page] == "1")
 
-      if include_in_community_subnav != @page.is_community_page
+      if include_in_community_subnav != @page.is_subnav_page
         @page.add_or_remove_from_community_subnav
       end
     end

--- a/app/admin/editor/pages.rb
+++ b/app/admin/editor/pages.rb
@@ -187,9 +187,8 @@ ActiveAdmin.register Page, namespace: :editor do
       f.input :template_type
       f.input :title, label: 'Title', hint: 'The main heading/"H1" of the page.'
       f.input :is_community_page,
-              label: 'Community page?',
-              as: :boolean,
-              hint: "Include as link in #{f.object.page_group&.name || "Community"} sub-nav?"
+              label: "Include as link in #{f.object.page_group&.name || "Community"} sub-nav?",
+              as: :boolean
       f.input :short_name,
               hint: "Overrides TITLE for use as link text in #{f.object.page_group&.name || "Community"} sub-nav"
       f.input :description, label: 'Description', hint: 'Overall purpose of the page.'

--- a/app/admin/editor/pages.rb
+++ b/app/admin/editor/pages.rb
@@ -190,6 +190,7 @@ ActiveAdmin.register Page, namespace: :editor do
               label: "Should we include this page in the #{f.object.page_group&.name || "Community"} sub-navigation?",
               as: :boolean
       f.input :short_name,
+              label: 'Page Nickname',
               hint: "This is the page's nickname for the #{f.object.page_group&.name || "Community"} sub-navigation. Needs to be short – 1 to 2 words maximum."
       f.input :description, label: 'Description', hint: 'Overall purpose of the page.'
       f.input :image,

--- a/app/admin/page_group.rb
+++ b/app/admin/page_group.rb
@@ -44,7 +44,7 @@ ActiveAdmin.register PageGroup do
               hint: "Enter VA emails as a comma-separated list, e.g. marketplace@va.gov, test@va.gov"
     end
 
-    if f.object.persisted?
+    if f.object.persisted? && f.object.is_community?
       f.inputs 'Pages', class: 'inputs' do
         community_pages = f.object.pages.community_pages.to_a
 

--- a/app/admin/page_group.rb
+++ b/app/admin/page_group.rb
@@ -44,7 +44,7 @@ ActiveAdmin.register PageGroup do
 
     f.inputs 'Pages', class: 'inputs' do
       if f.object.persisted?
-        community_pages = f.object.pages.where.not(position: nil).to_a
+        community_pages = f.object.pages.community_pages.to_a
 
         li class: 'community-nav-section' do
           label "Community sub-nav link ordering", for: "current_pages", class: "label"

--- a/app/admin/page_group.rb
+++ b/app/admin/page_group.rb
@@ -205,9 +205,11 @@ ActiveAdmin.register PageGroup do
     end
 
     def update_pages
-      params[:page_group][:pages_attributes].each do |_, page_params|
-        page = @page_group.pages.find(page_params[:id])
-        page.update(position: page_params[:position])
+      if params[:page_group][:pages_attributes].present?
+        params[:page_group][:pages_attributes].each do |_, page_params|
+          page = @page_group.pages.find(page_params[:id])
+          page.update(position: page_params[:position])
+        end
       end
       true
     end

--- a/app/admin/page_group.rb
+++ b/app/admin/page_group.rb
@@ -42,6 +42,8 @@ ActiveAdmin.register PageGroup do
               hint: "Enter VA emails as a comma-separated list, e.g. marketplace@va.gov, test@va.gov"
     end
 
+    # TODO: condense 'Editors' and 'Pages' parts of this form into partials to be shared with
+    # admin/page_group form
     f.inputs 'Pages', class: 'inputs' do
       if f.object.persisted?
         community_pages = f.object.pages.community_pages.to_a
@@ -55,8 +57,8 @@ ActiveAdmin.register PageGroup do
                   span class: 'handle' do
                     span page.short_name.present? ? page.short_name : page.title
                     span class: "fa fa-stack" do
-                      i class: "fa fa-caret-up"
-                      i class: "fa fa-caret-down"
+                      i class: "fa fa-caret-left"
+                      i class: "fa fa-caret-right"
                     end
                   end
                   f.hidden_field :id, value: page.id, name: "page_group[pages_attributes][#{index}][id]"
@@ -64,8 +66,8 @@ ActiveAdmin.register PageGroup do
                 end
               end
             end
-            span "Drag to adjust position of links as seen in community sub-nav", class: 'drag-position-hint'
-            span "Uses Page's TITLE as link text if COMMUNITY SUBNAV LINK TEXT is blank, update in Page's edit form", class: 'drag-position-hint'
+            span "Drag and drop to adjust position of links as seen in community sub-nav", class: 'drag-position-hint'
+            span "Uses Page's TITLE as link text if SHORT NAME is blank", class: 'drag-position-hint'
           else
             span "No pages assigned", class: 'no-community-pages'
           end

--- a/app/admin/page_group.rb
+++ b/app/admin/page_group.rb
@@ -44,12 +44,12 @@ ActiveAdmin.register PageGroup do
               hint: "Enter VA emails as a comma-separated list, e.g. marketplace@va.gov, test@va.gov"
     end
 
-    f.inputs 'Pages', class: 'inputs' do
-      if f.object.persisted?
+    if f.object.persisted?
+      f.inputs 'Pages', class: 'inputs' do
         community_pages = f.object.pages.community_pages.to_a
 
         li class: 'padding-bottom-2 margin-bottom-2 border-bottom-1px border-base-light' do
-          label "Community sub-nav link ordering", for: "current-pages text-no-wrap", class: "label"
+          label "Community Sub-Navigation Order", for: "current-pages text-no-wrap", class: "label"
           if community_pages.any?
             ul id: 'current-pages', class: 'margin-x-3 display-flex' do
               community_pages.each_with_index do |page, index|
@@ -66,8 +66,8 @@ ActiveAdmin.register PageGroup do
                 end
               end
             end
-            span "Drag and drop to adjust position of links as seen in community sub-nav", class: 'drag-position-hint display-block text-italic text-base-dark'
-            span "Uses Page's TITLE as link text if SHORT NAME is blank", class: 'drag-position-hint display-block text-italic text-base-dark padding-bottom-1'
+            span "Drag and drop to adjust the position of pages as seen in the community's sub-navigation.", class: 'drag-position-hint display-block text-italic text-base-dark'
+            span "Note that sub-navigation title will default to the original page title, rather than to a nickname, if the page nickname is left blank.", class: 'drag-position-hint display-block text-italic text-base-dark padding-bottom-1'
           else
             span "No pages assigned", class: 'no-community-pages display-block text-italic text-base-dark padding-bottom-1'
           end
@@ -75,7 +75,7 @@ ActiveAdmin.register PageGroup do
 
         li class: 'margin-top-1'do
           non_community_pages = f.object.pages.where(position: nil)
-          label "Pages not in community sub-nav", for: "unpositioned-pages", class: "label"
+          label "Pages Not In the Community Sub-Navigation", for: "unpositioned-pages", class: "label"
           if non_community_pages.any?
             ul class: 'unpositioned-pages' do
               non_community_pages.each do |page|
@@ -84,7 +84,7 @@ ActiveAdmin.register PageGroup do
                 end
               end
             end
-            span "Visit a Page's edit screen to add or remove as link in community sub-nav", class: 'unpositioned-page-hint display-block margin-top-1 text-italic text-base-dark'
+            span "Visit a page's edit screen to add it to / remove it from the community sub-navigation.", class: 'unpositioned-page-hint display-block margin-top-1 text-italic text-base-dark'
           else
             span "No pages assigned", class: 'no-unpositioned-pages display-block margin-top-1 text-italic text-base-dark'
           end

--- a/app/admin/page_group.rb
+++ b/app/admin/page_group.rb
@@ -12,14 +12,16 @@ ActiveAdmin.register PageGroup do
       f.input :description
     end
 
+    # TODO: condense 'Editors' and 'Pages' parts of this form into partials to be shared with
+    # admin/editor/page_group form
     f.inputs "Editors", class: 'inputs' do
       if f.object.persisted?
         editors = f.object.editors
 
         li do
-          label "Current Editors", for: "current_editors", class: "label"
+          label "Current Editors", for: "current-editors", class: "label"
           if editors.any?
-            ul id: 'current_editors', class: 'page_group_editors-list' do
+            ul id: 'current-editors', class: 'current-editors margin-left-3' do
               editors.each do |editor|
                 li class: 'margin-bottom-1' do
                   span editor.email
@@ -31,7 +33,7 @@ ActiveAdmin.register PageGroup do
               end
             end
           else
-            span "No editors assigned", class: 'placeholder'
+            span "No editors assigned", class: 'no-editors-assigned display-block margin-top-1 text-italic text-base-dark'
           end
         end
       end
@@ -42,23 +44,21 @@ ActiveAdmin.register PageGroup do
               hint: "Enter VA emails as a comma-separated list, e.g. marketplace@va.gov, test@va.gov"
     end
 
-    # TODO: condense 'Editors' and 'Pages' parts of this form into partials to be shared with
-    # admin/page_group form
     f.inputs 'Pages', class: 'inputs' do
       if f.object.persisted?
         community_pages = f.object.pages.community_pages.to_a
 
-        li class: 'community-nav-section' do
-          label "Community sub-nav link ordering", for: "current_pages", class: "label"
+        li class: 'padding-bottom-2 margin-bottom-2 border-bottom-1px border-base-light' do
+          label "Community sub-nav link ordering", for: "current-pages text-no-wrap", class: "label"
           if community_pages.any?
-            ul id: 'current_pages', class: 'community-nav-pages-list' do
+            ul id: 'current-pages', class: 'margin-x-3 display-flex' do
               community_pages.each_with_index do |page, index|
-                li class: 'margin-bottom-1', data: { page_id: page.id } do
-                  span class: 'handle' do
+                li class: 'margin-bottom-1 margin-right-1', data: { page_id: page.id } do
+                  span class: 'handle text-no-wrap' do
                     span page.short_name.present? ? page.short_name : page.title
-                    span class: "fa fa-stack" do
-                      i class: "fa fa-caret-left"
-                      i class: "fa fa-caret-right"
+                    span class: "fa fa-stack margin-left-05" do
+                      i class: "fa fa-caret-left margin-left-05"
+                      i class: "fa fa-caret-right margin-left-05"
                     end
                   end
                   f.hidden_field :id, value: page.id, name: "page_group[pages_attributes][#{index}][id]"
@@ -66,27 +66,27 @@ ActiveAdmin.register PageGroup do
                 end
               end
             end
-            span "Drag and drop to adjust position of links as seen in community sub-nav", class: 'drag-position-hint'
-            span "Uses Page's TITLE as link text if SHORT NAME is blank", class: 'drag-position-hint'
+            span "Drag and drop to adjust position of links as seen in community sub-nav", class: 'drag-position-hint display-block text-italic text-base-dark'
+            span "Uses Page's TITLE as link text if SHORT NAME is blank", class: 'drag-position-hint display-block text-italic text-base-dark padding-bottom-1'
           else
-            span "No pages assigned", class: 'no-community-pages'
+            span "No pages assigned", class: 'no-community-pages display-block text-italic text-base-dark padding-bottom-1'
           end
         end
 
-        li do
+        li class: 'margin-top-1'do
           non_community_pages = f.object.pages.where(position: nil)
-          label "Pages not in community sub-nav", for: "unpositioned_pages", class: "label"
+          label "Pages not in community sub-nav", for: "unpositioned-pages", class: "label"
           if non_community_pages.any?
-            ul id: 'unpositioned_pages', class: 'community-nav-pages-list' do
+            ul class: 'unpositioned-pages' do
               non_community_pages.each do |page|
                 li class: 'margin-bottom-1' do
-                  link_to page.title, edit_admin_page_path(page)
+                  link_to page.title, edit_editor_page_path(page)
                 end
               end
             end
-            span "Visit a Page's edit screen to add or remove as link in community sub-nav", class: 'unpositioned-page-hint'
+            span "Visit a Page's edit screen to add or remove as link in community sub-nav", class: 'unpositioned-page-hint display-block margin-top-1 text-italic text-base-dark'
           else
-            span "No pages assigned", class: 'no-unpositioned-pages'
+            span "No pages assigned", class: 'no-unpositioned-pages display-block margin-top-1 text-italic text-base-dark'
           end
         end
       end

--- a/app/admin/page_group.rb
+++ b/app/admin/page_group.rb
@@ -19,9 +19,9 @@ ActiveAdmin.register PageGroup do
         editors = f.object.editors
 
         li do
-          label "Current Editors", for: "current-editors", class: "label"
+          label "Current Editors", for: "current-editors-list", class: "label"
           if editors.any?
-            ul id: 'current-editors', class: 'current-editors margin-left-3' do
+            ul id: 'current-editors-list', class: 'current-editors margin-left-3' do
               editors.each do |editor|
                 li class: 'margin-bottom-1' do
                   span editor.email
@@ -46,13 +46,13 @@ ActiveAdmin.register PageGroup do
 
     if f.object.persisted? && f.object.is_community?
       f.inputs 'Pages', class: 'inputs' do
-        community_pages = f.object.pages.community_pages.to_a
+        subnav_pages = f.object.pages.subnav_pages.to_a
 
         li class: 'padding-bottom-2 margin-bottom-2 border-bottom-1px border-base-light' do
           label "Community Sub-Navigation Order", for: "current-pages text-no-wrap", class: "label"
-          if community_pages.any?
+          if subnav_pages.any?
             ul id: 'current-pages', class: 'margin-x-3 display-flex' do
-              community_pages.each_with_index do |page, index|
+              subnav_pages.each_with_index do |page, index|
                 li class: 'margin-bottom-1 margin-right-1', data: { page_id: page.id } do
                   span class: 'handle text-no-wrap' do
                     span page.short_name.present? ? page.short_name : page.title
@@ -74,11 +74,11 @@ ActiveAdmin.register PageGroup do
         end
 
         li class: 'margin-top-1'do
-          non_community_pages = f.object.pages.where(position: nil)
+          non_subnav_pages = f.object.pages.where(position: nil)
           label "Pages Not In the Community Sub-Navigation", for: "unpositioned-pages", class: "label"
-          if non_community_pages.any?
+          if non_subnav_pages.any?
             ul class: 'unpositioned-pages' do
-              non_community_pages.each do |page|
+              non_subnav_pages.each do |page|
                 li class: 'margin-bottom-1' do
                   link_to page.title, edit_admin_page_path(page)
                 end
@@ -108,18 +108,18 @@ ActiveAdmin.register PageGroup do
         end
       end
       row "Community Pages" do |pg|
-        community_pages = pg.pages.where.not(position: nil).to_a
+        subnav_pages = pg.pages.where.not(position: nil).to_a
         ul do
-          community_pages.each do |page|
+          subnav_pages.each do |page|
             li link_to page.title, edit_admin_page_path(page)
           end
         end
       end
 
       row "Non-Community Pages" do |pg|
-        non_community_pages = pg.pages.where(position: nil)
+        non_subnav_pages = pg.pages.where(position: nil)
         ul do
-          non_community_pages.each do |page|
+          non_subnav_pages.each do |page|
             li link_to page.title, edit_admin_page_path(page)
           end
         end

--- a/app/admin/page_group.rb
+++ b/app/admin/page_group.rb
@@ -80,7 +80,7 @@ ActiveAdmin.register PageGroup do
             ul class: 'unpositioned-pages' do
               non_community_pages.each do |page|
                 li class: 'margin-bottom-1' do
-                  link_to page.title, edit_editor_page_path(page)
+                  link_to page.title, edit_admin_page_path(page)
                 end
               end
             end

--- a/app/admin/pages.rb
+++ b/app/admin/pages.rb
@@ -84,7 +84,7 @@ ActiveAdmin.register Page do
   # end
   #
 
-  remove_filter :versions
+  remove_filter :versions, :position
   index do
     selectable_column
     column(:title) { |page| link_to(page.title, admin_page_path(page)) }

--- a/app/admin/pages.rb
+++ b/app/admin/pages.rb
@@ -16,7 +16,7 @@ ActiveAdmin.register Page do
                 :image,
                 :image_alt_text,
                 :delete_image_and_alt_text,
-                :is_community_page,
+                :is_subnav_page,
                 :short_name,
                 page_components_attributes: [
                   :id,
@@ -114,7 +114,7 @@ ActiveAdmin.register Page do
       }
       row :page_group
       row :slug
-      row :is_community_page
+      row :is_subnav_page
       row :template_type
       row :title
       row :short_name
@@ -194,7 +194,7 @@ ActiveAdmin.register Page do
       end
       f.input :template_type
       f.input :title, label: 'Title', hint: 'The main heading/"H1" of the page.'
-      f.input :is_community_page,
+      f.input :is_subnav_page,
               label: "Should we include this page in the #{f.object.page_group&.name || "Community"} sub-navigation?",
               as: :boolean
       f.input :short_name,
@@ -331,9 +331,9 @@ ActiveAdmin.register Page do
     end
 
     def update_page_group_position
-      include_in_community_subnav = (params[:page][:is_community_page] == "1")
+      include_in_community_subnav = (params[:page][:is_subnav_page] == "1")
 
-      if include_in_community_subnav != @page.is_community_page
+      if include_in_community_subnav != @page.is_subnav_page
         @page.add_or_remove_from_community_subnav
       end
     end

--- a/app/admin/pages.rb
+++ b/app/admin/pages.rb
@@ -16,7 +16,7 @@ ActiveAdmin.register Page do
                 :image,
                 :image_alt_text,
                 :delete_image_and_alt_text,
-                :included_in_community_subnav,
+                :is_community_page,
                 :short_name,
                 page_components_attributes: [
                   :id,
@@ -114,7 +114,7 @@ ActiveAdmin.register Page do
       }
       row :page_group
       row :slug
-      row :included_in_community_subnav
+      row :is_community_page
       row :template_type
       row :title
       row :short_name
@@ -194,8 +194,8 @@ ActiveAdmin.register Page do
       end
       f.input :template_type
       f.input :title, label: 'Title', hint: 'The main heading/"H1" of the page.'
-      f.input :included_in_community_subnav,
-              label: 'Include in community sub-nav',
+      f.input :is_community_page,
+              label: 'Community page?',
               as: :boolean,
               hint: 'Add or remove from community sub-nav links'
       f.input :short_name,
@@ -331,9 +331,9 @@ ActiveAdmin.register Page do
     end
 
     def update_page_group_position
-      include_in_community_subnav = (params[:page][:included_in_community_subnav] == "1")
+      include_in_community_subnav = (params[:page][:is_community_page] == "1")
 
-      if include_in_community_subnav != @page.included_in_community_subnav
+      if include_in_community_subnav != @page.is_community_page
         @page.add_or_remove_from_community_subnav
       end
     end

--- a/app/admin/pages.rb
+++ b/app/admin/pages.rb
@@ -195,11 +195,10 @@ ActiveAdmin.register Page do
       f.input :template_type
       f.input :title, label: 'Title', hint: 'The main heading/"H1" of the page.'
       f.input :is_community_page,
-              label: 'Community page?',
-              as: :boolean,
-              hint: 'Add or remove from community sub-nav links'
+              label: "Include as link in #{f.object.page_group&.name || "Community"} sub-nav?",
+              as: :boolean
       f.input :short_name,
-              hint: 'Overrides title for use as link text in community sub-nav'
+              hint: "Overrides TITLE for use as link text in #{f.object.page_group&.name || "Community"} sub-nav"
       f.input :description, label: 'Description', hint: 'Overall purpose of the page.'
       f.input :image,
               value: f.resource.image_file_name,

--- a/app/admin/pages.rb
+++ b/app/admin/pages.rb
@@ -199,7 +199,7 @@ ActiveAdmin.register Page do
               as: :boolean,
               hint: 'Add or remove from community sub-nav links'
       f.input :short_name,
-              hint: 'Overrides title for use as link text in sub-nav'
+              hint: 'Overrides title for use as link text in community sub-nav'
       f.input :description, label: 'Description', hint: 'Overall purpose of the page.'
       f.input :image,
               value: f.resource.image_file_name,

--- a/app/admin/pages.rb
+++ b/app/admin/pages.rb
@@ -195,10 +195,11 @@ ActiveAdmin.register Page do
       f.input :template_type
       f.input :title, label: 'Title', hint: 'The main heading/"H1" of the page.'
       f.input :is_community_page,
-              label: "Include as link in #{f.object.page_group&.name || "Community"} sub-nav?",
+              label: "Should we include this page in the #{f.object.page_group&.name || "Community"} sub-navigation?",
               as: :boolean
       f.input :short_name,
-              hint: "Overrides TITLE for use as link text in #{f.object.page_group&.name || "Community"} sub-nav"
+              label: 'Page Nickname',
+              hint: "This is the page's nickname for the #{f.object.page_group&.name || "Community"} sub-navigation. Needs to be short – 1 to 2 words maximum."
       f.input :description, label: 'Description', hint: 'Overall purpose of the page.'
       f.input :image,
               value: f.resource.image_file_name,

--- a/app/assets/javascripts/active_admin.js
+++ b/app/assets/javascripts/active_admin.js
@@ -5,6 +5,7 @@
 //= require arrive.min
 //= require tinymce
 //= require ./practice_editor_utilities
+//= require admin/page_group
 
 const CHARACTER_COUNTER_VALID_COLOR =  '#a9aeb1';
 const CHARACTER_COUNTER_INVALID_COLOR = '#e52207';
@@ -165,7 +166,6 @@ const pageComponentNames = [
         if (currentMCE) {
             tinymce.remove('#' + currentMCE);
         }
-        
         // Set the currentMCE variable to the current selector.
         currentMCE = selector;
 

--- a/app/assets/javascripts/admin/page_group.js
+++ b/app/assets/javascripts/admin/page_group.js
@@ -2,6 +2,7 @@ $(document).ready(function() {
   $('#current_pages').sortable({
     items: 'li',
     handle: '.handle',
+    axis: 'x',
     update: function(event, ui) {
       $('#current_pages li').each(function(index) {
         $(this).find('input[name*="[position]"]').val(index + 1);

--- a/app/assets/javascripts/admin/page_group.js
+++ b/app/assets/javascripts/admin/page_group.js
@@ -1,0 +1,11 @@
+$(document).ready(function() {
+  $('#current_pages').sortable({
+    items: 'li',
+    handle: '.handle',
+    update: function(event, ui) {
+      $('#current_pages li').each(function(index) {
+        $(this).find('input[name*="[position]"]').val(index + 1);
+      });
+    }
+  });
+});

--- a/app/assets/javascripts/admin/page_group.js
+++ b/app/assets/javascripts/admin/page_group.js
@@ -1,10 +1,10 @@
 $(document).ready(function() {
-  $('#current_pages').sortable({
+  $('#current-pages').sortable({
     items: 'li',
     handle: '.handle',
     axis: 'x',
     update: function(event, ui) {
-      $('#current_pages li').each(function(index) {
+      $('#current-pages li').each(function(index) {
         $(this).find('input[name*="[position]"]').val(index + 1);
       });
     }

--- a/app/assets/stylesheets/active_admin.scss
+++ b/app/assets/stylesheets/active_admin.scss
@@ -1,4 +1,4 @@
-@import 'activeadmin_addons/all';
+@import "activeadmin_addons/all";
 // SASS variable overrides must be declared before loading up Active Admin's styles.
 //
 // To view the variables that Active Admin provides, take a look at
@@ -9,15 +9,15 @@
 // $sidebar-width: 242px;
 
 // Active Admin's got SASS!
-@import 'active_admin/mixins';
-@import 'active_admin/base';
-@import 'active_skin';
-@import 'wigu/active_admin_theme';
+@import "active_admin/mixins";
+@import "active_admin/base";
+@import "active_skin";
+@import "wigu/active_admin_theme";
 @import "font-awesome-sprockets";
 @import "font-awesome";
 @import "uswds/uswds";
 @import "/dm_uswds/theme/uswds-theme-color";
-@import '/dm/classes';
+@import "/dm/classes";
 
 // Overriding any non-variable SASS must be done after the fact.
 // For example, to change the default status-tag color:
@@ -26,7 +26,9 @@
 
 @mixin tooltip-icon {
   margin-left: 0.25rem;
-  font-family: "Font Awesome 5 Free"; font-weight: 900; content: "\f059";
+  font-family: "Font Awesome 5 Free";
+  font-weight: 900;
+  content: "\f059";
 }
 
 @mixin bold($font-color: $black) {
@@ -51,14 +53,16 @@
 
   .attributes_table {
     table {
-      th, td {
+      th,
+      td {
         color: black;
       }
     }
   }
 
   table.index_table {
-    th, td {
+    th,
+    td {
       color: black;
     }
   }
@@ -83,10 +87,10 @@
   }
 
   .polyform {
-    display: none
+    display: none;
   }
 
-  .active_admin_action_button{
+  .active_admin_action_button {
     @include bold($theme-color-base-ink);
     background-image: none;
     border: none;
@@ -95,16 +99,17 @@
     border-radius: 4px;
     background-color: #5ea3d3;
     display: inline-block;
-    font-size: 1.0em;
-    font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
+    font-size: 1em;
+    font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
     text-decoration: none;
     padding: 10px 20px;
     line-height: 12px;
-      &:link,&:visited{
-        color: $theme-color-dm-white;
-        text-decoration: none;
-      }
-    &:hover{
+    &:link,
+    &:visited {
+      color: $theme-color-dm-white;
+      text-decoration: none;
+    }
+    &:hover {
       background-color: #72aed8 !important;
       text-decoration: none;
     }
@@ -119,7 +124,7 @@
   }
 
   .page_components .required > label::after {
-      content: ' *';
+    content: " *";
   }
 
   .page_components .form-header {
@@ -136,7 +141,6 @@
   .max-height-15 {
     max-height: 15rem;
   }
-
 
   .aa-downloadable-file-link {
     margin: 0.5em 0 0 20%;
@@ -180,7 +184,7 @@
       margin-bottom: 0;
 
       li {
-        color: #5E6469;
+        color: #5e6469;
         list-style-type: none;
         font-size: 13px;
       }
@@ -218,7 +222,7 @@
       margin-right: 0;
 
       li {
-        color: #5E6469;
+        color: #5e6469;
         list-style-type: none;
         font-size: 13px;
       }
@@ -231,10 +235,12 @@
     }
   }
 
-  #page_is_visible_input, #page_has_chrome_warning_banner_input, #page_is_public_input {
+  #page_is_visible_input,
+  #page_has_chrome_warning_banner_input,
+  #page_is_public_input {
     // Active admin 'hint'
     .inline-hints {
-      @include u-display('inline-block');
+      @include u-display("inline-block");
     }
   }
 }
@@ -270,9 +276,9 @@
 .dm-retired-reason-container {
   label {
     @include u-margin-top(5);
-    @include u-position('absolute');
-    @include u-text('bold');
-    @include u-text('uppercase');
+    @include u-position("absolute");
+    @include u-text("bold");
+    @include u-text("uppercase");
     left: 10px;
     color: #8494a8;
   }
@@ -301,8 +307,8 @@
     background-color: #5ea3d3;
     padding: 10px 20px;
     color: #ffffff !important;
-    font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
-    font-size: 1.0em;
+    font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+    font-size: 1em;
   }
 
   .admin-email-all-practice-editors {
@@ -310,8 +316,8 @@
     background-color: #5ea3d3;
     padding: 10px 20px;
     color: #ffffff !important;
-    font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
-    font-size: 1.0em;
+    font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+    font-size: 1em;
     margin-right: 2px;
   }
 }
@@ -344,4 +350,51 @@
 
 .toggle-large-title-styling {
   margin-top: 7px;
+}
+
+.handle {
+  cursor: grab;
+  display: inline-flex;
+  align-items: center;
+}
+
+.handle:active {
+  cursor: grabbing;
+}
+
+.fa-stack {
+  text-align: center;
+}
+
+.fa-stack .fa-caret-down {
+  position: absolute;
+  bottom: 0;
+}
+
+.fa-stack .fa-caret-up {
+  position: absolute;
+  top: 0;
+}
+
+.community-nav-pages-list,
+.page_group_editors-list {
+  margin-left: 20%;
+}
+
+.community-nav-section {
+  border-bottom: 1px solid #ccc; /* Adds a subtle line */
+  padding-bottom: 1rem; /* Ensures spacing between the line and the content below it */
+  margin-bottom: 1rem; /* Adds space after the border to separate from next section */
+}
+
+.drag-position-hint,
+.no-community-pages,
+.no-unpositioned-pages,
+.unpositioned-page-hint {
+  display: block;
+  margin-left: 20%;
+  margin-top: 5px;
+  font-size: smaller;
+  color: #666;
+  font-style: italic;
 }

--- a/app/assets/stylesheets/active_admin.scss
+++ b/app/assets/stylesheets/active_admin.scss
@@ -354,8 +354,9 @@
 
 .handle {
   cursor: grab;
-  display: inline-flex;
+  display: flex;
   align-items: center;
+  margin-right: 20%;
 }
 
 .handle:active {
@@ -366,14 +367,10 @@
   text-align: center;
 }
 
-.fa-stack .fa-caret-down {
-  position: absolute;
-  bottom: 0;
-}
-
-.fa-stack .fa-caret-up {
-  position: absolute;
-  top: 0;
+.fa-stack .fa-caret-left,
+.fa-stack .fa-caret-rigt {
+  position: static;
+  margin-left: 3px;
 }
 
 .community-nav-pages-list,
@@ -382,9 +379,9 @@
 }
 
 .community-nav-section {
-  border-bottom: 1px solid #ccc; /* Adds a subtle line */
-  padding-bottom: 1rem; /* Ensures spacing between the line and the content below it */
-  margin-bottom: 1rem; /* Adds space after the border to separate from next section */
+  border-bottom: 1px solid #ccc;
+  padding-bottom: 1rem;
+  margin-bottom: 1rem;
 }
 
 .drag-position-hint,
@@ -394,7 +391,22 @@
   display: block;
   margin-left: 20%;
   margin-top: 5px;
-  font-size: smaller;
+  font-size: 0.95em;
   color: #666;
   font-style: italic;
+}
+
+#current_pages {
+  display: flex;
+  gap: 1%;
+  margin-left: 20%;
+}
+
+#current_pages li {
+  flex: 0 0 auto; /* Prevents the flex items from growing or shrinking */
+}
+
+#current_pages .handle span {
+  white-space: nowrap;
+  display: inline-block;
 }

--- a/app/assets/stylesheets/active_admin.scss
+++ b/app/assets/stylesheets/active_admin.scss
@@ -354,59 +354,19 @@
 
 .handle {
   cursor: grab;
-  display: flex;
-  align-items: center;
-  margin-right: 20%;
 }
 
 .handle:active {
   cursor: grabbing;
 }
 
-.fa-stack {
-  text-align: center;
-}
-
-.fa-stack .fa-caret-left,
-.fa-stack .fa-caret-rigt {
-  position: static;
-  margin-left: 3px;
-}
-
-.community-nav-pages-list,
-.page_group_editors-list {
-  margin-left: 20%;
-}
-
-.community-nav-section {
-  border-bottom: 1px solid #ccc;
-  padding-bottom: 1rem;
-  margin-bottom: 1rem;
-}
-
+.current-editors,
+.no-editors-assigned,
+.current-pages,
 .drag-position-hint,
 .no-community-pages,
 .no-unpositioned-pages,
+.unpositioned-pages,
 .unpositioned-page-hint {
-  display: block;
   margin-left: 20%;
-  margin-top: 5px;
-  font-size: 0.95em;
-  color: #666;
-  font-style: italic;
-}
-
-#current_pages {
-  display: flex;
-  gap: 1%;
-  margin-left: 20%;
-}
-
-#current_pages li {
-  flex: 0 0 auto; /* Prevents the flex items from growing or shrinking */
-}
-
-#current_pages .handle span {
-  white-space: nowrap;
-  display: inline-block;
 }

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -1,6 +1,4 @@
 class AdminController < ApplicationController
-  skip_before_action :set_communities_for_header
-
   def create_user
     # Check if user already exists
     if User.find_by_email(user_params['email'])

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -3,7 +3,7 @@ class Page < ApplicationRecord
   belongs_to :page_group, inverse_of: :pages
   acts_as_list scope: :page_group
 
-  attr_accessor :delete_image_and_alt_text
+  attr_accessor :delete_image_and_alt_text, :included_in_community_subnav
 
   has_many :page_components, -> { order(position: :asc) }, dependent: :destroy, autosave: true
   has_attached_file :image, styles: { thumb: '768x432>' }
@@ -44,6 +44,18 @@ class Page < ApplicationRecord
       "has_chrome_warning_banner", "image_alt_text", "image_file_name", "image_content_type",
       "image_file_size", "is_public"
     ]
+  end
+
+  def included_in_community_subnav
+    self.position.present?
+  end
+
+  def add_or_remove_from_community_subnav
+    if position.present?
+      self.remove_from_list
+    else
+      self.set_list_position(-1)
+    end
   end
 
   private

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -1,6 +1,7 @@
 class Page < ApplicationRecord
   has_paper_trail
-  belongs_to :page_group
+  belongs_to :page_group, inverse_of: :pages
+  acts_as_list scope: :page_group
 
   attr_accessor :delete_image_and_alt_text
 

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -3,7 +3,7 @@ class Page < ApplicationRecord
   belongs_to :page_group, inverse_of: :pages
   acts_as_list scope: :page_group
 
-  attr_accessor :delete_image_and_alt_text, :included_in_community_subnav
+  attr_accessor :delete_image_and_alt_text, :is_community_page
 
   has_many :page_components, -> { order(position: :asc) }, dependent: :destroy, autosave: true
   has_attached_file :image, styles: { thumb: '768x432>' }
@@ -30,6 +30,8 @@ class Page < ApplicationRecord
 
   enum template_type: { default: 0, narrow: 1 }
 
+  scope :community_pages, -> { where.not(position: nil) }
+
   def image_s3_presigned_url(style = nil)
     object_presigned_url(image, style)
   end
@@ -46,7 +48,7 @@ class Page < ApplicationRecord
     ]
   end
 
-  def included_in_community_subnav
+  def is_community_page
     self.position.present?
   end
 

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -30,7 +30,7 @@ class Page < ApplicationRecord
 
   enum template_type: { default: 0, narrow: 1 }
 
-  scope :community_pages, -> { where.not(position: nil) }
+  scope :subnav_pages, -> { where.not(position: nil) }
 
   def image_s3_presigned_url(style = nil)
     object_presigned_url(image, style)

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -3,7 +3,7 @@ class Page < ApplicationRecord
   belongs_to :page_group, inverse_of: :pages
   acts_as_list scope: :page_group
 
-  attr_accessor :delete_image_and_alt_text, :is_community_page
+  attr_accessor :delete_image_and_alt_text, :is_subnav_page
 
   has_many :page_components, -> { order(position: :asc) }, dependent: :destroy, autosave: true
   has_attached_file :image, styles: { thumb: '768x432>' }
@@ -48,7 +48,7 @@ class Page < ApplicationRecord
     ]
   end
 
-  def is_community_page
+  def is_subnav_page
     self.position.present?
   end
 

--- a/app/models/page_group.rb
+++ b/app/models/page_group.rb
@@ -41,21 +41,14 @@ class PageGroup < ApplicationRecord
   def subnav_hash
     return nil if self.pages.empty?
     if self.landing_page&.published? # Use all pages when community homepage has not been published
-      subpages = self.pages.filter { |page| page.published? }.pluck("slug")
+      subpages = self.pages.community_pages.filter { |page| page.published? }
     else # Only show published subnav pages when homepage has been published
-      subpages = self.pages.pluck("slug")
+      subpages = self.pages.community_pages
     end
-    # TODO: replace hash with PageBuilder UI supplied info
-    approved_subpages =  { # Use hardcoded titles for nav because of mismatch with actual page names
-      "Community": "home",
-      "About": "about",
-      "Innovations": "innovations",
-      "Events and News": "events-and-news",
-      "Getting Started": "getting-started",
-      "Publications": "publications"
-    }
-
-    approved_subpages.filter {|k,v| subpages.include?(v)}
+    subpages.each_with_object({}) do |page, h|
+      link_text = page.short_name.present? ? page.short_name : page.title
+      h[link_text] = page.slug
+    end
   end
 
   def self.ransackable_attributes(auth_object = nil)

--- a/app/models/page_group.rb
+++ b/app/models/page_group.rb
@@ -7,7 +7,7 @@ class PageGroup < ApplicationRecord
   extend FriendlyId
   friendly_id :name, use: :slugged
 
-  has_many :pages, dependent: :destroy
+  has_many :pages, -> { order(position: :asc) }, dependent: :destroy, inverse_of: :page_group
   has_many :editor_roles, -> { where(name: 'page_group_editor', resource_type: 'PageGroup') },
             class_name: 'Role', foreign_key: :resource_id, inverse_of: :page_group
   has_many :editors, through: :editor_roles, source: :users

--- a/app/models/page_group.rb
+++ b/app/models/page_group.rb
@@ -41,9 +41,9 @@ class PageGroup < ApplicationRecord
   def subnav_hash
     return nil if self.pages.empty?
     if self.landing_page&.published? # Use all pages when community homepage has not been published
-      subpages = self.pages.community_pages.filter { |page| page.published? }
+      subpages = self.pages.subnav_pages.filter { |page| page.published? }
     else # Only show published subnav pages when homepage has been published
-      subpages = self.pages.community_pages
+      subpages = self.pages.subnav_pages
     end
     subpages.each_with_object({}) do |page, h|
       link_text = page.short_name.present? ? page.short_name : page.title

--- a/app/views/shared/_breadcrumbs.html.erb
+++ b/app/views/shared/_breadcrumbs.html.erb
@@ -20,7 +20,7 @@
   alt_text = session[:page_image_alt_text]
 %>
 
-<% if @page_group&.is_community? && @page.is_community_page # only shown on mobile width %>
+<% if @page_group&.is_community? && @page.is_subnav_page # only shown on mobile width %>
   <%= render partial: "page/community_subnav", locals: { community_slug: @page_group_slug, subnav_hash: @page_group.subnav_hash } %>
   <section class="<%= 'dm-gradient-banner' if heading.present? %><%= ' gradient-banner-with-image' if page_image.present? %> <%= classes if classes.present? %>">
     <div class="grid-container padding-y-4 desktop:padding-y-8">

--- a/app/views/shared/_breadcrumbs.html.erb
+++ b/app/views/shared/_breadcrumbs.html.erb
@@ -20,7 +20,7 @@
   alt_text = session[:page_image_alt_text]
 %>
 
-<% if @page_group&.is_community? # only shown on mobile width %>
+<% if @page_group&.is_community? && @page.is_community_page # only shown on mobile width %>
   <%= render partial: "page/community_subnav", locals: { community_slug: @page_group_slug, subnav_hash: @page_group.subnav_hash } %>
   <section class="<%= 'dm-gradient-banner' if heading.present? %><%= ' gradient-banner-with-image' if page_image.present? %> <%= classes if classes.present? %>">
     <div class="grid-container padding-y-4 desktop:padding-y-8">

--- a/db/migrate/20240516224142_add_position_to_pages.rb
+++ b/db/migrate/20240516224142_add_position_to_pages.rb
@@ -1,0 +1,5 @@
+class AddPositionToPages < ActiveRecord::Migration[6.1]
+  def change
+    add_column :pages, :position, :integer
+  end
+end

--- a/db/migrate/20240528183046_add_short_name_to_pages.rb
+++ b/db/migrate/20240528183046_add_short_name_to_pages.rb
@@ -1,0 +1,5 @@
+class AddShortNameToPages < ActiveRecord::Migration[6.1]
+  def change
+    add_column :pages, :short_name, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_05_16_224142) do
+ActiveRecord::Schema.define(version: 2024_05_28_183046) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -799,6 +799,7 @@ ActiveRecord::Schema.define(version: 2024_05_16_224142) do
     t.datetime "image_updated_at"
     t.boolean "is_public", default: false
     t.integer "position"
+    t.string "short_name"
     t.index ["page_group_id"], name: "index_pages_on_page_group_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_05_22_201114) do
+ActiveRecord::Schema.define(version: 2024_05_16_224142) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -798,6 +798,7 @@ ActiveRecord::Schema.define(version: 2024_05_22_201114) do
     t.bigint "image_file_size"
     t.datetime "image_updated_at"
     t.boolean "is_public", default: false
+    t.integer "position"
     t.index ["page_group_id"], name: "index_pages_on_page_group_id"
   end
 

--- a/spec/features/admin/admin_page_group_spec.rb
+++ b/spec/features/admin/admin_page_group_spec.rb
@@ -98,7 +98,7 @@ RSpec.describe 'PageGroup Management', type: :feature do
         existing_editor.add_role(:page_group_editor, page_group)
         visit edit_admin_page_group_path(page_group)
 
-        within("ul#current-editors") do
+        within("ul#current-editors-list") do
           find("li", text: editor.email).find("input[type='checkbox']").set(true)
         end
 
@@ -119,7 +119,7 @@ RSpec.describe 'PageGroup Management', type: :feature do
         existing_editor.add_role(:page_group_editor, page_group)
         visit edit_admin_page_group_path(page_group)
 
-        within("ul#current-editors") do
+        within("ul#current-editors-list") do
           all("li").each do |li|
             li.find("input[type='checkbox']").set(true)
           end

--- a/spec/features/admin/admin_page_group_spec.rb
+++ b/spec/features/admin/admin_page_group_spec.rb
@@ -98,7 +98,7 @@ RSpec.describe 'PageGroup Management', type: :feature do
         existing_editor.add_role(:page_group_editor, page_group)
         visit edit_admin_page_group_path(page_group)
 
-        within("ul#current_editors") do
+        within("ul#current-editors") do
           find("li", text: editor.email).find("input[type='checkbox']").set(true)
         end
 
@@ -119,7 +119,7 @@ RSpec.describe 'PageGroup Management', type: :feature do
         existing_editor.add_role(:page_group_editor, page_group)
         visit edit_admin_page_group_path(page_group)
 
-        within("ul#current_editors") do
+        within("ul#current-editors") do
           all("li").each do |li|
             li.find("input[type='checkbox']").set(true)
           end

--- a/spec/features/admin/admin_page_spec.rb
+++ b/spec/features/admin/admin_page_spec.rb
@@ -51,12 +51,12 @@ describe 'Page Builder', type: :feature do
     it 'allows admin to update short_name and community page status' do
       visit edit_admin_page_path(@page)
       fill_in 'Page Nickname', with: 'Quick Ref'
-      find('input[name="page[is_community_page]"]').set(true)
+      find('input[name="page[is_subnav_page]"]').set(true)
       all('input[type="submit"]').last.click
       expect(page).to have_content('Page was successfully updated.')
       updated_page = Page.find(@page.id)
       expect(updated_page.short_name).to eq('Quick Ref')
-      expect(updated_page.is_community_page).to be true
+      expect(updated_page.is_subnav_page).to be true
     end
   end
 

--- a/spec/features/admin/admin_page_spec.rb
+++ b/spec/features/admin/admin_page_spec.rb
@@ -50,7 +50,7 @@ describe 'Page Builder', type: :feature do
 
     it 'allows admin to update short_name and community page status' do
       visit edit_admin_page_path(@page)
-      fill_in 'Short name', with: 'Quick Ref'
+      fill_in 'Page Nickname', with: 'Quick Ref'
       find('input[name="page[is_community_page]"]').set(true)
       all('input[type="submit"]').last.click
       expect(page).to have_content('Page was successfully updated.')

--- a/spec/features/admin/admin_page_spec.rb
+++ b/spec/features/admin/admin_page_spec.rb
@@ -47,6 +47,17 @@ describe 'Page Builder', type: :feature do
       expect(page).to have_content("Image alt text can't be blank if Page image is present")
       expect(@page.image.present?).to eq(false)
     end
+
+    it 'allows admin to update short_name and community page status' do
+      visit edit_admin_page_path(@page)
+      fill_in 'Short name', with: 'Quick Ref'
+      find('input[name="page[is_community_page]"]').set(true)
+      all('input[type="submit"]').last.click
+      expect(page).to have_content('Page was successfully updated.')
+      updated_page = Page.find(@page.id)
+      expect(updated_page.short_name).to eq('Quick Ref')
+      expect(updated_page.is_community_page).to be true
+    end
   end
 
   describe 'creating the page' do

--- a/spec/features/editor/editor_page_group_spec.rb
+++ b/spec/features/editor/editor_page_group_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe 'PageGroup Management', type: :feature, js: true do
         new_editor.add_role(:page_group_editor, page_group)
         visit edit_editor_page_group_path(page_group)
 
-        within("ul#current-editors") do
+        within("ul#current-editors-list") do
           find("li", text: new_editor.email).find("input[type='checkbox']").set(true)
         end
 

--- a/spec/features/editor/editor_page_group_spec.rb
+++ b/spec/features/editor/editor_page_group_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe 'PageGroup Management', type: :feature, js: true do
-  describe 'Editing a PageGroup' do
+  describe "Editing a PageGroup's 'Editors'" do
     let!(:page_group) { create(:page_group) }
     let!(:editor) { create(:user, email: "editor_email1@va.gov") }
     let!(:new_editor) { create(:user, email: "editor_email2@va.gov") }
@@ -63,6 +63,57 @@ RSpec.describe 'PageGroup Management', type: :feature, js: true do
 
         expect(page).to have_content('User not found with email(s): nonexistent@va.gov')
         expect(page_group.reload.editors).not_to include(nonexistent_email)
+      end
+    end
+  end
+
+  describe "Editing a PageGroup's Pages" do
+    let!(:page_group) { create(:page_group, name: PageGroup::COMMUNITIES.first) }
+    let!(:editor) { create(:user, email: "editor_email1@va.gov") }
+    let!(:page_a) { create(:page, slug: "home", title: "Home Page", page_group: page_group) }
+    let!(:page_b) { create(:page, slug: "about", title: "About Page", page_group: page_group) }
+    let!(:page_c) { create(:page, slug: "innovations", title: "Innovations Page", page_group: page_group) }
+
+    before do
+      editor.add_role(:page_group_editor, page_group)
+      login_as(editor, scope: :user, run_callbacks: false)
+    end
+
+    it "displays the page_group's pages in the un-ordered section of 'Pages' section" do
+      page_group.pages.each {|page| page.update!(position: nil)}
+      visit edit_editor_page_group_path(page_group)
+
+      within("ul.unpositioned-pages") do
+        expect(page).to have_content(page_a.title)
+        expect(page).to have_content(page_b.title)
+        expect(page).to have_content(page_c.title)
+      end
+    end
+
+    it "displays the page_group's pages in the ordered section of 'Pages' section" do
+      visit edit_editor_page_group_path(page_group)
+
+      within("ul#current-pages") do
+        expect(page).to have_content(page_a.title)
+        expect(page).to have_content(page_b.title)
+        expect(page).to have_content(page_c.title)
+      end
+    end
+
+    it "displays the page_group's pages by short_name in the ordered section of 'Pages' section" do
+      page_a.update!(short_name: "Community")
+      page_b.update!(short_name: "About")
+      page_c.update!(short_name: "Innovations")
+      visit edit_editor_page_group_path(page_group)
+
+      within("ul#current-pages") do
+        expect(page).to_not have_content(page_a.title)
+        expect(page).to_not have_content(page_b.title)
+        expect(page).to_not have_content(page_c.title)
+
+        expect(page).to have_content(page_a.short_name)
+        expect(page).to have_content(page_b.short_name)
+        expect(page).to have_content(page_c.short_name)
       end
     end
   end

--- a/spec/features/editor/editor_page_group_spec.rb
+++ b/spec/features/editor/editor_page_group_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe 'PageGroup Management', type: :feature, js: true do
         new_editor.add_role(:page_group_editor, page_group)
         visit edit_editor_page_group_path(page_group)
 
-        within("ul#current_editors") do
+        within("ul#current-editors") do
           find("li", text: new_editor.email).find("input[type='checkbox']").set(true)
         end
 

--- a/spec/features/editor/editor_page_spec.rb
+++ b/spec/features/editor/editor_page_spec.rb
@@ -119,6 +119,17 @@ describe 'Page Management', type: :feature, js: true do
       expect(page).to_not have_content('Image Alt Text'.upcase)
       expect(Page.last.image_alt_text.present?).to eq(false)
     end
+
+    it 'allows admin to update short_name and community page status' do
+      visit edit_editor_page_path(pb_page_a)
+      fill_in 'Short name', with: 'Quick Ref'
+      find('input[name="page[is_community_page]"]').set(true)
+      all('input[type="submit"]').last.click
+      expect(page).to have_content('Page was successfully updated.')
+      updated_page = Page.find(pb_page_a.id)
+      expect(updated_page.short_name).to eq('Quick Ref')
+      expect(updated_page.is_community_page).to be true
+    end
   end
 
   describe 'Page groups' do

--- a/spec/features/editor/editor_page_spec.rb
+++ b/spec/features/editor/editor_page_spec.rb
@@ -122,7 +122,7 @@ describe 'Page Management', type: :feature, js: true do
 
     it 'allows editor to update short_name and community page status' do
       visit edit_editor_page_path(pb_page_a)
-      fill_in 'Short name', with: 'Quick Ref'
+      fill_in 'Page Nickname', with: 'Quick Ref'
       find('input[name="page[is_community_page]"]').set(true)
       all('input[type="submit"]').last.click
       expect(page).to have_content('Page was successfully updated.')

--- a/spec/features/editor/editor_page_spec.rb
+++ b/spec/features/editor/editor_page_spec.rb
@@ -120,7 +120,7 @@ describe 'Page Management', type: :feature, js: true do
       expect(Page.last.image_alt_text.present?).to eq(false)
     end
 
-    it 'allows admin to update short_name and community page status' do
+    it 'allows editor to update short_name and community page status' do
       visit edit_editor_page_path(pb_page_a)
       fill_in 'Short name', with: 'Quick Ref'
       find('input[name="page[is_community_page]"]').set(true)

--- a/spec/features/editor/editor_page_spec.rb
+++ b/spec/features/editor/editor_page_spec.rb
@@ -123,12 +123,12 @@ describe 'Page Management', type: :feature, js: true do
     it 'allows editor to update short_name and community page status' do
       visit edit_editor_page_path(pb_page_a)
       fill_in 'Page Nickname', with: 'Quick Ref'
-      find('input[name="page[is_community_page]"]').set(true)
+      find('input[name="page[is_subnav_page]"]').set(true)
       all('input[type="submit"]').last.click
       expect(page).to have_content('Page was successfully updated.')
       updated_page = Page.find(pb_page_a.id)
       expect(updated_page.short_name).to eq('Quick Ref')
-      expect(updated_page.is_community_page).to be true
+      expect(updated_page.is_subnav_page).to be true
     end
   end
 

--- a/spec/features/pages/community_spec.rb
+++ b/spec/features/pages/community_spec.rb
@@ -1,22 +1,20 @@
 require 'rails_helper'
 
 describe 'Communities', type: :feature, js:true do
-	before do
-		@approved_community = create(:community)
-		@non_community_pagegroup = PageGroup.create(name: "Competitions", slug: 'competitions', description: "not a community")
-		@community_landing_page = Page.create(page_group: @approved_community, title: 'Community homepage', description: 'cool stuff', slug: 'home', created_at: Time.now, is_public: true, published: Time.now)
-		@non_community_landing_page = Page.create(page_group: @non_community_pagegroup, title: 'Competitions open call', description: 'not a community', slug: 'home', created_at: Time.now, is_public: true, published: Time.now)
-		@community_subpage = Page.create(page_group: @approved_community, title: 'Community about page', description: 'about us', slug: 'about', created_at: Time.now, is_public: true, published: Time.now)
-	end
+	let!(:approved_community) { create(:community) }
+	let!(:non_community_pagegroup) { create(:page_group, name: "Competitions", slug: 'competitions', description: "not a community") }
+	let!(:community_landing_page) { create(:page, page_group: approved_community, title: 'Community homepage', description: 'cool stuff', slug: 'home', created_at: Time.now, is_public: true, published: Time.now) }
+	let!(:non_community_landing_page) { create(:page, page_group: non_community_pagegroup, title: 'Competitions open call', description: 'not a community', slug: 'home', created_at: Time.now, is_public: true, published: Time.now) }
+	let!(:community_subpage) { create(:page, page_group: approved_community, title: 'Community about page', description: 'about us', slug: 'about', created_at: Time.now, is_public: true, published: Time.now, short_name: 'About') }
 
 	describe 'subnav' do
-		it 'does not render for generic pagegroups' do
-			visit page_show_path(@non_community_pagegroup.slug, @non_community_landing_page.slug)
+		it 'does not render for a page that is not a community page' do
+			visit page_show_path(non_community_pagegroup.slug, non_community_landing_page.slug)
 			expect(page).not_to have_css('#community-subnav')
 		end
 
 		context 'published homepage' do
-			it 'is rendered for approved communities' do
+			it 'is rendered for pages that are community pages' do
 				visit('/communities/va-immersive')
 				expect(page).to have_css('#community-subnav')
 				within('#community-subnav') do
@@ -26,7 +24,7 @@ describe 'Communities', type: :feature, js:true do
 			end
 
 			it 'only shows pages that exist and have been published' do
-				another_subpage = Page.create(page_group: @approved_community, title: 'Community Events and News page', description: 'events and news', slug: 'events-and-news', created_at: Time.now, is_public: true, published: Time.now)
+				another_subpage = Page.create(page_group: approved_community, title: 'Community Events and News page', description: 'events and news', slug: 'events-and-news', created_at: Time.now, is_public: true, published: Time.now)
 				visit('/communities/va-immersive/about')
 				within('#community-subnav') do
 					expect(page).to have_content('About')
@@ -40,8 +38,8 @@ describe 'Communities', type: :feature, js:true do
 
 		context 'unpublished homepage' do
 			it 'renders all approved subpages regardless of publication status' do
-				@community_landing_page.update(published: nil)
-				unpublished_subpage = Page.create(page_group: @approved_community, title: 'Publications', description: 'approved subpage', slug: 'publications', created_at: Time.now, is_public: true, published: nil)
+				community_landing_page.update(published: nil)
+				unpublished_subpage = Page.create(page_group: approved_community, title: 'Publications', description: 'approved subpage', slug: 'publications', created_at: Time.now, is_public: true, published: nil)
 				visit('/communities/va-immersive/about')
 				within('#community-subnav') do
 					expect(page).to have_link('About', class: 'current-page')

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -71,15 +71,15 @@ RSpec.describe Page, type: :model do
     end
   end
 
-  describe '#is_community_page' do
+  describe '#is_subnav_page' do
     it 'returns true if the page has a position' do
       page = build(:page, position: 1)
-      expect(page.is_community_page).to be true
+      expect(page.is_subnav_page).to be true
     end
 
     it 'returns false if the page does not have a position' do
       page = build(:page, position: nil)
-      expect(page.is_community_page).to be false
+      expect(page.is_subnav_page).to be false
     end
   end
 

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -59,14 +59,14 @@ RSpec.describe Page, type: :model do
   end
 
   describe 'scopes' do
-    describe '.community_pages' do
+    describe '.subnav_pages' do
       it 'includes pages with non-nil positions' do
         included_page = create(:page, position: 1)
         excluded_page = create(:page)
         excluded_page.update!(position: nil)
 
-        expect(Page.community_pages).to include(included_page)
-        expect(Page.community_pages).not_to include(excluded_page)
+        expect(Page.subnav_pages).to include(included_page)
+        expect(Page.subnav_pages).not_to include(excluded_page)
       end
     end
   end

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -57,4 +57,46 @@ RSpec.describe Page, type: :model do
       end
     end
   end
+
+  describe 'scopes' do
+    describe '.community_pages' do
+      it 'includes pages with non-nil positions' do
+        included_page = create(:page, position: 1)
+        excluded_page = create(:page)
+        excluded_page.update!(position: nil)
+
+        expect(Page.community_pages).to include(included_page)
+        expect(Page.community_pages).not_to include(excluded_page)
+      end
+    end
+  end
+
+  describe '#is_community_page' do
+    it 'returns true if the page has a position' do
+      page = build(:page, position: 1)
+      expect(page.is_community_page).to be true
+    end
+
+    it 'returns false if the page does not have a position' do
+      page = build(:page, position: nil)
+      expect(page.is_community_page).to be false
+    end
+  end
+
+  describe '#add_or_remove_from_community_subnav' do
+    context 'when the page is already in the community sub-nav' do
+      it 'removes the page from the community sub-nav if it has a position' do
+        page = create(:page, position: 1)
+        expect { page.add_or_remove_from_community_subnav }.to change { page.position }.from(1).to(nil)
+      end
+    end
+
+    context 'when the page is not in the community sub-nav' do
+      it 'adds the page to the community sub-nav by setting position to -1' do
+        page = create(:page)
+        page.update!(position: nil)
+        expect { page.add_or_remove_from_community_subnav }.to change { page.position }.from(nil).to(1)
+      end
+    end
+  end
 end


### PR DESCRIPTION
### JIRA issue link
https://agile6.atlassian.net/browse/DM-4562

## Description - what does this code do?
Adds feature allowing management of community pages subnav links

The original goal (see jira ticket) was to remove the hard-coded community page subnav logic and replace it with dynamic logic that would allow for admins and page editors to add and remove links as well as control the text that appears for each page's link.

This ended up being a bit complicated as one of the things needed to be taken into consideration is the ordering of the links. We already had the `acts_as_list` gem as well as the `sortable` jquery library so I implemented a solution that allows for drag-and-drop reordering of the links from the `admin/page_group/edit` view. This solution required a new column, `position`,  to be added to the `pages` table. The column value is an integer, and in order to allow for a `page`'s removal from the community subnav it is allowed to be `nil`. Managing a `page`'s inclusion in the community subnav is controlled through a checkbox (see screenshots) found in the `page`'s `edit` view.

Another column, `short_name`, was added to the `pages` table which provides the link text used in the community subnavs. If left blank the text used defaults to the `page`'s `title`, and the management for this value is controlled through a text field labeled "SHORT NAME" found in the `page`'s `edit` view

## Testing done - how did you test it/steps on how can another person can test it 
1. As admin add 4-5 `page`s to a `page_group` named as one of the `PageGroup::COMMUNITIES`, make sure there is one page with "home" as the "URL SUFFIX" (`slug`), for each `page` leave the "Page Nickname" field empty and the "Should we include this page in the Suicide Prevention sub-navigation?" checkbox un-checked
2. Go to the edit view for the `page_group` and verify the "Pages" section appears at the bottom, verify the `page`s attributed as relations appear in the "PAGES NOT IN THE COMMUNITY SUB-NAVIGATION" section with each `page`'s `title` is a link to the given page's edit view.
3. For 3 of the `page`s, visit their edit views and check the "Should we include this page in the Suicide Prevention sub-navigation?" checkbox.
4. Back on the `page_group`'s edit screen verify those 3 `page`s' `title`s now appear in the "COMMUNITY SUB-NAVIGATION ORDER" section with lateral carets next to each. Verify that you can change the ordering of the `page`s in this section by dragging and dropping, and that the ordering changes persist when saving the form.
5. Back on the edit screen for a few of the `page`s that have been included in the ordering section, fill in the "Page Nickname" fields, verify that this now appears in place of the given `page`'s `title` in the ordering section of the `page_group`'s edit screen.
6. For one of the `page`s that have been included as a "Community page" uncheck the "Should we include this page in the Suicide Prevention sub-navigation?" checkbox in the `page`'s edit screen, verify that that `page` no longer appears in the "COMMUNITY SUB-NAVIGATION ORDER" section of the `page_group`'s edit screen but its `title` is now in the "PAGES NOT IN THE COMMUNITY SUB-NAVIGATION" as a link to its edit screen.
7. Create another `page_group` but name it something other than the `PageGroup::COMMUNITIES` names, attribute a few new `page`s to it.
8. Verify that the "Pages" section for the new `page_group` does not appear in the new `page_group`'s edit view.
9. I did a bit of refactoring of the "Editors" section of the `page_group` edit form so please verify that that functionality works as expected.
10. Verify that all fields work as expected for new `page_group`s and `page`s
11. Repeat all steps from the editor portal :face_exhaling:


## Screenshots, Gifs, Videos from application (if applicable)
<img width="1291" alt="Screenshot 2024-06-10 at 11 04 15 AM" src="https://github.com/department-of-veterans-affairs/diffusion-marketplace/assets/65036872/bd25a3f2-4daa-4125-85f9-93808265eafb">
<img width="1026" alt="Screenshot 2024-06-10 at 11 03 55 AM" src="https://github.com/department-of-veterans-affairs/diffusion-marketplace/assets/65036872/bb7d3814-3296-4045-8aec-e402ec5fed1b">

## Link to mock-ups/mock ups (image file if you have it) (if applicable)


## Acceptance criteria
- [ ]

## Definition of done
- [x] Unit tests written (if applicable)
- [x] e2e/accessibility tests written (if applicable)
- [x] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating JIRA issue
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs