### PR TITLE
DM-4710: Add a recommended image size to PageBuilder banner image upload

### DIFF
--- a/app/admin/pages.rb
+++ b/app/admin/pages.rb
@@ -195,7 +195,7 @@ ActiveAdmin.register Page do
               value: f.resource.image_file_name,
               type: 'file',
               label: 'Image',
-              hint: 'File types allowed: jpg, jpeg, and png. Max file size: 25MB',
+              hint: 'File types allowed: jpg, jpeg, and png. Recommended dimensions: 390 x 300 pixels or larger. Max file size: 25MB',
               input_html: { accept: '.jpg, .jpeg, .png' }
       # Page image preview
       image = f.resource.image


### PR DESCRIPTION
### JIRA issue link
[DM-4710](https://agile6.atlassian.net/browse/DM-4710)

## Description - what does this code do?
- Adds a suggested (but not required) image size to the PageBuilder banner image upload

## Screenshots, Gifs, Videos from application (if applicable)
<img width="553" alt="Screenshot 2024-06-04 at 5 27 51 PM" src="https://github.com/department-of-veterans-affairs/diffusion-marketplace/assets/5402927/f3be3795-5027-442a-b291-7706725963aa">

