### PR TITLE
dm-4865 Remove “Creation Date” from the Innovation Cards

### DIFF
--- a/app/views/practices/_search.js.erb
+++ b/app/views/practices/_search.js.erb
@@ -117,7 +117,7 @@ function buildPracticeCard(result) {
                     '<p class="multiline-ellipses-1 font-sans-sm practice-card-tagline">' + result.item.tagline + '</p>' +
                     '<div class="dm-practice-card-origin margin-bottom-2">' +
                         '<span class="font-sans-2xs text-italic line-height-sans-3 dm-practice-card-origin-info">' +
-                            'Created in ' + result.item.date_initiated + ' ' + result.item.initiating_facility_name +
+                            'Created ' + result.item.initiating_facility_name +
                         '</span>' +
                     '</div>' +
                 '</div>' +

--- a/app/views/shared/_practice_card.html.erb
+++ b/app/views/shared/_practice_card.html.erb
@@ -52,7 +52,7 @@
       </div>
       <div class="dm-practice-card-origin margin-bottom-2">
         <span class="font-sans-2xs text-italic line-height-sans-3 dm-practice-card-origin-info">
-          Created in <%= practice.date_initiated.present? ? date_format(practice.date_initiated) : '(start date unknown)' %><%= practice.initiating_facility_type.present? ? " #{origin_display(practice)}" : '' %>
+          Created<%= practice.initiating_facility_type.present? ? " #{origin_display(practice)}" : '' %>
         </span>
       </div>
     </div>


### PR DESCRIPTION
### JIRA issue link

## Description - what does this code do?
https://agile6.atlassian.net/browse/DM-4865

## Testing done - how did you test it/steps on how can another person can test it 
check the Innovation (practice) cards found on the search page and page-builder pages (with Innovations component present and populated) and verify the bottom appears as seen in the second screenshot below

## Screenshots, Gifs, Videos from application (if applicable)

before:
![Screenshot 2024-06-05 at 4 09 26 PM](https://github.com/department-of-veterans-affairs/diffusion-marketplace/assets/65036872/2740264a-a462-44ab-aa28-99f8865152a0)

after:
![Screenshot 2024-06-05 at 4 08 45 PM](https://github.com/department-of-veterans-affairs/diffusion-marketplace/assets/65036872/4417cdc4-9ae3-41ae-80ec-5026378484a7)

## Link to mock-ups/mock ups (image file if you have it) (if applicable)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Unit tests written (if applicable)
- [ ] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating JIRA issue
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs