### PR TITLE
DM-4864: Remove innovation partners from search filters view

### DIFF
--- a/app/assets/stylesheets/dm/pages/_search.scss
+++ b/app/assets/stylesheets/dm/pages/_search.scss
@@ -165,7 +165,7 @@
   padding: 0 !important;
 }
 
-.category-container, .originating-facility-container, .adopting-facility-container, .practice-partner-container {
+.category-container, .originating-facility-container, .adopting-facility-container {
   background-color: color($theme-color-secondary-light);
 
   @media screen and (min-width: 1024px) {
@@ -173,7 +173,7 @@
   }
 }
 
-.category-container, .practice-partner-container {
+.category-container, {
   .desktop\:grid-col-4 {
     @include u-padding-right('05');
   }

--- a/app/controllers/practices_controller.rb
+++ b/app/controllers/practices_controller.rb
@@ -211,7 +211,6 @@ class PracticesController < ApplicationController # rubocop:disable Metrics/Clas
     end
     @parent_categories = Category.get_cached_categories_grouped_by_parent
     @categories = Category.cached_categories.get_category_names
-    @practice_partners = PracticePartner.cached_practice_partners.major_partners
   end
 
   # POST /practices/1/favorite.js

--- a/app/views/practices/_search.js.erb
+++ b/app/views/practices/_search.js.erb
@@ -194,12 +194,6 @@ function toggleMobileAdoptingAccordion() {
     });
 }
 
-function toggleMobilePracticePartnersAccordion() {
-    $(document).on('click', '.mobile-practice-partner-accordion', function() {
-        toggleAccordion(this, '.practice-partner-container');
-    });
-}
-
 function closeMobileFiltersModal() {
     $(document).on('click', '#close_filters_modal', function () {
         $('.search-filters-accordion-button').attr('aria-expanded', 'false')
@@ -1084,7 +1078,6 @@ function searchPracticesPage() {
         closeAccordion('.mobile-origin-accordion', '.originating-facility-container');
         closeAccordion('.mobile-adopting-accordion', '.adopting-facility-container');
         closeAccordion('.mobile-category-accordion', '.category-container');
-        closeAccordion('.mobile-practice-partner-accordion', '.practice-partner-container');
 
         // Bring the user back to their original spot on the page, before they opened the mobile modal
         if ($(window).width() < 1024) {
@@ -1295,7 +1288,6 @@ function execSearchFunctions() {
     addAllCheckBoxListener('.all-clinical-checkbox', '.clinical-checkbox');
     addAllCheckBoxListener('.all-operational-checkbox', '.operational-checkbox');
     addAllCheckBoxListener('.all-strategic-checkbox', '.strategic-checkbox');
-    toggleMobilePracticePartnersAccordion();
 }
 
 document.addEventListener('turbolinks:load', function () {

--- a/app/views/practices/_search.js.erb
+++ b/app/views/practices/_search.js.erb
@@ -1100,7 +1100,7 @@ function searchPracticesPage() {
         var adoptingFacility = getComboBoxVal(adoptingFacilityInput, adoptingFacilityLi);
 
         // Get the values for any chosen categories
-        var selectedCategoryCheckboxes = $('#update-search-results-form [type="checkbox"]:checked:not(".all-clinical-checkbox"):not(".all-operational-checkbox"):not(".all-strategic-checkbox"):not(".practice-partner-search-checkbox")');
+        var selectedCategoryCheckboxes = $('#update-search-results-form [type="checkbox"]:checked:not(".all-clinical-checkbox"):not(".all-operational-checkbox"):not(".all-strategic-checkbox")');
         var chosenCategories = selectedCategoryCheckboxes.map(function () {
             return this.value;
         }).get();
@@ -1115,20 +1115,11 @@ function searchPracticesPage() {
             data: jQuery.param({query: searchField.value, chosenCategories: chosenCategories})
         });
 
-        // Get the values for any chosen practice partners
-        var selectedPracticePartnerCheckboxes = $('#update-search-results-form [type="checkbox"]:checked:not(".all-clinical-checkbox"):not(".all-operational-checkbox"):not(".all-strategic-checkbox"):not(".clinical-checkbox"):not(".operational-checkbox"):not(".strategic-checkbox")');
-        var chosenPracticePartners = selectedPracticePartnerCheckboxes.map(function () {
-            return this.value;
-        }).get();
-        if (!chosenPracticePartners.length) {
-            chosenPracticePartners = null;
-        }
-
         // Run the search
-        search(searchField.value, chosenCategories, originatingFacility, adoptingFacility, chosenPracticePartners);
+        search(searchField.value, chosenCategories, originatingFacility, adoptingFacility);
 
         // Display the amount of filters used(if any)
-        var checkboxCount = selectedCategoryCheckboxes.length + selectedPracticePartnerCheckboxes.length;
+        var checkboxCount = selectedCategoryCheckboxes.length;
         var noOriginatingFacilityText = originatingFacilityInput.val() === '';
         var originatingFacilityTextPresent = originatingFacilityInput.val() !== '';
         var noAdoptingFacilityText = adoptingFacilityInput.val() === '';

--- a/app/views/practices/search_partials/_search_filters.html.erb
+++ b/app/views/practices/search_partials/_search_filters.html.erb
@@ -76,61 +76,6 @@
       </div>
     </div>
   </fieldset>
-
-  <fieldset class="padding-0">
-    <legend class="usa-sr-only">Innovation Partner Filters</legend>
-    <div class="bg-gray-5 desktop:padding-bottom-2px search-practice-partner-filters">
-      <h2 class="usa-accordion__heading">
-        <button class="usa-accordion__button mobile-practice-partner-accordion desktop:display-none"
-                aria-expanded="false"
-                type="button">
-          Innovation Partners
-        </button>
-      </h2>
-
-      <div class="grid-row practice-partner-container display-none padding-top-2 desktop:padding-bottom-1 desktop:padding-top-0 desktop:display-flex desktop:padding-x-2">
-        <p class="text-bold line-height-26 margin-y-2 grid-col-12 display-none desktop:display-block margin-top-2">
-          Innovation Partners
-        </p>
-        <%
-          sliced_partners = split_data_into_three_columns(@practice_partners)
-        %>
-        <% if sliced_partners.present? %>
-          <div class="grid-row grid-col-12 practice-partner-container display-none padding-top-2 desktop:padding-bottom-1 desktop:padding-top-0 desktop:display-flex padding-left-0 padding-right-0">
-            <% sliced_partners.each_with_index do |sp, i| %>
-              <% if i != 3 %>
-                <% if sp.kind_of?(Array) %>
-                  <div class="grid-col-12 desktop:grid-col-4">
-                    <% sp.each do |partner| %>
-                      <%= render partial: 'shared/checkbox', locals: {
-                        data_id: "practice_partner_ids_#{partner.id}",
-                        data_name: 'practice_partners',
-                        data_value: partner.name,
-                        data_label_text: partner.name,
-                        data_input_class: ' practice-partner-search-checkbox',
-                        data_label_class: ' practice-partner-search-checkbox-label'
-                      } %>
-                    <% end %>
-                  </div>
-                <% else %>
-                  <div class="grid-col-12 desktop:grid-col-4">
-                    <%= render partial: 'shared/checkbox', locals: {
-                      data_id: "practice_partner_ids_#{sp.id}",
-                      data_name: 'practice_partners',
-                      data_value: sp.name,
-                      data_label_text: sp.name,
-                      data_input_class: ' practice-partner-search-checkbox',
-                      data_label_class: ' practice-partner-search-checkbox-label'
-                    } %>
-                  </div>
-                <% end %>
-              <% end %>
-            <% end %>
-          </div>
-        <% end %>
-      </div>
-    </div>
-  </fieldset>
 </div>
 
 <div class="padding-y-2 padding-x-3 border-top-2px border-base-lightest bg-white desktop:border-top-0 desktop:padding-2" id="filter_button_container">

--- a/spec/features/admin/admin_practice_partners_spec.rb
+++ b/spec/features/admin/admin_practice_partners_spec.rb
@@ -4,7 +4,7 @@ describe 'Admin Practice Partners Tab', type: :feature do
   before do
     @admin = User.create!(email: 'sandy.cheeks@va.gov', password: 'Password123', password_confirmation: 'Password123', skip_va_validation: true, confirmed_at: Time.now, accepted_terms: true)
     @admin.add_role(:admin)
-    @practice = Practice.create!(name: 'The Best Practice Ever!', initiating_facility_type: 'facility', tagline: 'Test tagline', date_initiated: 'Sun, 05 Feb 1992 00:00:00 UTC +00:00', summary: 'This is the best practice ever.', overview_problem: 'overview-problem', published: true, approved: true, user: @admin)
+    @practice = Practice.create!(name: 'The Best Practice Ever!' , initiating_facility_type: 'facility', tagline: 'Test tagline', date_initiated: 'Sun, 05 Feb 1992 00:00:00 UTC +00:00', summary: 'This is the best practice ever.', overview_problem: 'overview-problem', published: true, approved: true, user: @admin)
     @practice_partner = PracticePartner.create!(name: 'Practice Partner 1', is_major: true)
     @practice_partner2 = PracticePartner.create!(name: 'Practice Partner 2')
     login_as(@admin, scope: :user, run_callbacks: false)
@@ -56,7 +56,6 @@ describe 'Admin Practice Partners Tab', type: :feature do
       click_button('Update Practice partner')
       expect(cache_keys).not_to include('practice_partners')
       add_practice_partners_to_cache
-      find('.search-filters-accordion-button').click
       expect(page).to have_content('Updated Practice Partner 1')
     end
 
@@ -69,15 +68,15 @@ describe 'Admin Practice Partners Tab', type: :feature do
       click_button('Create Practice partner')
       expect(cache_keys).not_to include('practice_partners')
       add_practice_partners_to_cache
-      find('.search-filters-accordion-button').click
+      visit '/partners/new-practice-partner'
       expect(page).to have_content('New Practice Partner')
     end
 
     it 'Should be reset if a new practice is added to an existing practice partner' do
       # make sure the practice is present without the partner
       add_practice_partners_to_cache
-      expect(page).to have_content('1 result')
-      expect(page).to have_content(@practice.name)
+      expect(page).not_to have_content(@practice.name)
+      visit '/search'
       expect(cache_keys).to include('searchable_practices_json')
       visit '/admin/practice_partners'
       click_link('Edit', href: edit_admin_practice_partner_path(@practice_partner))
@@ -87,10 +86,6 @@ describe 'Admin Practice Partners Tab', type: :feature do
       expect(cache_keys).not_to include('searchable_practices_json')
       # make sure the cache has been reset and that the practice is now associated with the practice partner
       add_practice_partners_to_cache
-      find('.search-filters-accordion-button').click
-      all('.practice-partner-search-checkbox-label')[0].click
-      find('#dm-practice-search-button').click
-      expect(page).to have_content('1 result')
       expect(page).to have_content(@practice.name)
     end
 
@@ -98,11 +93,8 @@ describe 'Admin Practice Partners Tab', type: :feature do
       # make sure the practice is present with the partner
       PracticePartnerPractice.create!(practice_partner: @practice_partner, practice: @practice)
       add_practice_partners_to_cache
-      find('.search-filters-accordion-button').click
-      all('.practice-partner-search-checkbox-label')[0].click
-      find('#dm-practice-search-button').click
-      expect(page).to have_content('1 result')
       expect(page).to have_content(@practice.name)
+      visit '/search'
       expect(cache_keys).to include('searchable_practices_json')
       visit '/admin/practice_partners'
       click_link('Edit', href: edit_admin_practice_partner_path(@practice_partner))
@@ -113,16 +105,12 @@ describe 'Admin Practice Partners Tab', type: :feature do
       expect(cache_keys).not_to include('searchable_practices_json')
       # make sure the cache has been reset and that the practice is no longer associated with the practice partner
       add_practice_partners_to_cache
-      find('.search-filters-accordion-button').click
-      all('.practice-partner-search-checkbox-label')[0].click
-      find('#dm-practice-search-button').click
-      expect(page).to_not have_content('1 result')
       expect(page).to_not have_content(@practice.name)
     end
   end
 
   def add_practice_partners_to_cache
-    visit '/search'
+    visit practice_partner_path(@practice_partner) # TODO: swap this out for /innovations/:id/edit/introduction later
     expect(cache_keys).to include('practice_partners')
   end
 

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -372,10 +372,9 @@ describe 'Search', type: :feature do
         set_combobox_val(0, 'Norwood VA Clinic')
         select_category('.cat-2-label')
         select_category('.cat-5-label')
-        select_practice_partner(0)
         update_results
 
-        expect(page).to have_content('Filters (4)')
+        expect(page).to have_content('Filters (3)')
         expect(page).to have_content('6 results')
         expect(page).to have_content(@practice.name)
         expect(page).to have_content(@practice3.name)
@@ -448,10 +447,9 @@ describe 'Search', type: :feature do
         # Now add the remaining to eliminate one of the last two practices
         toggle_filters_accordion
         set_combobox_val(1, 'Aberdeen VA Clinic')
-        select_practice_partner(0)
         update_results
 
-        expect(page).to have_content('Filters (4)')
+        expect(page).to have_content('Filters (3)')
         expect(page).to have_content('1 result')
         expect(page).to have_content(@practice3.name)
         expect(page).to_not have_content(@practice5.name)
@@ -487,26 +485,6 @@ describe 'Search', type: :feature do
         expect(page).to have_content('Filters (1)')
         expect(page).to have_content('1 result')
         expect(page).to have_content(@practice6.name)
-
-        # Reset filters and select a practice partner from the major practice partner checkboxes
-        toggle_filters_accordion
-        click_button('Reset filters')
-        select_practice_partner(0)
-        update_results
-
-        expect(page).to have_content('Filters (1)')
-        expect(page).to have_content('2 results')
-        expect(page).to have_content(@practice.name)
-        expect(page).to have_content(@practice3.name)
-
-        # select another practice partner to further filter down the results
-        toggle_filters_accordion
-        select_practice_partner(1)
-        update_results
-
-        expect(page).to have_content('Filters (2)')
-        expect(page).to have_content('1 result')
-        expect(page).to have_content(@practice.name)
 
         # search for practices with the search bar and clinical resource hub filters
         add_crh_adoptions_and_practice_origin_facilities

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -269,7 +269,6 @@ describe 'Search', type: :feature do
       find('#dm-practice-search-button').click
 
       expect(page).to have_content(@practice.name)
-      expect(page).to have_content(@practice.initiating_facility)
       expect(page).to have_content('1 result')
     end
 
@@ -287,7 +286,6 @@ describe 'Search', type: :feature do
       expect(page).to have_content(@practice5.name)
       expect(page).to have_content(@practice6.name)
       expect(page).to have_content(@practice12.name)
-      expect(page).to have_content(@practice.initiating_facility)
     end
 
     it 'should be able to search based on practice maturity level' do

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -333,17 +333,6 @@ describe 'Search', type: :feature do
       expect(page).to have_content(@practice5.name)
     end
 
-    it 'should be able to search based on practice partners' do
-      visit_search_page
-      fill_in('dm-practice-search-field', with: 'practice partner')
-      find('#dm-practice-search-button').click
-      expect(page).to have_content('4 results')
-      expect(page).to have_content(@practice.name)
-      expect(page).to have_content(@practice3.name)
-      expect(page).to have_content(@practice4.name)
-      expect(page).to have_content(@practice5.name)
-    end
-
     it 'should only display search results for practices that are public-facing if the user is a guest' do
       # Try to search for an internal, VA-only practice as a guest user
       logout
@@ -534,22 +523,6 @@ describe 'Search', type: :feature do
         expect(page).to have_content('Filters (2)')
         expect(page).to have_content('1 result')
         expect(page).to have_content(@practice14.name)
-      end
-
-      it 'should only display checkboxes for major practice partners in the search filters' do
-        visit_search_page
-        toggle_filters_accordion
-        expect(page).to have_css('.practice-partner-search-checkbox', visible: false, count: 3)
-      end
-
-      it 'should allow users to filter practices based on their practice partners' do
-        visit_search_page
-        toggle_filters_accordion
-        select_practice_partner(0)
-        search
-        expect(page).to have_content('2 results:')
-        expect(page).to have_content(@practice.name)
-        expect(page).to have_content(@practice3.name)
       end
 
       describe 'Originating Facility Combo Box' do

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -104,16 +104,6 @@ describe 'Search', type: :feature do
     DiffusionHistoryStatus.create!(diffusion_history_id: dh_6.id, status: 'Completed')
     dh_7 = DiffusionHistory.create!(practice_id: @practice10.id, va_facility: facility_5)
     DiffusionHistoryStatus.create!(diffusion_history_id: dh_7.id, status: 'Completed')
-    partner_1 = PracticePartner.create!(name: 'Practice Partner 1', is_major: true)
-    PracticePartnerPractice.create!(practice: @practice, practice_partner: partner_1)
-    PracticePartnerPractice.create!(practice: @practice3, practice_partner: partner_1)
-    partner_2 = PracticePartner.create!(name: 'Practice Partner 2', is_major: true)
-    PracticePartnerPractice.create!(practice: @practice, practice_partner: partner_2)
-    PracticePartnerPractice.create!(practice: @practice4, practice_partner: partner_2)
-    partner_3 = PracticePartner.create!(name: 'Practice Partner 3', is_major: true)
-    PracticePartnerPractice.create!(practice: @practice3, practice_partner: partner_3)
-    partner_4 = PracticePartner.create!(name: 'Practice Partner 4')
-    PracticePartnerPractice.create!(practice: @practice5, practice_partner: partner_4)
     user_login
   end
 
@@ -167,10 +157,6 @@ describe 'Search', type: :feature do
 
   def select_category(label_class)
     find(label_class).click
-  end
-
-  def select_practice_partner(index)
-    all('.practice-partner-search-checkbox-label')[index].click
   end
 
   def add_crh_adoptions_and_practice_origin_facilities


### PR DESCRIPTION
### JIRA issue link
[DM-4864](https://agile6.atlassian.net/browse/DM-4864)

## Description - what does this code do?
- Removes Innovation Partners from the search filter UI

## Testing done - how did you test it/steps on how can another person can test it 
1. Go to `/search` 
2. Confirm that `Innovation Partners` are no longer available as a filter option
3. Select multiple filters and update results. 
4. Confirm that the number of filters is reflected in the Accordion title e.g. `Filters (3)`
