### PR TITLE
DM-4864: Remove partners from main search algorithm

### DIFF
--- a/app/views/practices/_search.js.erb
+++ b/app/views/practices/_search.js.erb
@@ -274,10 +274,10 @@ function searchPracticesPage() {
     var searchLocation = window.location.search.split('=');
 
     // Search practices and populate the page
-    function search(query, categories, originatingFacility, adoptingFacility, practicePartners) {
+    function search(query, categories, originatingFacility, adoptingFacility) {
         // Trim whitespace from the query (can cause matching problems)
         query = query.trim();
-        isBlankSearch = !Boolean(query) && categories == undefined && originatingFacility == undefined && adoptingFacility == undefined && practicePartners == undefined ? true : false;
+        isBlankSearch = !Boolean(query) && categories == undefined && originatingFacility == undefined && adoptingFacility == undefined ? true : false;
         // Set variables
         var resultsSummary = document.querySelector('#results-summary');
         // set the search page search bar input value
@@ -379,13 +379,6 @@ function searchPracticesPage() {
             }
         }
 
-        if (practicePartners) {
-            // Collect any practice that has a practice partner that matches the selected partner(s).
-            var practicePartnerFilters = [];
-            practicePartners.forEach(function (partnerSelection) {
-                return practicePartnerFilters.push({'practice_partner_names': "=\"" + partnerSelection + "\""});
-            });
-        }
         /*
         IMPORTANT: Per Research and Design, if the user's search contains a string from the search bar, utilize the $and operator so that the result(s) must match all conditions.
         On the other hand, if the user's search only contains filters, utilize the $or operator so that the results can match ANY of the conditions.
@@ -453,28 +446,6 @@ function searchPracticesPage() {
             });
         }
 
-        /*
-        Make a result a closer match if it has more than one matching practice partner, as Fuse.js uses short-circuit evaluation. This means most of the time,
-        the results will have the same score because it stops after the first match.
-        */
-        function improveResultScoreBasedOnAmountOfPracticePartnerMatches(results) {
-            results.map(function(result) {
-                var resultScore = result.score;
-                var practice_partner_names = result.item.practice_partner_names;
-                if (practice_partner_names && Array.isArray(practice_partner_names)) {
-                    practice_partner_names.forEach(function (ppn) {
-                        if (practicePartners.includes(ppn)) {
-                            resultScore = result.score / 2;
-                        }
-                        result.score = resultScore;
-                    });
-                } else if (practice_partner_names && !Array.isArray(practice_partner_names)) {
-                    resultScore = result.score / 2;
-                    result.score = resultScore;
-                }
-            });
-        }
-
         function searchWithQueryAndAllFilters() {
             results = fuse.search({
                 $and: [
@@ -493,51 +464,6 @@ function searchPracticesPage() {
                         $and: [
                             {$or: adoptionFacilityArray}
                         ]
-                    },
-                    {
-                        $and: practicePartnerFilters
-                    }
-                ]
-            });
-        }
-
-        function searchWithQueryAndCategoriesAndOriginFacilityAndPracticePartners() {
-            results = fuse.search({
-                $and: [
-                    {
-                        $or: searchBarQueryArray
-                    },
-                    {
-                        $and: categoryFilters
-                    },
-                    {
-                        $and: [
-                            {$or: originFacilityArray}
-                        ]
-                    },
-                    {
-                        $and: practicePartnerFilters
-                    }
-                ]
-            });
-        }
-
-        function searchWithQueryAndCategoriesAndAdoptingFacilityAndPracticePartners() {
-            results = fuse.search({
-                $and: [
-                    {
-                        $or: searchBarQueryArray
-                    },
-                    {
-                        $and: categoryFilters
-                    },
-                    {
-                        $and: [
-                            {$or: adoptionFacilityArray}
-                        ]
-                    },
-                    {
-                        $and: practicePartnerFilters
                     }
                 ]
             });
@@ -561,45 +487,6 @@ function searchPracticesPage() {
                         $and: [
                             {$or: adoptionFacilityArray}
                         ]
-                    }
-                ]
-            });
-        }
-
-        function searchWithQueryAndPracticePartnersAndBothFacilities() {
-            results = fuse.search({
-                $and: [
-                    {
-                        $or: searchBarQueryArray
-                    },
-                    {
-                        $and: practicePartnerFilters
-                    },
-                    {
-                        $and: [
-                            {$or: originFacilityArray}
-                        ]
-                    },
-                    {
-                        $and: [
-                            {$or: adoptionFacilityArray}
-                        ]
-                    }
-                ]
-            });
-        }
-
-        function searchWithQueryAndCategoriesAndPracticePartners() {
-            results = fuse.search({
-                $and: [
-                    {
-                        $or: searchBarQueryArray
-                    },
-                    {
-                        $and: categoryFilters
-                    },
-                    {
-                        $and: practicePartnerFilters
                     }
                 ]
             });
@@ -631,42 +518,6 @@ function searchPracticesPage() {
                     },
                     {
                         $and: categoryFilters
-                    },
-                    {
-                        $and: [
-                            {$or: adoptionFacilityArray}
-                        ]
-                    }
-                ]
-            });
-        }
-
-        function searchWithQueryAndPracticePartnersAndOriginatingFacility() {
-            results = fuse.search({
-                $and: [
-                    {
-                        $or: searchBarQueryArray
-                    },
-                    {
-                        $and: practicePartnerFilters
-                    },
-                    {
-                        $and: [
-                            {$or: originFacilityArray}
-                        ]
-                    }
-                ]
-            });
-        }
-
-        function searchWithQueryAndPracticePartnersAndAdoptingFacility() {
-            results = fuse.search({
-                $and: [
-                    {
-                        $or: searchBarQueryArray
-                    },
-                    {
-                        $and: practicePartnerFilters
                     },
                     {
                         $and: [
@@ -740,19 +591,6 @@ function searchPracticesPage() {
             });
         }
 
-        function searchWithQueryAndPracticePartners() {
-            results = fuse.search({
-                $and: [
-                    {
-                        $or: searchBarQueryArray
-                    },
-                    {
-                        $and: practicePartnerFilters
-                    }
-                ]
-            });
-        }
-
         function searchWithNoQueryAndNoFilters() {
             var maturityLevels = ['emerging', 'replicate', 'scale'];
             var filterTerm = decodeURI(searchLocation[1]);
@@ -777,37 +615,15 @@ function searchPracticesPage() {
         }
 
         function searchWithAllFilters() {
-            results = fuse.search({$or: categoryFilters.concat(originFacilityArray, adoptionFacilityArray, practicePartnerFilters)});
-            improveResultScoreBasedOnAmountOfCategoryMatches(results);
-            improveResultScoreBasedOnOriginatingFacility(results);
-            improveResultScoreBasedOnAmountOfAdoptingFacilities(results);
-            improveResultScoreBasedOnAmountOfPracticePartnerMatches(results);
-        }
-
-        function searchWithCategoriesAndOriginatingFacilityAndPracticePartners() {
-            results = fuse.search({$or: categoryFilters.concat(originFacilityArray, practicePartnerFilters)});
-            improveResultScoreBasedOnAmountOfCategoryMatches(results);
-            improveResultScoreBasedOnOriginatingFacility(results);
-            improveResultScoreBasedOnAmountOfPracticePartnerMatches(results);
-        }
-
-        function searchWithCategoriesAndAdoptingFacilityAndPracticePartners() {
-            results = fuse.search({$or: categoryFilters.concat(adoptionFacilityArray, practicePartnerFilters)});
-            improveResultScoreBasedOnAmountOfCategoryMatches(results);
-            improveResultScoreBasedOnAmountOfAdoptingFacilities(results);
-            improveResultScoreBasedOnAmountOfPracticePartnerMatches(results);
-        }
-
-        function searchWithCategoriesAndBothFacilities() {
             results = fuse.search({$or: categoryFilters.concat(originFacilityArray, adoptionFacilityArray)});
             improveResultScoreBasedOnAmountOfCategoryMatches(results);
             improveResultScoreBasedOnOriginatingFacility(results);
             improveResultScoreBasedOnAmountOfAdoptingFacilities(results);
         }
 
-        function searchWithPracticePartnersAndBothFacilities() {
-            results = fuse.search({$or: practicePartnerFilters.concat(originFacilityArray, adoptionFacilityArray)});
-            improveResultScoreBasedOnAmountOfPracticePartnerMatches(results);
+        function searchWithCategoriesAndBothFacilities() {
+            results = fuse.search({$or: categoryFilters.concat(originFacilityArray, adoptionFacilityArray)});
+            improveResultScoreBasedOnAmountOfCategoryMatches(results);
             improveResultScoreBasedOnOriginatingFacility(results);
             improveResultScoreBasedOnAmountOfAdoptingFacilities(results);
         }
@@ -821,24 +637,6 @@ function searchPracticesPage() {
         function searchWithCategoriesAndAdoptingFacility() {
             results = fuse.search({$or: categoryFilters.concat(adoptionFacilityArray)});
             improveResultScoreBasedOnAmountOfCategoryMatches(results);
-            improveResultScoreBasedOnAmountOfAdoptingFacilities(results);
-        }
-
-        function searchWithCategoriesAndPracticePartners() {
-            results = fuse.search({$or: categoryFilters.concat(practicePartnerFilters)});
-            improveResultScoreBasedOnAmountOfCategoryMatches(results);
-            improveResultScoreBasedOnAmountOfPracticePartnerMatches(results);
-        }
-
-        function searchWithPracticePartnersAndOriginatingFacility() {
-            results = fuse.search({$or: practicePartnerFilters.concat(originFacilityArray)});
-            improveResultScoreBasedOnAmountOfPracticePartnerMatches(results);
-            improveResultScoreBasedOnOriginatingFacility(results);
-        }
-
-        function searchWithPracticePartnersAndAdoptingFacility() {
-            results = fuse.search({$or: practicePartnerFilters.concat(adoptionFacilityArray)});
-            improveResultScoreBasedOnAmountOfPracticePartnerMatches(results);
             improveResultScoreBasedOnAmountOfAdoptingFacilities(results);
         }
 
@@ -863,11 +661,6 @@ function searchPracticesPage() {
             improveResultScoreBasedOnAmountOfAdoptingFacilities(results);
         }
 
-        function searchWithOnlyPracticePartners() {
-            results = fuse.search({$or: practicePartnerFilters});
-            improveResultScoreBasedOnAmountOfPracticePartnerMatches(results);
-        }
-
         function searchByFilterTerm(searchKey, filterTerm) {
             var searchFilter = {};
             searchFilter[searchKey] = "=\"" + filterTerm + "\"";
@@ -875,74 +668,44 @@ function searchPracticesPage() {
         }
 
         // Run the search query and include filters(if any)
-        if (!query && !categories && !originatingFacility && !adoptingFacility && !practicePartners) {
+        if (!query && !categories && !originatingFacility && !adoptingFacility) {
             searchWithNoQueryAndNoFilters();
-        } else if (query && categories && originatingFacility && adoptingFacility && practicePartners) {
+        } else if (query && categories && originatingFacility && adoptingFacility) {
             searchWithQueryAndAllFilters();
-        } else if (query && categories && originatingFacility && !adoptingFacility && practicePartners) {
-            searchWithQueryAndCategoriesAndOriginFacilityAndPracticePartners();
-        } else if (query && categories && !originatingFacility && adoptingFacility && practicePartners) {
-            searchWithQueryAndCategoriesAndAdoptingFacilityAndPracticePartners();
-        } else if (query && categories && originatingFacility && adoptingFacility && !practicePartners) {
+        } else if (query && categories && originatingFacility && adoptingFacility) {
             searchWithQueryAndCategoriesAndBothFacilities();
-        } else if (query && !categories && originatingFacility && adoptingFacility && practicePartners) {
-            searchWithQueryAndPracticePartnersAndBothFacilities();
-        } else if (query && categories && originatingFacility && !adoptingFacility && !practicePartners) {
+        } else if (query && categories && originatingFacility && !adoptingFacility) {
             searchWithQueryAndCategoriesAndOriginFacility();
-        } else if (query && categories && !originatingFacility && adoptingFacility && !practicePartners) {
+        } else if (query && categories && !originatingFacility && adoptingFacility) {
             searchWithQueryAndCategoriesAndAdoptingFacility();
-        } else if (query && categories && !originatingFacility && !adoptingFacility && practicePartners) {
-            searchWithQueryAndCategoriesAndPracticePartners();
-        } else if (query && !categories && originatingFacility && !adoptingFacility && practicePartners) {
-            searchWithQueryAndPracticePartnersAndOriginatingFacility();
-        } else if (query && !categories && !originatingFacility && adoptingFacility && practicePartners) {
-            searchWithQueryAndPracticePartnersAndAdoptingFacility();
-        } else if (query && !categories && originatingFacility && adoptingFacility && !practicePartners) {
+        } else if (query && !categories && originatingFacility && adoptingFacility) {
             searchWithQueryAndBothFacilities();
-        } else if (query && categories && !originatingFacility && !adoptingFacility && !practicePartners) {
+        } else if (query && categories && !originatingFacility && !adoptingFacility) {
             searchWithQueryAndCategories();
-        } else if (query && !categories && originatingFacility && !adoptingFacility && !practicePartners) {
+        } else if (query && !categories && originatingFacility && !adoptingFacility) {
             searchWithQueryAndOriginFacility();
-        } else if (query && !categories && !originatingFacility && adoptingFacility && !practicePartners) {
+        } else if (query && !categories && !originatingFacility && adoptingFacility) {
             searchWithQueryAndAdoptingFacility();
-        } else if (query && !categories && !originatingFacility && !adoptingFacility && practicePartners) {
-            searchWithQueryAndPracticePartners();
-        } else if (!query && categories && originatingFacility && adoptingFacility && practicePartners) {
-            searchWithAllFilters();
-        } else if (!query && categories && originatingFacility && !adoptingFacility && practicePartners) {
-            searchWithCategoriesAndOriginatingFacilityAndPracticePartners();
-        } else if (!query && categories && !originatingFacility && adoptingFacility && practicePartners) {
-            searchWithCategoriesAndAdoptingFacilityAndPracticePartners();
-        } else if (!query && categories && originatingFacility && adoptingFacility && !practicePartners) {
+        } else if (!query && categories && originatingFacility && adoptingFacility) {
             searchWithCategoriesAndBothFacilities();
-        } else if (!query && !categories && originatingFacility && adoptingFacility && practicePartners) {
-            searchWithPracticePartnersAndBothFacilities();
-        } else if (!query && categories && originatingFacility && !adoptingFacility && !practicePartners) {
+        } else if (!query && categories && originatingFacility && !adoptingFacility) {
             searchWithCategoriesAndOriginatingFacility();
-        } else if (!query && categories && !originatingFacility && adoptingFacility && !practicePartners) {
+        } else if (!query && categories && !originatingFacility && adoptingFacility) {
             searchWithCategoriesAndAdoptingFacility();
-        } else if (!query && categories && !originatingFacility && !adoptingFacility && practicePartners) {
-            searchWithCategoriesAndPracticePartners();
-        } else if (!query && !categories && originatingFacility && !adoptingFacility && practicePartners) {
-            searchWithPracticePartnersAndOriginatingFacility();
-        } else if (!query && !categories && !originatingFacility && adoptingFacility && practicePartners) {
-            searchWithPracticePartnersAndAdoptingFacility();
-        } else if (!query && !categories && originatingFacility && adoptingFacility && !practicePartners) {
+        } else if (!query && !categories && originatingFacility && adoptingFacility) {
             searchWithBothFacilities();
-        } else if (!query && categories && !originatingFacility && !adoptingFacility && !practicePartners ) {
+        } else if (!query && categories && !originatingFacility && !adoptingFacility ) {
             searchWIthOnlyCategories();
-        } else if (!query && !categories && originatingFacility && !adoptingFacility && !practicePartners) {
+        } else if (!query && !categories && originatingFacility && !adoptingFacility) {
             searchWithOnlyOriginatingFacility();
-        } else if (!query && !categories && !originatingFacility && adoptingFacility && !practicePartners) {
+        } else if (!query && !categories && !originatingFacility && adoptingFacility) {
             searchWithOnlyAdoptingFacility();
-        } else if (!query && !categories && !originatingFacility && !adoptingFacility && practicePartners) {
-            searchWithOnlyPracticePartners();
-        } else if (query && !categories && !originatingFacility && !adoptingFacility && !practicePartners) {
+        } else if (query && !categories && !originatingFacility && !adoptingFacility) {
             results = fuse.search(query);
         }
 
         // Get the results and then filter them
-        if (!query && !categories && !originatingFacility && !adoptingFacility && !practicePartners) {
+        if (!query && !categories && !originatingFacility && !adoptingFacility) {
             // on an empty search or filtered search, sort by most adoptions and disable the score sorting option, since the score for each result is the same
             buildSearchResults(results, sortByAdoptionCounts);
             $(SORT_EL).children().first().attr('disabled', 'true');
@@ -971,7 +734,7 @@ function searchPracticesPage() {
     // Adapted from: https://github.com/brunocechet/Fuse.js-with-highlight
     function highlighter(resultItem) {
         resultItem.matches.forEach(function (matchItem) {
-            // don't highlight if match was on category, adoption facilities, or practice partners since they are not in practice search result text and can't be highlighted
+            // don't highlight if match was on category, or adoption facilities, since they are not in practice search result text and can't be highlighted
             // don't highlight origin_facilities or initiating_facility because they are ids. The initiating_facility_name key will cover any text
             if (matchItem.key != 'category_names' &&
                 matchItem.key != 'adoption_facilities' &&


### PR DESCRIPTION
### JIRA issue link
DM-4864, rebase after #905 is merged

## Description - what does this code do?
- Follow up to #905, where we removed `Innovation Partners` from the search interface
- This PR removes code from our main search logic that included Partners

## Testing done - how did you test it/steps on how can another person can test it 
I recommend testing this in DEV, where more complete filter data is available.

1. On `master`, run several searches and note their result numbers: 
- search w/ category
- search w/ adoption facility
- search w/ originating facility 

2. Deploy this branch to DEV
3. Run the same searches and compare search result numbers