### PR TITLE
DM-4578: Adjust styling for sitewide footer 'Return to top' button

### DIFF
--- a/app/assets/stylesheets/dm/pages/_partials/_footer.scss
+++ b/app/assets/stylesheets/dm/pages/_partials/_footer.scss
@@ -1,4 +1,5 @@
 footer {
+  background-color: color('blue-warm-80v');
   .dm-footer-heading {
     color: color($theme-color-base-lighter);
   }
@@ -12,11 +13,6 @@ footer {
         color: color($theme-color-secondary-darker);
         text-decoration: underline;
       }
-  }
-
-  .usa-footer__return-to-top {
-    @include u-padding-top(0, !important);
-    padding-bottom: 32px !important;
   }
 
   nav {

--- a/app/assets/stylesheets/dm/pages/_partials/_footer.scss
+++ b/app/assets/stylesheets/dm/pages/_partials/_footer.scss
@@ -1,5 +1,4 @@
 footer {
-  background-color: color('blue-warm-80v');
   .dm-footer-heading {
     color: color($theme-color-base-lighter);
   }

--- a/app/views/practices/shared/_practice_editor_footer.html.erb
+++ b/app/views/practices/shared/_practice_editor_footer.html.erb
@@ -27,10 +27,10 @@
   }
 %>
 
-<footer class="<%= yield(:footer_classes) %>">
+<footer class="practice-editor-footer <%= yield(:footer_classes) %>">
   <%# only show return to top on mobile views, practice show page and long practice editor pages (per design 9/21/21) %>
   <div class="grid-container usa-footer__return-to-top<%= params[:controller] === 'practices' && NavigationHelper::RETURN_TO_TOP_PAGES.include?(params[:action]) ? ' desktop:display-block' : ' tablet:display-none' %>">
-    <button class="dm-button--unstyled-primary dm-return-to-top width-auto">Back to Top</button>
+    <button class="dm-button--unstyled-primary dm-return-to-top width-auto">Return to Top</button>
   </div>
 
   <% if params[:action] === 'metrics' %>

--- a/app/views/practices/shared/_practice_editor_footer.html.erb
+++ b/app/views/practices/shared/_practice_editor_footer.html.erb
@@ -30,7 +30,7 @@
 <footer class="<%= yield(:footer_classes) %>">
   <%# only show return to top on mobile views, practice show page and long practice editor pages (per design 9/21/21) %>
   <div class="grid-container usa-footer__return-to-top<%= params[:controller] === 'practices' && NavigationHelper::RETURN_TO_TOP_PAGES.include?(params[:action]) ? ' desktop:display-block' : ' tablet:display-none' %>">
-    <button class="dm-button--unstyled-primary dm-return-to-top width-auto">Return to top</button>
+    <button class="dm-button--unstyled-primary dm-return-to-top width-auto">Back to Top</button>
   </div>
 
   <% if params[:action] === 'metrics' %>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -3,7 +3,7 @@
   <div
     class="grid-container usa-footer__return-to-top<%= params[:controller] === 'practices' && NavigationHelper::RETURN_TO_TOP_PAGES.include?(params[:action]) ? ' desktop:display-block' : ' tablet:display-none' %> margin-top-8 tablet:margin-top-0"
   >
-    <button class="dm-button--unstyled-primary dm-return-to-top width-auto">Return to top</button>
+    <button class="usa-button--big dm-button--outline-secondary dm-return-to-top width-auto">Return to top</button>
   </div>
 
   <div class="usa-footer__primary-section bg-primary-darker padding-y-4 desktop:padding-x-7">

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,4 +1,4 @@
-<footer class="usa-footer usa-footer--big <%= yield(:footer_classes) %>">
+<footer class="bg-primary-darker usa-footer usa-footer--big <%= yield(:footer_classes) %>">
   <%# only show return to top on mobile views, practice show page and long practice editor pages (per design 9/21/21) %>
   <div
     class="grid-container usa-footer__return-to-top<%= params[:controller] === 'practices' && NavigationHelper::RETURN_TO_TOP_PAGES.include?(params[:action]) ? ' desktop:display-block' : ' tablet:display-none' %> margin-top-8 tablet:margin-top-0"

--- a/spec/features/shared/footer_spec.rb
+++ b/spec/features/shared/footer_spec.rb
@@ -12,10 +12,10 @@ describe 'Diffusion Marketplace footer', type: :feature, js: true do
       visit practice_path(@practice)
     end
 
-    describe 'Return to top' do
+    describe 'Back to top' do
       it 'should exist' do
         within('footer') do
-          expect(page).to have_content('Return to top')
+          expect(page).to have_content('Back to Top')
         end
       end
     end

--- a/spec/features/shared/footer_spec.rb
+++ b/spec/features/shared/footer_spec.rb
@@ -15,7 +15,7 @@ describe 'Diffusion Marketplace footer', type: :feature, js: true do
     describe 'Back to top' do
       it 'should exist' do
         within('footer') do
-          expect(page).to have_content('Back to Top')
+          expect(page).to have_content('Return to top')
         end
       end
     end


### PR DESCRIPTION
### JIRA issue link
[DM-4578](https://agile6.atlassian.net/browse/DM-4578)

## Description - what does this code do?
- Updates styling for the `Return to top` link to make it button-ier
- Changes the public-facing button text to `Back to top`
  - Retains a separate style for the innovation editor footer to avoid confusion with `Back` button
<img width="464" alt="Screenshot 2024-06-05 at 7 59 01 PM" src="https://github.com/department-of-veterans-affairs/diffusion-marketplace/assets/5402927/d99a11a1-45cf-42b0-8ff8-0bd8be864e9a">

## Testing done - how did you test it/steps on how can another person can test it 
1. Open the homepage using dev tools Responsive mode. Set width to a mobile device. 
2. Scroll down to the footer and confirm the new styling + text change is applied 
3. Click on the `Back to top` button and confirm that it brings you to the top of the page

## Screenshots, Gifs, Videos from application (if applicable)
### Before
<img width="421" alt="Screenshot 2024-06-05 at 7 58 29 PM" src="https://github.com/department-of-veterans-affairs/diffusion-marketplace/assets/5402927/68d63eca-4ab9-42ad-9c9a-7a7aca7221ba">

### After
<img width="416" alt="Screenshot 2024-06-05 at 8 02 44 PM" src="https://github.com/department-of-veterans-affairs/diffusion-marketplace/assets/5402927/6da65a9b-7ef1-4f68-bf3c-15da9a9cbee1">

