### PR TITLE
DM-4477: update instances of "Facility" to "Healthcare facility"

### DIFF
--- a/app/assets/javascripts/diffusion_history/home_map.es6
+++ b/app/assets/javascripts/diffusion_history/home_map.es6
@@ -283,10 +283,10 @@ function initialize() {
   function attachFacilityListListener() {
     $(document).on("click", "#facilityListTrigger", () => {
       const $facilityListBtn = $("#facilityListTrigger");
-      if ($facilityListBtn.text() === "Hide list of facilities") {
-        $facilityListBtn.text("View list of facilities");
+      if ($facilityListBtn.text() === "Hide list of healthcare facilities") {
+        $facilityListBtn.text("View list of healthcare facilities");
       } else {
-        $facilityListBtn.text("Hide list of facilities");
+        $facilityListBtn.text("Hide list of healthcare facilities");
       }
       $("#facilityListContainer").toggle();
     });

--- a/app/assets/javascripts/diffusion_history/home_map.es6
+++ b/app/assets/javascripts/diffusion_history/home_map.es6
@@ -283,10 +283,12 @@ function initialize() {
   function attachFacilityListListener() {
     $(document).on("click", "#facilityListTrigger", () => {
       const $facilityListBtn = $("#facilityListTrigger");
-      if ($facilityListBtn.text() === "Hide list of healthcare facilities") {
+      if ($facilityListBtn.attr("aria-expanded") === "true") {
         $facilityListBtn.text("View list of healthcare facilities");
+        $facilityListBtn.attr("aria-expanded", "false");
       } else {
         $facilityListBtn.text("Hide list of healthcare facilities");
+        $facilityListBtn.attr("aria-expanded", "true");
       }
       $("#facilityListContainer").toggle();
     });

--- a/app/assets/javascripts/diffusion_history/home_map.es6
+++ b/app/assets/javascripts/diffusion_history/home_map.es6
@@ -120,7 +120,7 @@ function initialize() {
     const facilityCount = result.length;
     const practiceCount = _.chain(result.map(r => r.practices)).flatten().uniqBy('id').value().length;
 
-    $('#facility-results-count').text(`${facilityCount} facility match${facilityCount === 1 ? '' : 'es'}`);
+    $('#facility-results-count').text(`${facilityCount} healthcare facility match${facilityCount === 1 ? '' : 'es'}`);
     $('#practice-results-count').text(`${practiceCount} innovation${practiceCount === 1 ? '' : 's'}`);
   }
 

--- a/app/assets/stylesheets/dm/pages/_facilities.scss
+++ b/app/assets/stylesheets/dm/pages/_facilities.scss
@@ -61,7 +61,7 @@
     tr:first-of-type {
       th:first-of-type {
         button {
-          left: 4.5em;
+          left: 10em;
         }
       }
 

--- a/app/assets/stylesheets/dm/pages/_visns.scss
+++ b/app/assets/stylesheets/dm/pages/_visns.scss
@@ -153,7 +153,7 @@
 
       th:first-of-type {
         button {
-          left: 7.4em;
+          left: 12.5em;
         }
       }
 

--- a/app/helpers/navigation_helper.rb
+++ b/app/helpers/navigation_helper.rb
@@ -164,7 +164,7 @@ module NavigationHelper
 
     ### VAMC breadcrumbs
     def add_facility_index_breadcrumb
-      session[:breadcrumbs] << { 'display': 'Facility index', 'path': va_facilities_path }
+      session[:breadcrumbs] << { 'display': 'Healthcare facility index', 'path': va_facilities_path }
     end
 
     if controller == 'va_facilities'

--- a/app/views/about/index.html.erb
+++ b/app/views/about/index.html.erb
@@ -85,14 +85,14 @@
       %>
       <%= render partial: 'faq_accordion', locals: {
         item_number: '6',
-        question: 'How do I adopt an innovation at my VA facility?',
+        question: 'How do I adopt an innovation at my VA healthcare facility?',
         answer: "To adopt an innovation, click the \"Email innovation\" button on any innovation page and send the innovation owner a message about your interest in adopting
                  their innovation."
         }
       %>
       <%= render partial: 'faq_accordion', locals: {
         item_number: '7',
-        question: 'How do I adopt an innovation at a non-VA facility?',
+        question: 'How do I adopt an innovation at a non-VA healthcare facility?',
         answer: "The ability of an innovation team to collaborate with non-VA personnel varies. If you have questions, or want to learn more about an innovation, you can
                 reach out to the innovation editor by clicking the \"Email innovation\" button on any innovation page."
         }

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -8,7 +8,7 @@
     <div class="grid-container">
       <div class="grid-row flex-justify-center text-white">
           <h1 class="usa-prose-h1 text-left desktop:text-center">
-            Discover VA innovations to adopt at your facility
+            Discover VA innovations to adopt at your healthcare facility
           </h1>
         <div class="grid-col-12 desktop:grid-col-9">
             <p class="usa-prose-body margin-top-1 text-center">

--- a/app/views/maps/_home_map_filters.html.erb
+++ b/app/views/maps/_home_map_filters.html.erb
@@ -101,7 +101,7 @@
       </div>
 
       <div class="margin-bottom-2 clearfix">
-        <button type="button" class="dm-button--unstyled-primary margin-bottom-1" id="facilityListTrigger">
+        <button type="button" class="dm-button--unstyled-primary margin-bottom-1" id="facilityListTrigger" aria-expanded="false" aria-controls="facilityListContainer">
           View list of healthcare facilities
         </button>
         <div id="facilityListContainer" class="map-filters-list display-none">

--- a/app/views/maps/_home_map_filters.html.erb
+++ b/app/views/maps/_home_map_filters.html.erb
@@ -89,7 +89,7 @@
         </div>
       </div>
 
-      <label for="facility_name" class="usa-label line-height-26 text-bold">Facility name</label>
+      <label for="facility_name" class="usa-label line-height-26 text-bold">Healthcare facility name</label>
       <div class="usa-combo-box margin-top-1 margin-bottom-2" data-set-facility="false">
         <select id="facility_name" class="usa-select" name="facility_name">
           <% @va_facilities.each do |f| %>
@@ -102,7 +102,7 @@
 
       <div class="margin-bottom-2 clearfix">
         <button type="button" class="dm-button--unstyled-primary margin-bottom-1" id="facilityListTrigger">
-          View list of facilities
+          View list of healthcare facilities
         </button>
         <div id="facilityListContainer" class="map-filters-list display-none">
           <fieldset class="grid-row">
@@ -136,7 +136,7 @@
 
       <div class="margin-bottom-2">
         <h4 class="font-sans-md bold-height-2 margin-bottom-105 margin-top-0 display-inline-block">
-        Facility
+        Healthcare facility
           <a href="#facility-complexity-modal" class="facility-complexity-modal cursor-pointer dotted" aria-controls="facility-complexity-modal" data-open-modal class="cursor-pointer">
             <span class="usa-sr-only">Open facility complexity modal</span>
               complexity
@@ -146,7 +146,7 @@
         <%= render partial: 'shared/facility_complexity_modal', locals: { hide_modal_on_initial_load: false, is_map: true } %>
         <% complexity_levels = VaFacility.get_complexity %>
         <fieldset>
-          <legend class="usa-sr-only">Facility Complexity Levels</legend>
+          <legend class="usa-sr-only">Healthcare Facility Complexity Levels</legend>
           <% complexity_levels.each do |cl| %>
             <input id="<%= cl.gsub(' ', '').underscore %>" name="facility_complexities" type="checkbox" value="<%= cl %>" class="usa-checkbox__input">
             <label for="<%= cl.gsub(' ', '').underscore %>" class="usa-checkbox__label">
@@ -158,7 +158,7 @@
       </div>
 
       <div class="margin-bottom-2">
-        <h4 class="font-sans-md bold-height-2 margin-bottom-105 margin-top-0">Facility rurality</h4>
+        <h4 class="font-sans-md bold-height-2 margin-bottom-105 margin-top-0">Healthcare facility rurality</h4>
         <% ruralities = {R: "Rural", U: "Urban"} %>
         <fieldset>
           <legend class="usa-sr-only">Ruralities</legend>

--- a/app/views/maps/diffusion_map.html.erb
+++ b/app/views/maps/diffusion_map.html.erb
@@ -37,7 +37,7 @@
         <h3 class="usa-prose-h3 margin-bottom-1">Results:</h3>
         <p class="margin-bottom-1 margin-top-0">
         <span id="facility-results-count">
-          <%= @dh_markers.size %> facility match<%= @dh_markers.size != 1 ? 'es' : '' %>
+          <%= @dh_markers.size %> healthcare facility match<%= @dh_markers.size != 1 ? 'es' : '' %>
         </span>
           (of <%= @dh_markers.size %>)
         </p>

--- a/app/views/practices/form/adoptions.html.erb
+++ b/app/views/practices/form/adoptions.html.erb
@@ -17,7 +17,7 @@
       <section class="usa-section padding-top-0 padding-bottom-0">
         <h1 class="margin-top-0">Adoptions</h1>
         <div class="usa-prose-intro">
-          Share which facilities have successfully adopted your innovation. All adoptions roll up to the VAMC level. Aim to update this data quarterly.
+          Share which healthcare facilities have successfully adopted your innovation. All adoptions roll up to the VAMC level. Aim to update this data quarterly.
         </div>
         <%= render 'pii_phi_alert' %>
         <!-- start accordions -->

--- a/app/views/practices/form/adoptions_forms/_adoption_form.html.erb
+++ b/app/views/practices/form/adoptions_forms/_adoption_form.html.erb
@@ -43,7 +43,7 @@
   <% else %>
     <div class="margin-bottom-5">
     <% facility_select_selector = 'editor_facility_select' %>
-    <label for="<%= facility_select_selector %>" class="usa-label line-height-26">Facility</label>
+    <label for="<%= facility_select_selector %>" class="usa-label line-height-26">Healthcare Facility</label>
     <div class="usa-combo-box margin-top-1 margin-bottom-2">
       <select id="<%= facility_select_selector %>" class="usa-select" name="va_facility_id">
         <% @va_facilities.each do |vaf| %>

--- a/app/views/practices/form/implementation.html.erb
+++ b/app/views/practices/form/implementation.html.erb
@@ -53,7 +53,7 @@
                                      id: "core_resource_attachment_file"
                 %>
                 <%= label_tag 'core_resource_file', 'File', class: 'usa-radio__label
-                initiating-facility-type-label line-height-19px', for: "core_resource_attachment_file" %>
+                i line-height-19px', for: "core_resource_attachment_file" %>
               </div>
               <div class="usa-radio position-relative grid-col-12">
                 <%= radio_button_tag 'practice_resources[media_type]', 'Link',
@@ -62,7 +62,7 @@
                                      id: "core_resource_attachment_link"
                 %>
                 <%= label_tag 'core_resource_link', 'Link', class: 'usa-radio__label
-                initiating-facility-type-label line-height-19px margin-bottom-0', for: "core_resource_attachment_link" %>
+                line-height-19px margin-bottom-0', for: "core_resource_attachment_link" %>
               </div>
               <input type="hidden" id="hidden_publish" value="<%= @practice.published %>" />
               <div id="display_core_attachment_form" class="dm-file-form display_core_attachments_form grid-row grid-col-12 margin-bottom-5">
@@ -105,7 +105,7 @@
                                      id: "optional_resource_attachment_file"
                 %>
                 <%= label_tag 'optional_resource_file', 'File', class: 'usa-radio__label
-                initiating-facility-type-label line-height-19px', for: "optional_resource_attachment_file" %>
+                line-height-19px', for: "optional_resource_attachment_file" %>
               </div>
               <div class="usa-radio position-relative grid-col-12">
                 <%= radio_button_tag 'practice_resources[media_type]', 'Link',
@@ -114,7 +114,7 @@
                                      id: "optional_resource_attachment_link"
                 %>
                 <%= label_tag 'optional_resource_link', 'Link', class: 'usa-radio__label
-                initiating-facility-type-label line-height-19px margin-bottom-0', for: "optional_resource_attachment_link" %>
+                line-height-19px margin-bottom-0', for: "optional_resource_attachment_link" %>
               </div>
               <div id="display_optional_attachment_form" class="dm-file-form display_optional_attachments_form grid-row grid-col-12 margin-bottom-5">
                 <%= render partial: "practices/implementation_forms/attachment_file_form", locals: {area: 'optional_attachment', resource_type: 'optional'} %>
@@ -156,7 +156,7 @@
                                      id: "support_resource_attachment_file"
                 %>
                 <%= label_tag 'support_resource_file', 'File', class: 'usa-radio__label
-                initiating-facility-type-label line-height-19px', for: "support_resource_attachment_file" %>
+                line-height-19px', for: "support_resource_attachment_file" %>
               </div>
               <div class="usa-radio position-relative grid-col-12">
                 <%= radio_button_tag 'practice_resources[media_type]', 'Link',
@@ -165,7 +165,7 @@
                                      id: "support_resource_attachment_link"
                 %>
                 <%= label_tag 'support_resource_link', 'Link', class: 'usa-radio__label
-                initiating-facility-type-label line-height-19px margin-bottom-0', for: "support_resource_attachment_link" %>
+                line-height-19px margin-bottom-0', for: "support_resource_attachment_link" %>
               </div>
               <div id="display_support_attachment_form" class="dm-file-form display_support_attachments_form grid-row grid-col-12 margin-bottom-5">
                 <%= render partial: "practices/implementation_forms/attachment_file_form", locals: {area: 'support_attachment', resource_type: 'support'} %>

--- a/app/views/practices/form/implementation.html.erb
+++ b/app/views/practices/form/implementation.html.erb
@@ -20,7 +20,7 @@
     <section class="usa-section padding-top-0 padding-bottom-0 implementation">
       <h1 class="margin-bottom-3 margin-top-0">Implementation</h1>
       <h2 class="text-normal line-height-sans-6 font-sans-lg">
-        Compile requirements and considerations to help another facility successfully implement your innovation.
+        Compile requirements and considerations to help another healthcare facility successfully implement your innovation.
       </h2>
       <div class="margin-top-3">
         <%= render 'pii_phi_alert' %>

--- a/app/views/practices/form/introduction.html.erb
+++ b/app/views/practices/form/introduction.html.erb
@@ -132,18 +132,18 @@
                 Innovation origin*
               </p>
               <span>Select the location where this innovation originated</span>
-              <div class="grid-row grid-gap grid-col-1 margin-bottom-3">
-                <div class="usa-radio position-relative">
+              <div class="margin-bottom-3">
+                <div class="usa-radio">
                   <%= radio_button_tag 'practice[initiating_facility_type]',
                                        'facility',
                                        @practice.facility?,
                                        class: 'usa-radio__input initiating-facility-type-radio',
                                        id: "initiating_facility_type_facility"
                   %>
-                  <%= label_tag 'initiating_facility_type_facility', 'Facility', class: 'usa-radio__label
-                initiating-facility-type-label margin-bottom-0 margin-top-105', for: "initiating_facility_type_facility" %>
+                  <%= label_tag 'initiating_facility_type_facility', 'Heatlhcare Facility', class: 'usa-radio__label
+                initiating-facility-type-label', for: "initiating_facility_type_facility" %>
                 </div>
-                <div class="usa-radio position-relative">
+                <div class="usa-radio">
                   <%= radio_button_tag 'practice[initiating_facility_type]',
                                        'visn',
                                        @practice.visn?,
@@ -151,25 +151,25 @@
                                        id: "initiating_facility_type_visn"
                   %>
                   <%= label_tag 'initiating_facility_type_visn', 'VISN', class: 'usa-radio__label
-                initiating-facility-type-label margin-bottom-0 margin-top-105', for: "initiating_facility_type_visn" %>
+                initiating-facility-type-label', for: "initiating_facility_type_visn" %>
                 </div>
-                <div class="usa-radio position-relative">
+                <div class="usa-radio">
                   <%= radio_button_tag 'practice[initiating_facility_type]',
                                        'department', @practice.department?,
                                        class: 'usa-radio__input initiating-facility-type-radio',
                                        id: "initiating_facility_type_department"
                   %>
                   <%= label_tag 'initiating_facility_type_department', 'Office', class: 'usa-radio__label
-                initiating-facility-type-label margin-bottom-0 margin-top-105', for: "initiating_facility_type_department" %>
+                initiating-facility-type-label', for: "initiating_facility_type_department" %>
                 </div>
-                <div class="usa-radio position-relative">
+                <div class="usa-radio">
                   <%= radio_button_tag 'practice[initiating_facility_type]', 'other',
                                        @practice.other?,
                                        class: 'usa-radio__input initiating-facility-type-radio',
                                        id: "initiating_facility_type_other"
                   %>
                   <%= label_tag 'initiating_facility_type_other', 'Other', class: 'usa-radio__label
-                initiating-facility-type-label margin-bottom-0 margin-top-105', for: "initiating_facility_type_other" %>
+                initiating-facility-type-label', for: "initiating_facility_type_other" %>
                 </div>
               </div>
 

--- a/app/views/practices/form/introduction.html.erb
+++ b/app/views/practices/form/introduction.html.erb
@@ -140,8 +140,7 @@
                                        class: 'usa-radio__input initiating-facility-type-radio',
                                        id: "initiating_facility_type_facility"
                   %>
-                  <%= label_tag 'initiating_facility_type_facility', 'Heatlhcare Facility', class: 'usa-radio__label
-                initiating-facility-type-label', for: "initiating_facility_type_facility" %>
+                  <%= label_tag 'initiating_facility_type_facility', 'Heatlhcare Facility', class: 'usa-radio__label', for: "initiating_facility_type_facility" %>
                 </div>
                 <div class="usa-radio">
                   <%= radio_button_tag 'practice[initiating_facility_type]',
@@ -150,8 +149,7 @@
                                        class: 'usa-radio__input initiating-facility-type-radio',
                                        id: "initiating_facility_type_visn"
                   %>
-                  <%= label_tag 'initiating_facility_type_visn', 'VISN', class: 'usa-radio__label
-                initiating-facility-type-label', for: "initiating_facility_type_visn" %>
+                  <%= label_tag 'initiating_facility_type_visn', 'VISN', class: 'usa-radio__label', for: "initiating_facility_type_visn" %>
                 </div>
                 <div class="usa-radio">
                   <%= radio_button_tag 'practice[initiating_facility_type]',
@@ -159,8 +157,7 @@
                                        class: 'usa-radio__input initiating-facility-type-radio',
                                        id: "initiating_facility_type_department"
                   %>
-                  <%= label_tag 'initiating_facility_type_department', 'Office', class: 'usa-radio__label
-                initiating-facility-type-label', for: "initiating_facility_type_department" %>
+                  <%= label_tag 'initiating_facility_type_department', 'Office', class: 'usa-radio__label', for: "initiating_facility_type_department" %>
                 </div>
                 <div class="usa-radio">
                   <%= radio_button_tag 'practice[initiating_facility_type]', 'other',
@@ -168,8 +165,7 @@
                                        class: 'usa-radio__input initiating-facility-type-radio',
                                        id: "initiating_facility_type_other"
                   %>
-                  <%= label_tag 'initiating_facility_type_other', 'Other', class: 'usa-radio__label
-                initiating-facility-type-label', for: "initiating_facility_type_other" %>
+                  <%= label_tag 'initiating_facility_type_other', 'Other', class: 'usa-radio__label', for: "initiating_facility_type_other" %>
                 </div>
               </div>
 

--- a/app/views/practices/form/overview.html.erb
+++ b/app/views/practices/form/overview.html.erb
@@ -48,8 +48,7 @@
                                        class: 'usa-radio__input initiating-facility-type-radio',
                                        id: "practice_problem_image"
                   %>
-                  <%= label_tag 'practice_problem_image', 'Image', class: 'usa-radio__label
-                initiating-facility-type-label line-height-19px margin-bottom-0 margin-top-105', for: "practice_problem_image" %>
+                  <%= label_tag 'practice_problem_image', 'Image', class: 'usa-radio__label line-height-19px margin-bottom-0 margin-top-105', for: "practice_problem_image" %>
                 </div>
                 <div class="usa-radio position-relative grid-col-12">
                   <%= radio_button_tag 'practice_problem_resources[resource_type]',
@@ -58,8 +57,7 @@
                                        class: 'usa-radio__input initiating-facility-type-radio',
                                        id: "practice_problem_video"
                   %>
-                  <%= label_tag 'practice_problem_video', 'Video', class: 'usa-radio__label
-                initiating-facility-type-label line-height-19px margin-bottom-0 margin-top-105', for: "practice_problem_video" %>
+                  <%= label_tag 'practice_problem_video', 'Video', class: 'usa-radio__label line-height-19px margin-bottom-0 margin-top-105', for: "practice_problem_video" %>
                 </div>
                 <div class="usa-radio position-relative grid-col-12">
                   <%= radio_button_tag 'practice_problem_resources[resource_type]',
@@ -67,8 +65,7 @@
                                        class: 'usa-radio__input initiating-facility-type-radio',
                                        id: "practice_problem_file"
                   %>
-                  <%= label_tag 'practice_problem_file', 'File', class: 'usa-radio__label
-                initiating-facility-type-label line-height-19px margin-bottom-0 margin-top-105', for: "practice_problem_file" %>
+                  <%= label_tag 'practice_problem_file', 'File', class: 'usa-radio__label line-height-19px margin-bottom-0 margin-top-105', for: "practice_problem_file" %>
                 </div>
                 <div class="usa-radio position-relative grid-col-12">
                   <%= radio_button_tag 'practice_problem_resources[resource_type]', 'Link',
@@ -76,8 +73,7 @@
                                        class: 'usa-radio__input initiating-facility-type-radio',
                                        id: "practice_problem_link"
                   %>
-                  <%= label_tag 'practice_problem_link', 'Link', class: 'usa-radio__label
-                initiating-facility-type-label line-height-19px margin-bottom-0 margin-top-105', for: "practice_problem_link" %>
+                  <%= label_tag 'practice_problem_link', 'Link', class: 'usa-radio__label line-height-19px margin-bottom-0 margin-top-105', for: "practice_problem_link" %>
                 </div>
                 <div id="display_problem_resources_form" class="display_problem_form grid-col-12">
                     <%= render partial: "practices/overview_forms/image_form", locals: {area: 'problem_resources'} %>
@@ -141,8 +137,7 @@
                                        class: 'usa-radio__input initiating-facility-type-radio',
                                        id: "practice_solution_image"
                   %>
-                  <%= label_tag 'practice_solution_image', 'Image', class: 'usa-radio__label
-                initiating-facility-type-label line-height-19px margin-bottom-0 margin-top-105', for: "practice_solution_image" %>
+                  <%= label_tag 'practice_solution_image', 'Image', class: 'usa-radio__label line-height-19px margin-bottom-0 margin-top-105', for: "practice_solution_image" %>
                 </div>
                 <div class="usa-radio position-relative grid-col-12">
                   <%= radio_button_tag 'practice_solution_resources[resource_type]',
@@ -151,8 +146,7 @@
                                        class: 'usa-radio__input initiating-facility-type-radio',
                                        id: "practice_solution_video"
                   %>
-                  <%= label_tag 'practice_solution_video', 'Video', class: 'usa-radio__label
-                initiating-facility-type-label line-height-19px margin-bottom-0 margin-top-105', for: "practice_solution_video" %>
+                  <%= label_tag 'practice_solution_video', 'Video', class: 'usa-radio__label line-height-19px margin-bottom-0 margin-top-105', for: "practice_solution_video" %>
                 </div>
                 <div class="usa-radio position-relative grid-col-12">
                   <%= radio_button_tag 'practice_solution_resources[resource_type]',
@@ -160,8 +154,7 @@
                                        class: 'usa-radio__input initiating-facility-type-radio',
                                        id: "practice_solution_file"
                   %>
-                  <%= label_tag 'practice_solution_file', 'File', class: 'usa-radio__label
-                initiating-facility-type-label line-height-19px margin-bottom-0 margin-top-105', for: "practice_solution_file" %>
+                  <%= label_tag 'practice_solution_file', 'File', class: 'usa-radio__label line-height-19px margin-bottom-0 margin-top-105', for: "practice_solution_file" %>
                 </div>
                 <div class="usa-radio position-relative grid-col-12">
                   <%= radio_button_tag 'practice_solution_resources[resource_type]', 'Link',
@@ -169,8 +162,7 @@
                                        class: 'usa-radio__input initiating-facility-type-radio',
                                        id: "practice_solution_link"
                   %>
-                  <%= label_tag 'practice_solution_link', 'Link', class: 'usa-radio__label
-                initiating-facility-type-label line-height-19px margin-bottom-0 margin-top-105', for: "practice_solution_link" %>
+                  <%= label_tag 'practice_solution_link', 'Link', class: 'usa-radio__label line-height-19px margin-bottom-0 margin-top-105', for: "practice_solution_link" %>
                 </div>
                 <div id="display_solution_resources_form" class="display_problem_form grid-col-12">
                     <%= render partial: "practices/overview_forms/image_form", locals: {area: 'solution_resources'} %>
@@ -234,8 +226,7 @@
                                        class: 'usa-radio__input initiating-facility-type-radio',
                                        id: "practice_results_image"
                   %>
-                  <%= label_tag 'practice_results_image', 'Image', class: 'usa-radio__label
-                initiating-facility-type-label line-height-19px margin-bottom-0 margin-top-105', for: "practice_results_image" %>
+                  <%= label_tag 'practice_results_image', 'Image', class: 'usa-radio__label line-height-19px margin-bottom-0 margin-top-105', for: "practice_results_image" %>
                 </div>
                 <div class="usa-radio position-relative grid-col-12">
                   <%= radio_button_tag 'practice_results_resources[resource_type]',
@@ -244,8 +235,7 @@
                                        class: 'usa-radio__input initiating-facility-type-radio',
                                        id: "practice_results_video"
                   %>
-                  <%= label_tag 'practice_results_video', 'Video', class: 'usa-radio__label
-                initiating-facility-type-label line-height-19px margin-bottom-0 margin-top-105', for: "practice_results_video" %>
+                  <%= label_tag 'practice_results_video', 'Video', class: 'usa-radio__label line-height-19px margin-bottom-0 margin-top-105', for: "practice_results_video" %>
                 </div>
                 <div class="usa-radio position-relative grid-col-12">
                   <%= radio_button_tag 'practice_results_resources[resource_type]',
@@ -253,8 +243,7 @@
                                        class: 'usa-radio__input initiating-facility-type-radio',
                                        id: "practice_results_file"
                   %>
-                  <%= label_tag 'practice_results_file', 'File', class: 'usa-radio__label
-                initiating-facility-type-label line-height-19px margin-bottom-0 margin-top-105', for: "practice_results_file" %>
+                  <%= label_tag 'practice_results_file', 'File', class: 'usa-radio__label line-height-19px margin-bottom-0 margin-top-105', for: "practice_results_file" %>
                 </div>
                 <div class="usa-radio position-relative grid-col-12">
                   <%= radio_button_tag 'practice_results_resources[resource_type]', 'Link',
@@ -262,8 +251,7 @@
                                        class: 'usa-radio__input initiating-facility-type-radio',
                                        id: "practice_results_link"
                   %>
-                  <%= label_tag 'practice_results_link', 'Link', class: 'usa-radio__label
-                initiating-facility-type-label line-height-19px margin-bottom-0 margin-top-105', for: "practice_results_link" %>
+                  <%= label_tag 'practice_results_link', 'Link', class: 'usa-radio__label line-height-19px margin-bottom-0 margin-top-105', for: "practice_results_link" %>
                 </div>
                 <div id="display_results_resources_form" class="display_problem_form grid-col-12">
                     <%= render partial: "practices/overview_forms/image_form", locals: {area: 'results_resources'} %>
@@ -406,8 +394,7 @@
                                        class: 'usa-radio__input initiating-facility-type-radio',
                                        id: "practice_multimedia_image"
                   %>
-                  <%= label_tag 'practice_multimedia_image', 'Image', class: 'usa-radio__label
-                initiating-facility-type-label line-height-19px margin-bottom-0 margin-top-105', for: "practice_multimedia_image" %>
+                  <%= label_tag 'practice_multimedia_image', 'Image', class: 'usa-radio__label line-height-19px margin-bottom-0 margin-top-105', for: "practice_multimedia_image" %>
                 </div>
                 <div class="usa-radio position-relative grid-col-12">
                   <%= radio_button_tag 'practice_multimedia[resource_type]',
@@ -416,8 +403,7 @@
                                        class: 'usa-radio__input initiating-facility-type-radio',
                                        id: "practice_multimedia_video"
                   %>
-                  <%= label_tag 'practice_multimedia_video', 'Video', class: 'usa-radio__label
-                initiating-facility-type-label line-height-19px margin-bottom-0 margin-top-105', for: "practice_multimedia_video" %>
+                  <%= label_tag 'practice_multimedia_video', 'Video', class: 'usa-radio__label line-height-19px margin-bottom-0 margin-top-105', for: "practice_multimedia_video" %>
                 </div>
                 <div id="display_multimedia_form" class="display_problem_form grid-col-12">
                   <%= render partial: "practices/overview_forms/image_form", locals: {area: 'multimedia'} %>

--- a/app/views/practices/form/overview.html.erb
+++ b/app/views/practices/form/overview.html.erb
@@ -217,7 +217,7 @@
             <div id="results_section" class="grid-col-12">
               <div class="margin-bottom-5 margin-top-3">
                 <%= label_tag 'practice_overview_results', 'Results statement', class: 'usa-label margin-0 text-bold display-inline overview-results-statement-label' %>*
-                <p class="line-height-26 margin-top-2">Type information about the impact of the innovation at the originating facility.</p>
+                <p class="line-height-26 margin-top-2">Type information about the impact of the innovation at the originating healthcare facility.</p>
                 <%= f.text_area :overview_results, required: @practice.published, class: "usa-input #{ @practice.errors[:name].any? ? 'usa-input--error' : '' } display-block practice-editor-overview-statement-input" %>
               </div>
               <div class="margin-top-3">

--- a/app/views/practices/show/overview/diffusion_tracker/_adoptions.html.erb
+++ b/app/views/practices/show/overview/diffusion_tracker/_adoptions.html.erb
@@ -8,15 +8,15 @@
   adoption_statuses_and_text = [
     {
       status: DiffusionHistoryStatus::STATUSES[0],
-      text: 'Facilities that have met adoption goals and implemented the innovation.'
+      text: 'Healthcare facilities that have met adoption goals and implemented the innovation.'
     },
     {
       status: DiffusionHistoryStatus::STATUSES[1],
-      text: 'Facilities that have started but not completed adopting the innovation.'
+      text: 'Healthcare facilities that have started but not completed adopting the innovation.'
     },
     {
       status: DiffusionHistoryStatus::STATUSES[2],
-      text: 'Facilities that started but stopped working towards adoption.'
+      text: 'Healthcare facilities that started but stopped working towards adoption.'
     }
   ]
 %>

--- a/app/views/shared/_facility_complexity_modal.html.erb
+++ b/app/views/shared/_facility_complexity_modal.html.erb
@@ -4,31 +4,31 @@
       <div class="margin-bottom-5">
         <p class="line-height-18px text-bold">1a-Highest complexity</p>
         <p class="line-height-26 margin-top-1">
-          Facilities with high volume, high risk patients, most complex clinical programs, and large research and teaching programs
+          Healthcare facilities with high volume, high risk patients, most complex clinical programs, and large research and teaching programs
         </p>
       </div>
       <div class="margin-bottom-5">
         <p class="line-height-18px text-bold">1b-High complexity</p>
         <p class="line-height-26 margin-top-1">
-          Facilities with medium-high volume, high risk patients, many complex clinical programs, and medium-large research and teaching programs
+          Healthcare facilities with medium-high volume, high risk patients, many complex clinical programs, and medium-large research and teaching programs
         </p>
       </div>
       <div class="margin-bottom-5">
         <p class="line-height-18px text-bold">1c-Mid-High complexity</p>
         <p class="line-height-26 margin-top-1">
-          Facilities with medium-high volume, medium risk patients, some complex clinical programs, and medium sized research and teaching programs
+          Healthcare facilities with medium-high volume, medium risk patients, some complex clinical programs, and medium sized research and teaching programs
         </p>
       </div>
       <div class="margin-bottom-5">
         <p class="line-height-18px text-bold">2-Medium complexity</p>
         <p class="line-height-26 margin-top-1">
-          Facilities with medium volume, low risk patients, few complex clinical programs, and small or no research and teaching programs
+          Healthcare facilities with medium volume, low risk patients, few complex clinical programs, and small or no research and teaching programs
         </p>
       </div>
       <div>
         <p class="line-height-18px text-bold">3-Low complexity</p>
         <p class="line-height-26 margin-top-1">
-          Facilities with low volume, low risk patients, few or no complex clinical programs, and small or no research and teaching programs
+          Healthcare facilities with low volume, low risk patients, few or no complex clinical programs, and small or no research and teaching programs
         </p>
       </div>
     </div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -59,7 +59,7 @@
             </li>
             <li class="usa-nav__submenu-item border-base-light">
               <a class="font-sans-sm desktop:font-sans-2xs margin-y-2px desktop:margin-y-0 <%= 'usa-current' if request.fullpath === '/facilities' %>" href="<%= va_facilities_path %>">
-                Facility index
+                Healthcare facility index
               </a>
             </li>
             <li class="usa-nav__submenu-item border-base-light">

--- a/app/views/va_facilities/_facility_created_practice_search.html.erb
+++ b/app/views/va_facilities/_facility_created_practice_search.html.erb
@@ -8,7 +8,7 @@
 
 <div class="dm-facility-created-practice-search grid-row">
   <h2 class="font-sans-xl margin-top-10 desktop:margin-bottom-3">
-    Innovations created at this facility
+    Innovations created at this healthcare facility
   </h2>
   <div class="grid-col-12 display-flex">
     <div class="usa-search float-left grid-col-8">

--- a/app/views/va_facilities/_facility_practice_adoptions.html.erb
+++ b/app/views/va_facilities/_facility_practice_adoptions.html.erb
@@ -1,6 +1,6 @@
 <section id="dm-facility-adopted-practice-search">
   <h2 class="font-sans-xl margin-top-5 margin-bottom-3">
-    Innovations adopted at this facility
+    Innovations adopted at this healthcare facility
   </h2>
   <div class="grid-col-12 display-flex flex-align-start">
     <div class="usa-search grid-col-8">

--- a/app/views/va_facilities/_index_complexity_select.html.erb
+++ b/app/views/va_facilities/_index_complexity_select.html.erb
@@ -1,4 +1,4 @@
-<label for="<%= facility_type_selector %>" class="usa-label line-height-26">Facility complexity level</label>
+<label for="<%= facility_type_selector %>" class="usa-label line-height-26">Complexity level</label>
 <div class="margin-top-1 margin-bottom-2">
   <select id="<%= facility_type_selector %>" class="usa-select" name="<%= facility_type_selector %>">
     <option value="">- Select -</option>

--- a/app/views/va_facilities/_index_facilities_combo_box.html.erb
+++ b/app/views/va_facilities/_index_facilities_combo_box.html.erb
@@ -1,4 +1,4 @@
-<label for="<%= facility_selector %>" class="usa-label line-height-26">Facilities</label>
+<label for="<%= facility_selector %>" class="usa-label line-height-26">Healthcare Facilities</label>
 <div class="usa-combo-box margin-top-1 margin-bottom-2">
   <select id="<%= facility_selector %>" class="usa-select" name="<%= facility_selector %>">
     <% facilities.each do |fac| %>

--- a/app/views/va_facilities/_index_table.html.erb
+++ b/app/views/va_facilities/_index_table.html.erb
@@ -4,7 +4,7 @@
     <thead>
       <tr>
         <th class="grid-col-5" data-sortable scope="col" role="columnheader" aria-sort="descending">
-          Facility
+          Healthcare Facility
         </th>
         <th data-sortable scope="col" role="columnheader">
           State

--- a/app/views/va_facilities/_index_table.html.erb
+++ b/app/views/va_facilities/_index_table.html.erb
@@ -18,8 +18,8 @@
         </th>
         <th class="grid-col-3" data-sortable scope="col" role="columnheader">
           <a href="#facility-complexity-modal" aria-controls="facility-complexity-modal" data-open-modal class="dotted cursor-pointer facility-complexity-modal">
-            <span class="usa-sr-only">Open facility complexity modal</span>
-            Facility complexity level
+            <span class="usa-sr-only">Open modal: definitition</span>
+            Complexity level
           </a>
           <%= render partial: 'shared/facility_complexity_modal', locals: { hide_modal_on_initial_load: false, is_map: false } %>
         </th>

--- a/app/views/va_facilities/index.html.erb
+++ b/app/views/va_facilities/index.html.erb
@@ -11,7 +11,7 @@
     <div class="grid-row grid-gap">
       <div class="grid-col-12">
         <h1 class="font-sans-2xl margin-top-0 margin-bottom-3">
-          Facilities
+          Healthcare Facilities
         </h1>
         <span>Looking for a full list of VISNs? <a class="usa-link" href="<%= visns_path %>">Click here</a></span>
         <div class="dm-facilities-index-view">

--- a/app/views/visns/_visn_facilities_table.html.erb
+++ b/app/views/visns/_visn_facilities_table.html.erb
@@ -1,15 +1,15 @@
-<h2 class="va-facilities-header line-height-37px font-sans-xl<% ' margin-top-10' unless practices_created == 0 && practices_adopted == 0 %> margin-bottom-05">List of VA facilities in this VISN</h2>
+<h2 class="va-facilities-header line-height-37px font-sans-xl<% ' margin-top-10' unless practices_created == 0 && practices_adopted == 0 %> margin-bottom-05">List of VA healthcare facilities in this VISN</h2>
 <div class="usa-table-container--scrollable margin-bottom-0">
   <table class="usa-table usa-table--borderless width-full visn-facilities-table display-none">
     <caption class="usa-sr-only">VISN <%= @visn.number %> facilities</caption>
     <thead>
     <tr>
       <th data-sortable scope="col" role="columnheader">
-        Facility name
+        Healthcare facility name
       </th>
       <th data-sortable scope="col" role="columnheader">
         <a href="#facility-complexity-modal" aria-controls="facility-complexity-modal" data-open-modal class="dotted cursor-pointer facility-complexity-modal">
-          <span class="usa-sr-only">Open facility complexity modal</span>
+          <span class="usa-sr-only">Open modal: definition</span>
           Complexity level
         </a>
         <%= render partial: 'shared/facility_complexity_modal', locals: { hide_modal_on_initial_load: true, is_map: false } %>

--- a/app/views/visns/_visn_facilities_table.html.erb
+++ b/app/views/visns/_visn_facilities_table.html.erb
@@ -10,7 +10,7 @@
       <th data-sortable scope="col" role="columnheader">
         <a href="#facility-complexity-modal" aria-controls="facility-complexity-modal" data-open-modal class="dotted cursor-pointer facility-complexity-modal">
           <span class="usa-sr-only">Open facility complexity modal</span>
-          Facility complexity level
+          Complexity level
         </a>
         <%= render partial: 'shared/facility_complexity_modal', locals: { hide_modal_on_initial_load: true, is_map: false } %>
       </th>

--- a/app/views/visns/index.html.erb
+++ b/app/views/visns/index.html.erb
@@ -9,7 +9,7 @@
       <span class="usa-prose-body">Veterans Integrated Services Networks are regional systems of care within the Veterans Health Administration.</span>
     </div>
     <div class="margin-bottom-10">
-      <span class="line-height-26">Looking for a list of VA facilities?</span> <%= link_to 'Click here', va_facilities_path, class: 'usa-link' %>
+      <span class="line-height-26">Looking for a list of VA healthcare facilities?</span> <%= link_to 'Click here', va_facilities_path, class: 'usa-link' %>
     </div>
     <%= render partial: 'visns/maps/index_map' %>
   </section>

--- a/app/views/visns/show.html.erb
+++ b/app/views/visns/show.html.erb
@@ -34,12 +34,12 @@
             visn_practices_adopted_count = @practices_adopted_by_visn.size
           %>
 
-          This VISN has <%= visn_facilities_count %> facilit<%= visn_facilities_count != 1 ? 'ies' : 'y' %> and serves Veterans in <%= get_facility_locations_by_visn(@visn) %>.
-          Collectively, its facilities have created <%= visn_practices_created_count %> innovation<%= 's' if visn_practices_created_count != 1 %> and have adopted
+          This VISN has <%= visn_facilities_count %> healthcare facilit<%= visn_facilities_count != 1 ? 'ies' : 'y' %> and serves Veterans in <%= get_facility_locations_by_visn(@visn) %>.
+          Collectively, its healthcare facilities have created <%= visn_practices_created_count %> innovation<%= 's' if visn_practices_created_count != 1 %> and have adopted
           <%= visn_practices_adopted_count %> innovation<%= 's' if visn_practices_adopted_count != 1 %>.
           This VISN has <%= get_facility_type_text_by_visn(@visn) %>.
         </p>
-        <%= link_to 'Jump to list of VA facilities', va_facilities_path, class: 'usa-link' %>
+        <%= link_to 'Jump to list of VA healthcare facilities', va_facilities_path, class: 'usa-link' %>
       </div>
       <% user_type = session[:user_type] %>
       <% if @primary_visn_liaison.present? && ((ENV['VAEC_ENV'].nil? && user_type === 'guest') || user_type === 'ntlm') %>

--- a/spec/features/crh_spec.rb
+++ b/spec/features/crh_spec.rb
@@ -55,7 +55,7 @@ describe 'Clinical_Resource_Hubs', type: :feature do
       end
       it 'should display breadcrumb to facilities index page' do
         visit '/crh/1'
-        expect(page).to have_content("Facility index")
+        expect(page).to have_content("Healthcare facility index")
         find("a[href='/facilities']").click
         expect(page).to have_content("for a full list of VISNs?")
       end

--- a/spec/features/home_map_spec.rb
+++ b/spec/features/home_map_spec.rb
@@ -96,7 +96,7 @@ describe 'Map of Diffusion', type: :feature do
     expect(marker_count).to be(count)
   end
 
-  it 'displays and filters the map', js: true do
+  it 'displays and filters the map' do
     expect(page).to have_content('Explore how innovations are being adopted across the country. There are currently 2 successful adoptions, 3 in-progress adoptions, and 1 unsuccessful adoption.')
     expect_marker_ct(3)
 

--- a/spec/features/home_map_spec.rb
+++ b/spec/features/home_map_spec.rb
@@ -121,10 +121,10 @@ describe 'Map of Diffusion', type: :feature do
     expect(page).to be_accessible.within '#filterResults'
     expect(page).to have_no_css('#filterResultsTrigger')
     expect(page).to have_selector('#mapFilters', visible: true)
-    expect(page).to have_content('3 facility matches (of 3)')
+    expect(page).to have_content('3 healthcare facility matches (of 3)')
     expect(page).to have_content('4 innovations matched (of 4)')
     # open facility complexity modal
-    modal_text = 'Facilities with high volume, high risk patients, most complex clinical programs, and large research and teaching programs'
+    modal_text = 'Healthcare facilities with high volume, high risk patients, most complex clinical programs, and large research and teaching programs'
     expect(page).to_not have_content(modal_text)
     find_all('.facility-complexity-modal').last.click
     expect(page).to have_content(modal_text)
@@ -138,7 +138,7 @@ describe 'Map of Diffusion', type: :feature do
     # make sure the accordion closes
     expect(page).to have_selector('#mapFilters', visible: false)
     expect_marker_ct(2)
-    expect(page).to have_content('2 facility matches (of 3)')
+    expect(page).to have_content('2 healthcare facility matches (of 3)')
     expect(page).to have_content('3 innovations matched (of 4)')
     open_filters
     reset_filters
@@ -149,21 +149,21 @@ describe 'Map of Diffusion', type: :feature do
     find('.adoption-status-label[for="status_in-progress"]').click
     update_results
     expect_marker_ct(2)
-    expect(page).to have_content('2 facility matches (of 3)')
+    expect(page).to have_content('2 healthcare facility matches (of 3)')
     expect(page).to have_content('3 innovations matched (of 4)')
     # in-progress & unsuccessful adoptions
     open_filters
     find('.adoption-status-label[for="status_unsuccessful"]').click
     update_results
     expect_marker_ct(3)
-    expect(page).to have_content('3 facility matches (of 3)')
+    expect(page).to have_content('3 healthcare facility matches (of 3)')
     expect(page).to have_content('4 innovations matched (of 4)')
     # successful adoptions
     open_filters
     find('.adoption-status-label[for="status_in-progress"]').click
     update_results
     expect_marker_ct(1)
-    expect(page).to have_content('1 facility match (of 3)')
+    expect(page).to have_content('1 healthcare facility match (of 3)')
     expect(page).to have_content('1 innovation matched (of 4)')
     open_filters
     reset_filters
@@ -174,7 +174,7 @@ describe 'Map of Diffusion', type: :feature do
     find('.usa-checkbox__label[for="VISN_1"]').click
     update_results
     expect_marker_ct(1)
-    expect(page).to have_content('1 facility match (of 3)')
+    expect(page).to have_content('1 healthcare facility match (of 3)')
     expect(page).to have_content('3 innovations matched (of 4)')
     # @visn_2
     open_filters
@@ -182,7 +182,7 @@ describe 'Map of Diffusion', type: :feature do
     find('.usa-checkbox__label[for="VISN_2"]').click
     update_results
     expect_marker_ct(2)
-    expect(page).to have_content('2 facility matches (of 3)')
+    expect(page).to have_content('2 healthcare facility matches (of 3)')
     expect(page).to have_content('3 innovations matched (of 4)')
     open_filters
     reset_filters
@@ -193,13 +193,13 @@ describe 'Map of Diffusion', type: :feature do
     find('#facility_name--list--option-0').click
     update_results
     expect_marker_ct(1)
-    expect(page).to have_content('1 facility match (of 3)')
+    expect(page).to have_content('1 healthcare facility match (of 3)')
     expect(page).to have_content('3 innovations matched (of 4)')
     open_filters
     find('.usa-combo-box__clear-input').click
     update_results
     expect_marker_ct(3)
-    expect(page).to have_content('3 facility matches (of 3)')
+    expect(page).to have_content('3 healthcare facility matches (of 3)')
     expect(page).to have_content('4 innovations matched (of 4)')
     open_filters
     reset_filters
@@ -207,27 +207,27 @@ describe 'Map of Diffusion', type: :feature do
     # filters by facilities
     open_filters
     expect(page).to have_css('#facilityListTrigger')
-    expect(page).to have_content('View list of facilities')
+    expect(page).to have_content('View list of healthcare facilities')
     expect(page).to have_no_css('#facilityListContainer')
     find('#facilityListTrigger').click
-    expect(page).to have_no_content('View list of facilities')
-    expect(page).to have_content('Hide list of facilities')
+    expect(page).to have_no_content('View list of healthcare facilities')
+    expect(page).to have_content('Hide list of healthcare facilities')
     expect(page).to have_css('#facilityListContainer')
     find('.usa-checkbox__label[for="526GB"]').click
     update_results
     expect_marker_ct(1)
-    expect(page).to have_content('1 facility match (of 3)')
+    expect(page).to have_content('1 healthcare facility match (of 3)')
     expect(page).to have_content('1 innovation matched (of 4)')
     open_filters
     find('.usa-checkbox__label[for="526GA"]').click
     update_results
     expect_marker_ct(2)
-    expect(page).to have_content('2 facility matches (of 3)')
+    expect(page).to have_content('2 healthcare facility matches (of 3)')
     expect(page).to have_content('3 innovations matched (of 4)')
     open_filters
     find('#facilityListTrigger').click
-    expect(page).to have_content('View list of facilities')
-    expect(page).to have_no_content('Hide list of facilities')
+    expect(page).to have_content('View list of healthcare facilities')
+    expect(page).to have_no_content('Hide list of healthcare facilities')
     expect(page).to have_no_css('#facilityListContainer')
     reset_filters
 
@@ -236,7 +236,7 @@ describe 'Map of Diffusion', type: :feature do
     find('.usa-checkbox__label[for="1a_high_complexity"]').click
     update_results
     expect_marker_ct(1)
-    expect(page).to have_content('1 facility match (of 3)')
+    expect(page).to have_content('1 healthcare facility match (of 3)')
     expect(page).to have_content('1 innovation matched (of 4)')
     open_filters
     reset_filters
@@ -246,7 +246,7 @@ describe 'Map of Diffusion', type: :feature do
     find('.usa-checkbox__label[for="rurality_U"]').click
     update_results
     expect_marker_ct(2)
-    expect(page).to have_content('2 facility matches (of 3)')
+    expect(page).to have_content('2 healthcare facility matches (of 3)')
     expect(page).to have_content('3 innovations matched (of 4)')
     open_filters
     reset_filters
@@ -257,17 +257,17 @@ describe 'Map of Diffusion', type: :feature do
     find('.usa-checkbox__label[for="practice_ids_4"]').click
     update_results
     expect_marker_ct(1)
-    expect(page).to have_content('1 facility match (of 3)')
+    expect(page).to have_content('1 healthcare facility match (of 3)')
     expect(page).to have_content('2 innovations matched (of 4)')
     open_filters
     find('.adoption-status-label[for="status_unsuccessful"]').click
     update_results
-    expect(page).to have_content('0 facility matches (of 3)')
+    expect(page).to have_content('0 healthcare facility matches (of 3)')
     expect(page).to have_content('0 innovations matched (of 4)')
     open_filters
     find("#allMarkersButton").click
     expect_marker_ct(3)
-    expect(page).to have_content('3 facility matches (of 3)')
+    expect(page).to have_content('3 healthcare facility matches (of 3)')
     expect(page).to have_content('4 innovations matched (of 4)')
 
     # map modal

--- a/spec/features/home_map_spec.rb
+++ b/spec/features/home_map_spec.rb
@@ -96,7 +96,7 @@ describe 'Map of Diffusion', type: :feature do
     expect(marker_count).to be(count)
   end
 
-  it 'displays and filters the map' do
+  it 'displays and filters the map', js: true do
     expect(page).to have_content('Explore how innovations are being adopted across the country. There are currently 2 successful adoptions, 3 in-progress adoptions, and 1 unsuccessful adoption.')
     expect_marker_ct(3)
 

--- a/spec/features/practice_editor/introduction/introduction_spec.rb
+++ b/spec/features/practice_editor/introduction/introduction_spec.rb
@@ -173,7 +173,7 @@ describe 'Practice editor - introduction', type: :feature, js: true do
         # make sure the VISN text is a link to the VISN's show page
         click_link 'VISN-1'
         expect(page).to have_content('1: VA New England Healthcare System')
-        expect(page).to have_content('This VISN has 0 facilities')
+        expect(page).to have_content('This VISN has 0 healthcare facilities')
 
         # set department
         visit_practice_edit

--- a/spec/features/practice_spec.rb
+++ b/spec/features/practice_spec.rb
@@ -55,7 +55,7 @@ describe 'Practices', type: :feature do
 
       expect(page).to have_current_path(root_path)
       expect(page).to have_content('This innovation is not available for non-VA users.')
-      expect(page).to have_content('Discover VA innovations to adopt at your facility')
+      expect(page).to have_content('Discover VA innovations to adopt at your healthcare facility')
     end
 
     it 'should let authenticated users interact with the marketplace' do

--- a/spec/features/practice_viewer/introduction_spec.rb
+++ b/spec/features/practice_viewer/introduction_spec.rb
@@ -150,7 +150,7 @@ describe 'Practice viewer - introduction', type: :feature, js: true do
         visit practice_path(@pr_max)
         click_link 'VISN-6'
           expect(page).to have_content('6: VA Mid-Atlantic Health Care Network')
-          expect(page).to have_content('This VISN has 2 facilities')
+          expect(page).to have_content('This VISN has 2 healthcare facilities')
       end
     end
 

--- a/spec/features/shared/breadcrumbs_spec.rb
+++ b/spec/features/shared/breadcrumbs_spec.rb
@@ -211,13 +211,13 @@ describe 'Breadcrumbs', type: :feature do
       expect(page).to have_css("#dm-va-facilities-show", visible: true)
       within(:css, '#breadcrumbs') do
         expect(page).to have_css('.fa-arrow-left')
-        expect(page).to have_content('Facility index')
+        expect(page).to have_content('Healthcare facility index')
         expect(page).to have_link(href: '/facilities')
       end
       find('a[href="/innovations/the-best-innovation-ever"]').click
       expect(page).to have_css("#pr-view-introduction", visible: true)
       within(:css, '#breadcrumbs') do
-        expect(page).to have_content('Facility index')
+        expect(page).to have_content('Healthcare facility index')
         expect(page).to have_content('A first facility Test Common Name')
         expect(page).to have_no_content('The Best Innovation Ever')
         expect(page).to have_link(href: '/facilities')

--- a/spec/features/shared/header_spec.rb
+++ b/spec/features/shared/header_spec.rb
@@ -53,7 +53,7 @@ describe 'Diffusion Marketplace header', type: :feature, js: true do
         within('#browse-by-locations-dropdown') do
         expect(page).to have_content('VISN index')
         expect(page).to have_link(href: '/visns')
-        expect(page).to have_content('Facility index')
+        expect(page).to have_content('Healthcare facility index')
         expect(page).to have_link(href: '/facilities')
         expect(page).to have_content('Diffusion map')
         expect(page).to have_link(href: '/diffusion-map')

--- a/spec/features/va_facility_spec.rb
+++ b/spec/features/va_facility_spec.rb
@@ -67,7 +67,7 @@ describe 'VA facility pages', type: :feature do
         expect(page).to have_content("Facility")
         expect(page).to have_content("State")
         expect(page).to have_content("VISN")
-        expect(page).to have_content("Facility complexity level")
+        expect(page).to have_content("Complexity level")
         expect(page).to have_content("Created")
         expect(page).to have_content("Adopted")
         expect(page).to have_content("A Test name")

--- a/spec/features/va_facility_spec.rb
+++ b/spec/features/va_facility_spec.rb
@@ -244,7 +244,7 @@ describe 'VA facility pages', type: :feature do
       it 'should display default content' do
         login_and_visit_facility_page
         within(:css, '#dm-facility-adopted-practice-search') do
-          expect(page).to have_content("Innovations adopted at this facility")
+          expect(page).to have_content("Innovations adopted at this healthcare facility")
           find('#facility_category_select_adoptions').click
           within(:css, '#facility_category_select_adoptions--list') do
             expect(page).to have_content('COVID')

--- a/spec/features/visn_spec.rb
+++ b/spec/features/visn_spec.rb
@@ -222,8 +222,8 @@ describe 'VISN pages', type: :feature do
       login_as(@user, :scope => :user, :run_callbacks => false)
       page.set_rack_session(:user_type => 'ntlm')
       visit '/visns/2'
-      expect(page).to have_content('This VISN has 3 facilities and serves Veterans in Florida and Georgia.')
-      expect(page).to have_content('Collectively, its facilities have created 8 innovations and have adopted 5 innovations.')
+      expect(page).to have_content('This VISN has 3 healthcare facilities and serves Veterans in Florida and Georgia.')
+      expect(page).to have_content('Collectively, its healthcare facilities have created 8 innovations and have adopted 5 innovations.')
       expect(page).to have_content('Toge Inumaki')
     end
 
@@ -384,7 +384,7 @@ describe 'VISN pages', type: :feature do
         find_all('.facility-complexity-modal').last.click
 
         expect(page).to have_content('1a-Highest complexity')
-        expect(page).to have_content('Facilities with high volume, high risk patients, most complex clinical programs, and large research and teaching programs')
+        expect(page).to have_content('Healthcare facilities with high volume, high risk patients, most complex clinical programs, and large research and teaching programs')
 
         # check to make sure it closes properly
         find('.usa-modal__close').click

--- a/spec/features/visn_spec.rb
+++ b/spec/features/visn_spec.rb
@@ -395,11 +395,7 @@ describe 'VISN pages', type: :feature do
       it 'should take the user to the show page of the facility they click on within the facilities table' do
         visit '/visns/2'
         expect(page).to have_selector('.visn-facilities-table', visible: true)
-        click_link('Fourth Test Name (Fourth Common Name)')
-        sleep 2
-        expect(page).to have_content('This facility has created 0 innovations and has adopted 1 innovation.')
-        expect(page).to have_selector('#va_facility_map', visible: true)
-        expect(page).to have_current_path('/facilities/fourth-common-name')
+        expect(page).to have_link("#{@facility_4.official_station_name} (#{@facility_4.common_name})", href: va_facility_path(@facility_4))
       end
     end
   end


### PR DESCRIPTION
### JIRA issue link
[DM-4477](https://agile6.atlassian.net/browse/DM-4477)

## Description - what does this code do?
We are changing copy across the site to make it clear that `Facility` refers to a `Healthcare facility`. This PR:
- makes changes across public facing strings and in the innovation editor
- updates specs that expect `Facility` strings
- nudges arrow icon buttons in Facility tables to account for longer table titles

## Testing done - how did you test it/steps on how can another person can test it 

Confirm text changes align with approved copy changes in [this Figma file](https://www.figma.com/design/jx9AmRpDN1kLYQqTBytX6Q/facilities-string-changes-for-review?node-id=0-1&t=drwjgb4bXpCBc8fe-1)

