### PR TITLE
Render categories in ascending order by count in search

### DIFF
--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -59,7 +59,10 @@ class Category < ApplicationRecord
   end
 
   def self.get_cached_categories_grouped_by_parent
-    cached_categories.includes([:parent_category]).group_by(&:parent_category)
+    sub_categories = cached_categories.where.not(parent_category_id: nil).includes(:parent_category)
+    grouped_categories = sub_categories.group_by(&:parent_category)
+    sorted_groups = grouped_categories.sort_by { |_parent, categories| -categories.size }
+    sorted_groups.reverse.to_h
   end
 
   def self.ransackable_attributes(auth_object = nil)

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -54,4 +54,24 @@ RSpec.describe Category, type: :model do
       end
     end
   end
+
+  describe '.get_cached_categories_grouped_by_parent' do
+    let(:parent_a) { create(:category) }
+    let(:parent_b) { create(:category) }
+
+    before do
+      create_list(:category, 3, parent_category: parent_a)
+      create_list(:category, 5, parent_category: parent_b)
+      allow(described_class).to receive(:cached_categories).and_return(described_class.all)
+    end
+
+    it 'returns categories grouped by parent and sorted by group size in descending order' do
+      result = described_class.get_cached_categories_grouped_by_parent
+
+      expect(result.keys.first).to eq(parent_a)
+      expect(result.keys.second).to eq(parent_b)
+      expect(result[parent_a].size).to eq(3)
+      expect(result[parent_b].size).to eq(5)
+    end
+  end
 end


### PR DESCRIPTION
### JIRA issue link


## Description - what does this code do?
edits so that it returns a hash of parent categories and their subcategories ordered by count of subcategories in ascending order

## Testing done - how did you test it/steps on how can another person can test it 
1. running the app locally, verify that the filters within the dropdown are ordered by count of subcategories in ascending order

## Screenshots, Gifs, Videos from application (if applicable)
![Screenshot 2024-06-13 at 12 44 41 PM](https://github.com/department-of-veterans-affairs/diffusion-marketplace/assets/65036872/75b42acd-9319-49bb-a57d-88622eff8c17)


## Link to mock-ups/mock ups (image file if you have it) (if applicable)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Unit tests written (if applicable)
- [ ] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating JIRA issue
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs