### PR TITLE
DM-4860 add placeholder text to search page search field

### DIFF
--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -35,7 +35,7 @@
           type="search"
           name="search"
           autocomplete="off"
-          placeholder="Search innovations, tags..."
+          placeholder="Search innovations, tags, communities..."
           aria-labelledby="dm-homepage-search-form"
         >
           <div

--- a/app/views/practices/search.html.erb
+++ b/app/views/practices/search.html.erb
@@ -21,7 +21,15 @@
         <div role="search" class="flex-column">
           <label for="dm-practice-search-field"></label>
           <div id="search-bar-container" class="display-flex">
-            <input class="usa-input" id="dm-practice-search-field" title="Type at least three characters to search." autocomplete="off" type="search" name="search">
+            <input
+              class="usa-input"
+              id="dm-practice-search-field"
+              title="Type at least three characters to search."
+              autocomplete="off"
+              type="search"
+              name="search"
+              placeholder="Search innovations, tags, communities..."
+            >
             <button id="dm-practice-search-button" class="usa-button" type="submit" name="search-button">
               <span class="usa-search__submit-text text-bold">Search</span>
             </button>


### PR DESCRIPTION
### JIRA issue link
https://agile6.atlassian.net/browse/DM-4860

## Description - what does this code do?
Adds placeholder text in the search field on the `/search` page

## Testing done - how did you test it/steps on how can another person can test it 
1. On the `/search` page verify the placeholder text appears in the search field as per the "After" screenshot below

## Screenshots, Gifs, Videos from application (if applicable)
Before:
![Screenshot 2024-06-18 at 12 02 00 PM](https://github.com/department-of-veterans-affairs/diffusion-marketplace/assets/65036872/3a930094-84e5-47f8-a769-752da230aad9)

After:
![Screenshot 2024-06-18 at 12 02 55 PM](https://github.com/department-of-veterans-affairs/diffusion-marketplace/assets/65036872/cbda44fb-16a4-48f9-9a3b-4894a2c092c7)

## Link to mock-ups/mock ups (image file if you have it) (if applicable)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Unit tests written (if applicable)
- [ ] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating JIRA issue
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs