### PR TITLE
DM-4627 remove un-needed filters from admin/pages

### DIFF
--- a/app/admin/pages.rb
+++ b/app/admin/pages.rb
@@ -86,7 +86,19 @@ ActiveAdmin.register Page do
   # end
   #
 
-  remove_filter :versions, :position, :short_name
+  remove_filter :versions,
+                :position,
+                :short_name,
+                :page_components,
+                :published,
+                :is_visible,
+                :template_type,
+                :has_chrome_warning_banner,
+                :image_alt_text,
+                :image_file_name,
+                :image_content_type,
+                :image_file_size,
+                :image_updated_at
   index do
     selectable_column
     column(:title) { |page| link_to(page.title, admin_page_path(page)) }


### PR DESCRIPTION
### JIRA issue link
https://agile6.atlassian.net/browse/DM-4627

## Description - what does this code do?
removes un-needed fields from the `admin/pages` index

## Testing done - how did you test it/steps on how can another person can test it 
1. As admin visit the `/admin/pages` page and verify the filters appear as per the "After" screenshot below

## Screenshots, Gifs, Videos from application (if applicable)
Before:
![Screenshot 2024-06-18 at 11 57 57 AM](https://github.com/department-of-veterans-affairs/diffusion-marketplace/assets/65036872/80ac0149-2495-4102-b1d5-4d9491fe62a6)

After:
![Screenshot 2024-06-18 at 11 57 15 AM](https://github.com/department-of-veterans-affairs/diffusion-marketplace/assets/65036872/5d5d6600-0b95-43f6-b382-259aad076715)

## Link to mock-ups/mock ups (image file if you have it) (if applicable)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Unit tests written (if applicable)
- [ ] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating JIRA issue
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs