### PR TITLE
DM-4806 add column to admin/pages and editor/pages index

### DIFF
--- a/app/admin/editor/pages.rb
+++ b/app/admin/editor/pages.rb
@@ -91,6 +91,7 @@ ActiveAdmin.register Page, namespace: :editor do
     }
     column(:description)
     column(:published)
+    column(:is_public)
     actions do |page|
       publish_action_str = page.published ? "Unpublish" : "Publish"
       item publish_action_str, publish_page_admin_page_path(page), method: :post

--- a/app/admin/pages.rb
+++ b/app/admin/pages.rb
@@ -99,6 +99,7 @@ ActiveAdmin.register Page do
     }
     column(:description)
     column(:published)
+    column(:is_public)
     actions do |page|
       publish_action_str = page.published ? "Unpublish" : "Publish"
       item publish_action_str, publish_page_admin_page_path(page), method: :post


### PR DESCRIPTION
### JIRA issue link
https://agile6.atlassian.net/browse/DM-4806

## Description - what does this code do?
add  Is Public column column to admin/pages and editor/pages index

## Testing done - how did you test it/steps on how can another person can test it 
1. As admin visit `/admin/pages` and `editor/pages` and verify the "Is Public" column appears in the grid as per the "After" screenshot below.

## Screenshots, Gifs, Videos from application (if applicable)
Before:
![Screenshot 2024-06-18 at 12 16 44 PM](https://github.com/department-of-veterans-affairs/diffusion-marketplace/assets/65036872/9d0a3087-b907-4620-87ee-977d0997e9a4)

After:
![Screenshot 2024-06-18 at 12 17 35 PM](https://github.com/department-of-veterans-affairs/diffusion-marketplace/assets/65036872/3e43749b-f79b-404f-8fbb-5a8fe0c7d305)


## Link to mock-ups/mock ups (image file if you have it) (if applicable)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Unit tests written (if applicable)
- [ ] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating JIRA issue
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs