### PR TITLE
dm-4908 Change admin landing page

### DIFF
--- a/app/admin/categories.rb
+++ b/app/admin/categories.rb
@@ -79,7 +79,7 @@ ActiveAdmin.register Category do
       f.input :is_other
     end
     f.actions do
-      f.action :submit, label: 'Create Tag'
+      f.action :submit, label: object.new_record? ? 'Create Tag' : 'Update Tag'
       f.cancel_link
     end
   end

--- a/app/admin/categories.rb
+++ b/app/admin/categories.rb
@@ -1,4 +1,5 @@
 ActiveAdmin.register Category do
+  menu priority: 1
   batch_action :destroy, false
 
   filter :name

--- a/app/admin/categories.rb
+++ b/app/admin/categories.rb
@@ -1,11 +1,25 @@
 ActiveAdmin.register Category do
+  menu label: "Tags"
   batch_action :destroy, false
 
   filter :name
   filter :description
   filter :related_terms
 
-  index do
+  breadcrumb do
+    if params[:action] == "show"
+      [
+        link_to('Admin', admin_root_path),
+        link_to('Tags', admin_categories_path)
+      ]
+    else
+      [
+        link_to('Admin', admin_root_path),
+      ]
+    end
+  end
+
+  index title: "Tags" do
     id_column
     column :name
     column :short_name

--- a/app/admin/categories.rb
+++ b/app/admin/categories.rb
@@ -13,8 +13,12 @@ ActiveAdmin.register Category do
     link_to 'New Tag', new_admin_category_path
   end
 
+  action_item :edit, only: :show do
+    link_to 'Edit Tag', edit_admin_category_path(resource) if authorized?(:edit, resource)
+  end
+
   breadcrumb do
-    if params[:action] == "show"
+    if params[:action] == "show" || params[:action] == "edit"
       [
         link_to('Admin', admin_root_path),
         link_to('Tags', admin_categories_path)
@@ -31,7 +35,7 @@ ActiveAdmin.register Category do
     column :name
     column :short_name
     column :description
-    column "Parent Category" do |p|
+    column "Parent Tag" do |p|
       if p.present?
         Category.find_by_id(p.parent_category_id)
        end
@@ -135,7 +139,12 @@ ActiveAdmin.register Category do
     end
 
     def set_page_title
-      @page_title = params[:action] == 'new' ? 'New Tag' : "Edit Tag - #{resource.name}"
+      case action_name
+      when 'new'
+        @page_title = 'New Tag'
+      when 'edit'
+        @page_title = "Edit Tag"
+      end
     end
   end
 end

--- a/app/admin/categories.rb
+++ b/app/admin/categories.rb
@@ -1,5 +1,4 @@
 ActiveAdmin.register Category do
-  menu priority: 1
   batch_action :destroy, false
 
   filter :name

--- a/app/admin/site_metrics.rb
+++ b/app/admin/site_metrics.rb
@@ -1,7 +1,7 @@
 include ActiveAdminHelpers
 
 ActiveAdmin.register_page 'Site Metrics' do
-  menu priority: 1, label: proc {I18n.t('active_admin.site_metrics')}
+  menu label: proc {I18n.t('active_admin.site_metrics')}
 
   controller do
     helper_method :set_date_values

--- a/config/initializers/active_admin.rb
+++ b/config/initializers/active_admin.rb
@@ -118,7 +118,7 @@ ActiveAdmin.setup do |config|
   # roots for each namespace.
   #
   # Default:
-  config.root_to = 'site_metrics#index'
+  config.root_to = 'categories#index'
 
   # == Admin Comments
   #

--- a/spec/features/admin/admin_categories_spec.rb
+++ b/spec/features/admin/admin_categories_spec.rb
@@ -20,12 +20,12 @@ describe 'Admin Dashboard Categories Tab', type: :feature do
     visit '/admin/categories'
 
     # since the category being created does not have any subcategories, the 'Parent category' select element should show up
-    click_link('New Category')
+    click_link('New Tag')
     expect(page).to have_selector('#category_parent_category_id')
 
     fill_in('Name', with: 'Fifth Category')
     select('Second Parent Category', :from => 'category_parent_category_id')
-    click_button('Create Category')
+    click_button('Create Tag')
 
     expect(page).to have_content('Category was successfully created.')
   end
@@ -44,7 +44,7 @@ describe 'Admin Dashboard Categories Tab', type: :feature do
     expect(page).to_not have_selector('#category_parent_category_id')
 
     fill_in('Name', with: 'Parent Category Three')
-    click_button('Update Category')
+    click_button('Update Tag')
 
     expect(page).to have_content('Category was successfully updated.')
   end
@@ -56,7 +56,7 @@ describe 'Admin Dashboard Categories Tab', type: :feature do
       all('.edit_link').first.click
       select('First Parent Category', :from => 'category_parent_category_id')
       fill_in('Name', with: 'Completely updated category')
-      click_button('Update Category')
+      click_button('Update Tag')
       expect(cache_keys).not_to include("categories")
       add_categories_to_cache
       find('.search-filters-accordion-button').click
@@ -66,10 +66,10 @@ describe 'Admin Dashboard Categories Tab', type: :feature do
     it 'Should be reset if a new category is created through the admin panel' do
       add_categories_to_cache
       visit '/admin/categories'
-      click_link('New Category')
+      click_link('New Tag')
       fill_in('Name', with: 'Newest Category')
       select('Second Parent Category', :from => 'category_parent_category_id')
-      click_button('Create Category')
+      click_button('Create Tag')
       expect(cache_keys).not_to include("categories")
       add_categories_to_cache
       find('.search-filters-accordion-button').click

--- a/spec/features/admin/admin_spec.rb
+++ b/spec/features/admin/admin_spec.rb
@@ -83,10 +83,9 @@ describe 'The admin dashboard', type: :feature do
 
     it 'should show the admin dashboard if logged in as an admin' do
       login_as(@admin, scope: :user, run_callbacks: false)
-      visit '/admin'
+      visit '/admin/site_metrics'
 
       expect(page).to be_accessible.according_to :wcag2a, :section508
-      expect(page).to have_current_path(admin_root_path)
 
       expect(page).to have_link('General', href: '#general')
       expect(page).to have_link('Innovation Engagement', href: '#innovation-engagement')
@@ -99,26 +98,23 @@ describe 'The admin dashboard', type: :feature do
       login_as(@admin, scope: :user, run_callbacks: false)
 
       visit admin_root_path
-      expect(find('.menu_item.current')).to have_text('Site Metrics')
-      expect(page).to have_content('General')
-      expect(page).to have_content('Innovation Engagement')
-      expect(page).to have_content('Users')
+      expect(find('.menu_item.current')).to have_text('Tags')
+      expect(page).to have_content('New Tag')
     end
   end
 
   describe 'Navigation' do
     it 'should have several tabs that allow navigation' do
       login_as(@admin, scope: :user, run_callbacks: false)
-      visit '/admin'
+      visit '/admin/site_metrics'
 
       expect(page).to be_accessible.according_to :wcag2a, :section508
-      expect(page).to have_current_path(admin_root_path)
 
       within(:css, '#header') do
         click_link('Site Metrics')
         expect(page).to have_current_path(admin_site_metrics_path)
 
-        click_link('Categories')
+        click_link('Tags')
         expect(page).to have_current_path(admin_categories_path)
 
         click_link('Comments')
@@ -153,33 +149,30 @@ describe 'The admin dashboard', type: :feature do
       login_as(@admin, scope: :user, run_callbacks: false)
       visit '/admin'
 
-      # view categories
-      click_link('Categories')
-      expect(page).to have_current_path(admin_categories_path)
       expect(page).to have_content('COVID')
       expect(page).to have_content('COVID-19, Coronavirus')
       expect(page).to have_content('Telehealth')
 
       # new category
-      click_link('New Category')
+      click_link('New Tag')
       expect(page).to have_current_path(new_admin_category_path)
       fill_in('Name', with: 'Mental Health')
       fill_in('Description', with: 'Mental Health related practices')
       fill_in('Related Terms', with: 'emotional health, emotional wellbeing')
-      click_button('Create Category')
+      click_button('Create Tag')
       expect(page).to have_current_path(admin_category_path(Category.last))
 
       # edit category
-      click_link('Edit Category')
+      click_link('Edit Tag')
       fill_in('Related Terms', with: 'psychological health, mental wellbeing')
-      click_button('Update Category')
+      click_button('Update Tag')
       expect(page).to have_current_path(admin_category_path(Category.last))
       expect(page).to have_content('psychological health, mental wellbeing')
 
       # edit category - remove related terms
-      click_link('Edit Category')
+      click_link('Edit Tag')
       fill_in('Related Terms', with: '')
-      click_button('Update Category')
+      click_button('Update Tag')
       expect(page).to have_current_path(admin_category_path(Category.last))
       expect(page).to have_no_content('psychological health, mental wellbeing')
 
@@ -410,7 +403,7 @@ describe 'The admin dashboard', type: :feature do
 
       # check if categories display correctly
       click_link('Edit', href: edit_admin_practice_path(@practice))
-      expect(page).to have_content('Categories')
+      expect(page).to have_content('Tags')
       expect(page).to have_content('Covid')
       expect(page).to have_content('Telehealth')
       expect(find_field('practice_category_ids').find('option[selected]').text).to eq('Telehealth')

--- a/spec/features/admin/site_metrics_spec.rb
+++ b/spec/features/admin/site_metrics_spec.rb
@@ -81,7 +81,7 @@ describe 'Admin site metrics', type: :feature do
       @page_group_1 = PageGroup.create(name: 'ghost_page', description: 'Pages should not be in the metrics')
       Page.create!(title: 'Test', description: 'This is a test page', slug: 'home', page_group: @page_group)
 
-      visit '/admin'
+      visit '/admin/site_metrics'
       expect(page).to have_no_content(@page_group_1.name)
       expect(page).to have_link(href: '/programming')
       within(:css, '#dm-custom-page-traffic') do
@@ -89,7 +89,7 @@ describe 'Admin site metrics', type: :feature do
         expect(td_unique.text).to eq('0')
       end
       visit '/programming'
-      visit '/admin'
+      visit '/admin/site_metrics'
       within(:css, '#dm-custom-page-traffic') do
         td_unique = all('td[class*="total_views_custom_page"]')[1]
         expect(td_unique.text).to eq('1')
@@ -98,7 +98,7 @@ describe 'Admin site metrics', type: :feature do
 
     it 'should not display the custom page view section if there are no page groups with homepages' do
       PageGroup.destroy_all
-      visit '/admin'
+      visit '/admin/site_metrics'
       expect(page).to have_no_content('Custom Page Traffic')
       expect(page).to have_no_link(href: '/programming')
     end
@@ -136,7 +136,7 @@ describe 'Admin site metrics', type: :feature do
 
     it 'favorite should display in last month but not in total if unfavorited' do
       user_practice_favorited = UserPractice.create(time_favorited: DateTime.now - 1.months, user: @admin, practice: @practice, favorited: true)
-      visit '/admin'
+      visit '/admin/site_metrics'
       click_link('Innovation Engagement')
 
       within(:css, '#favorited_stats') do
@@ -148,7 +148,7 @@ describe 'Admin site metrics', type: :feature do
 
       user_practice_favorited.favorited = false
       user_practice_favorited.save
-      visit '/admin'
+      visit '/admin/site_metrics'
       click_link('Innovation Engagement')
 
       within(:css, '#favorited_stats') do
@@ -161,7 +161,7 @@ describe 'Admin site metrics', type: :feature do
 
     it 'favorite should display in current month but not in total if unfavorited' do
       user_practice_favorited = UserPractice.create(time_favorited: DateTime.now, user: @admin, practice: @practice, favorited: true)
-      visit '/admin'
+      visit '/admin/site_metrics'
       click_link('Innovation Engagement')
 
       within(:css, '#favorited_stats') do
@@ -173,7 +173,7 @@ describe 'Admin site metrics', type: :feature do
 
       user_practice_favorited.favorited = false
       user_practice_favorited.save
-      visit '/admin'
+      visit '/admin/site_metrics'
       click_link('Innovation Engagement')
 
       within(:css, '#favorited_stats') do
@@ -186,7 +186,7 @@ describe 'Admin site metrics', type: :feature do
 
     it 'should display at least one time_favorited' do
       UserPractice.create(time_favorited: DateTime.now - 1.months, user: @admin, practice: @practice, time_committed: DateTime.now - 1.months, committed: true)
-      visit '/admin'
+      visit '/admin/site_metrics'
       click_link('Innovation Engagement')
 
       within(:css, '#favorited_stats') do
@@ -195,7 +195,7 @@ describe 'Admin site metrics', type: :feature do
       end
 
       UserPractice.create(time_favorited: DateTime.now - 1.months, user: @admin, practice: @practice, time_committed: DateTime.now - 1.months, committed: true)
-      visit '/admin'
+      visit '/admin/site_metrics'
       click_link('Innovation Engagement')
 
       within(:css, '#favorited_stats') do
@@ -220,21 +220,21 @@ describe 'Admin site metrics', type: :feature do
         end
       end
 
-      visit '/admin'
+      visit '/admin/site_metrics'
       click_link('Innovation Engagement')
       check_counts(1)
       visit practice_path(@practice)
       within(:css, '#dm-practice-nav') do
         find('.dm-email-practice').click
       end
-      visit '/admin'
+      visit '/admin/site_metrics'
       click_link('Innovation Engagement')
       check_counts(2)
       visit practice_path(@practice)
       within(:css, '.main-email-address-container') do
         find('.dm-email-practice').click
       end
-      visit '/admin'
+      visit '/admin/site_metrics'
       click_link('Innovation Engagement')
       check_counts(3)
     end
@@ -283,7 +283,7 @@ describe 'Admin site metrics', type: :feature do
       expect(cache_keys).to include('published_enabled_approved_practices')
       @practice.update(name: 'The Coolest Practice Ever!')
       expect(cache_keys).not_to include("searchable_practices_json")
-      visit '/admin'
+      visit '/admin/site_metrics'
       expect(cache_keys).to include('published_enabled_approved_practices')
     end
   end

--- a/spec/features/practice_spec.rb
+++ b/spec/features/practice_spec.rb
@@ -155,14 +155,14 @@ describe 'Practices', type: :feature do
       expect(page).to have_content(@enabled_practice.initiating_facility)
       expect(page).to have_current_path(practice_path(@enabled_practice))
       click_on('Bookmark')
-      visit admin_root_path
+      visit admin_site_metrics_path
       click_on('Innovation Engagement')
       expect(page).to have_content('Enabled practice')
     end
 
     it 'should NOT display disabled practice in metrics' do
       login_as(@admin, :scope => :user, :run_callbacks => false)
-      visit admin_root_path
+      visit admin_site_metrics_path
       click_on('Innovation Engagement')
       expect(page).to_not have_content('Disabled practice')
     end


### PR DESCRIPTION
### JIRA issue link
https://agile6.atlassian.net/browse/DM-4908

## Description - what does this code do?
updates landing page for admin access to be `/categories` instead of `/site_metrics`

## Testing done - how did you test it/steps on how can another person can test it 
1. go to `/admin` and verify the `/admin/categories` page renders
2. Verify the subnav link and  title reads "Tags" and that the admin show view for a tag (category) reads "ADMIN / TAGS" in the breadcrumbs - see screenshots

## Screenshots, Gifs, Videos from application (if applicable)

before:
<img width="521" alt="Screenshot 2024-06-26 at 4 04 11 PM" src="https://github.com/department-of-veterans-affairs/diffusion-marketplace/assets/65036872/5b8ab324-e465-4ed1-b2ad-7fb89efe4678">

after:
![Screenshot 2024-06-27 at 3 23 33 PM](https://github.com/department-of-veterans-affairs/diffusion-marketplace/assets/65036872/7b82a7b5-a646-4720-a434-672ecea99009)

![Screenshot 2024-06-27 at 3 24 28 PM](https://github.com/department-of-veterans-affairs/diffusion-marketplace/assets/65036872/5d2085b7-ce8c-48c2-998d-f16dcfa73504)


## Link to mock-ups/mock ups (image file if you have it) (if applicable)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Unit tests written (if applicable)
- [ ] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating JIRA issue
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs