### PR TITLE
Dm 4876 add unpublished page banner

### DIFF
--- a/app/views/page/show.html.erb
+++ b/app/views/page/show.html.erb
@@ -16,7 +16,7 @@
         <% unless @page.published? %>
           <div class="usa-alert usa-alert--warning">
             <div class="usa-alert__body">
-              <h3 class="usa-alert__heading">This Page will not be visible to non-admins because it is unpublished</h3>
+              <h3 class="usa-alert__heading">This page is not visible because it is not published</h3>
             <div>
           <div>
         <% end %>

--- a/app/views/page/show.html.erb
+++ b/app/views/page/show.html.erb
@@ -10,6 +10,19 @@
 <% accordion_ctr = 0 %>
 <% page_narrow_classes = 'desktop:grid-col-8 margin-x-auto' if @page.narrow? %>
 <div id="page-builder-page" class="margin-top-5">
+  <section class="usa-section padding-y-0 margin-bottom-1 margin-top-0">
+    <div class="grid-container position-relative">
+      <div class="grid-row grid-gap">
+        <% unless @page.published? %>
+          <div class="usa-alert usa-alert--warning">
+            <div class="usa-alert__body">
+              <h3 class="usa-alert__heading">This Page will not be visible to non-admins because it is unpublished</h3>
+            <div>
+          <div>
+        <% end %>
+      </div>
+    </div>
+  </section>
   <section>
     <div class="dm-page-content">
       <% @page_components.each_with_index do |pc, index| %>

--- a/spec/features/pages/show_page_spec.rb
+++ b/spec/features/pages/show_page_spec.rb
@@ -155,7 +155,7 @@ describe 'Page Builder - Show', type: :feature do
     @page.update(published: false)
     visit '/programming/ruby-rocks'
 
-    expect(page).to have_content("This Page will not be visible to non-admins because it is unpublished")
+    expect(page).to have_content("This page is not visible because it is not published")
   end
 
   context 'PageAccordionComponent' do

--- a/spec/features/pages/show_page_spec.rb
+++ b/spec/features/pages/show_page_spec.rb
@@ -151,6 +151,13 @@ describe 'Page Builder - Show', type: :feature do
     expect(page).to have_content('It is pretty cool too')
   end
 
+  it 'should display banner when unpublished' do
+    @page.update(published: false)
+    visit '/programming/ruby-rocks'
+
+    expect(page).to have_content("This Page will not be visible to non-admins because it is unpublished")
+  end
+
   context 'PageAccordionComponent' do
     it 'should display properly' do
       expect(page).to have_content('FAQ 1')
@@ -309,6 +316,7 @@ describe 'Page Builder - Show', type: :feature do
 
       visit '/programming/javascript'
       # Make sure the map components are 508 compliant
+
       expect(page).to be_accessible.according_to :wcag2a, :section508
       expect(page).to have_css('.page-map-component', count: 2)
       within(all('.page-map-component').first) do


### PR DESCRIPTION
### JIRA issue link
https://agile6.atlassian.net/browse/DM-4876

## Description - what does this code do?
Adds banner to the top of pagebuilder pages when they are unpublished

## Testing done - how did you test it/steps on how can another person can test it 
1. Go to a page that is not published and verify the banner appears below the blue banner

## Screenshots, Gifs, Videos from application (if applicable)
![Screenshot 2024-06-27 at 2 29 56 PM](https://github.com/department-of-veterans-affairs/diffusion-marketplace/assets/65036872/843131eb-40ab-4000-932e-26680f018ac2)

## Link to mock-ups/mock ups (image file if you have it) (if applicable)


## Acceptance criteria
- [ ]

## Definition of done
- [x] Unit tests written (if applicable)
- [x] e2e/accessibility tests written (if applicable)
- [x] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating JIRA issue
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs