### PR TITLE
dm-4930 add fragment caching to home_map_filters partial

### DIFF
--- a/app/views/maps/_home_map_filters.html.erb
+++ b/app/views/maps/_home_map_filters.html.erb
@@ -107,26 +107,28 @@
         <div id="facilityListContainer" class="map-filters-list display-none">
           <fieldset class="grid-row">
             <legend class="usa-sr-only">Facilities</legend>
-            <% sliced_facilities = split_data_into_three_columns(@va_facilities) %>
-            <% if sliced_diffused_practices.present? %>
-              <% sliced_facilities.each_with_index do |facilities_array, i| %>
-                <% unless i === 3 %>
-                  <div class="grid-col-4">
-                    <% facilities_array.each do |f| %>
-                      <%
-                        station_number = f.station_number
-                        station_name = f.official_station_name
-                      %>
-                      <%= render partial: 'shared/checkbox', locals: {
-                        data_id: station_number,
-                        data_name: 'facilities',
-                        data_value: station_number,
-                        data_label_text: "#{f.street_address_state}: #{facility_name_with_common_name(station_name, f.common_name)}",
-                        data_input_class: '',
-                        data_label_class: ''
-                      } %>
-                    <% end %>
-                  </div>
+            <% cache(["facilities_checkboxes", @va_facilities.maximum(:updated_at)]) do %>
+              <% sliced_facilities = split_data_into_three_columns(@va_facilities) %>
+              <% if sliced_diffused_practices.present? %>
+                <% sliced_facilities.each_with_index do |facilities_array, i| %>
+                  <% unless i === 3 %>
+                    <div class="grid-col-4">
+                      <% facilities_array.each do |f| %>
+                        <%
+                          station_number = f.station_number
+                          station_name = f.official_station_name
+                        %>
+                        <%= render partial: 'shared/checkbox', locals: {
+                          data_id: station_number,
+                          data_name: 'facilities',
+                          data_value: station_number,
+                          data_label_text: "#{f.street_address_state}: #{facility_name_with_common_name(station_name, f.common_name)}",
+                          data_input_class: '',
+                          data_label_class: ''
+                        } %>
+                      <% end %>
+                    </div>
+                  <% end %>
                 <% end %>
               <% end %>
             <% end %>


### PR DESCRIPTION
### JIRA issue link
https://agile6.atlassian.net/browse/DM-4930

## Description - what does this code do?

Implements simple fragment caching within the `home_map_filters` partial that renders hundreds (on prod) of subsequent 'shared/checkbox' partials. The cache key is the most recent `updated_at` of the `VaFacility` collection, which is automatically invalidated when there is a new most recent `updated_at`.

You can see evidence of the cache working in the terminal output after initially loading the `/diffusion_map` page, the first time will run as it usually does but after that the output will be considerably reduced as hundreds of `Rendered shared/_checkbox.html.erb` will be replaced by `Rendered maps/_home_map_filters.html.erb (Duration: 45.9ms | Allocations: 128471) [cache hit]`

It's unclear if this will help page load times until we test it out on a live server.

## Testing done - how did you test it/steps on how can another person can test it 
1. Locally with `redis` running, verify the `/diffusion_map` page loads, reload a few times.
2. On DEV, before deploying, record the rough average of FCP, LCP times.
3. With the branch deployed to DEV, record load times again and compare.

## Screenshots, Gifs, Videos from application (if applicable)
before:
<img width="543" alt="Screenshot 2024-07-02 at 11 23 44 AM" src="https://github.com/department-of-veterans-affairs/diffusion-marketplace/assets/65036872/e005d46f-6cf4-43b6-b208-af80e02e2269">

after:
<img width="791" alt="Screenshot 2024-07-02 at 11 24 30 AM" src="https://github.com/department-of-veterans-affairs/diffusion-marketplace/assets/65036872/9d59cb2e-987f-4a08-a440-f53a596c98cf">

## Link to mock-ups/mock ups (image file if you have it) (if applicable)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Unit tests written (if applicable)
- [ ] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating JIRA issue
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs