### PR TITLE
dm-4935: Create a responsive layout with placeholder sections for search results refresh

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -10,6 +10,7 @@ on:
     branches:
       [
         "master",
+        "feature/DM-4866-search-results-refresh",
         "ci-migration",
         "ci-migration-cv",
         "ci-migration-en",
@@ -17,7 +18,7 @@ on:
         "ci-migration-bj",
       ]
   pull_request:
-    branches: ["master"]
+    branches: ["master", "feature/DM-4866-search-results-refresh"]
 jobs:
   build:
     name: rspec

--- a/app/assets/stylesheets/dm/pages/_search.scss
+++ b/app/assets/stylesheets/dm/pages/_search.scss
@@ -6,6 +6,24 @@
     border-radius: 2px;
   }
 
+  #REPLACE-with-something-about-filters {
+    .usa-accordion {
+      width: unset;
+    }
+  }
+
+  #REPLACE-with-something-about-innovation-results {
+    .innovation-preview {
+      border-top: 1px solid color($theme-color-base-lighter);
+
+      img {
+        min-height: 125px;
+        min-width: 195px;
+        object-fit: cover;
+      }
+    }
+  }
+
   .usa-checkbox__label:before {
     border-radius: 0 !important;
   }

--- a/app/assets/stylesheets/dm/pages/_search.scss
+++ b/app/assets/stylesheets/dm/pages/_search.scss
@@ -1,5 +1,11 @@
 // Styles for the practice search page
 #search-page {
+
+  .applied-filter {
+    @include transition-btn-colors;
+    border-radius: 2px;
+  }
+
   .usa-checkbox__label:before {
     border-radius: 0 !important;
   }

--- a/app/views/practices/_search.js.erb
+++ b/app/views/practices/_search.js.erb
@@ -718,7 +718,7 @@ function searchPracticesPage() {
         }
 
         // Print the number of results for the query
-        resultsSummary.innerHTML = results.length + ' result' + (results.length === 1 ? ':' : 's:');
+        resultsSummary.innerHTML = results.length + ' Result' + (results.length === 1 ? ':' : 's:');
 
         // Highlight results (only Fuse.js matching)
         results.forEach(function (result) {

--- a/app/views/practices/search.html.erb
+++ b/app/views/practices/search.html.erb
@@ -18,7 +18,7 @@
   <div class="grid-row">
     <div class="grid-col-12">
       <h2 class="usa-prose-h2">Search Results {for: search string}</h2>
-      <span class="display-block desktop:display-inline">{NUMBER} Results:</span> <span class="applied-filter display-block desktop:display-inline usa-tag usa-tag--big">{Filter applied style 1}</span> <span class="applied-filter display-block desktop:display-inline usa-tag usa-tag--big">{Filter applied style 2}</span><span class="applied-filter display-block desktop:display-inline usa-tag usa-tag--big">{Filter applied style 3}</span><span class="applied-filter display-block desktop:display-inline usa-tag usa-tag--big">{Filter applied style 4}</span>
+      <span id="results-summary" class="display-block desktop:display-inline">Results:</span> <span class="applied-filter display-block desktop:display-inline usa-tag usa-tag--big">{Filter applied style 1}</span> <span class="applied-filter display-block desktop:display-inline usa-tag usa-tag--big">{Filter applied style 2}</span><span class="applied-filter display-block desktop:display-inline usa-tag usa-tag--big">{Filter applied style 3}</span><span class="applied-filter display-block desktop:display-inline usa-tag usa-tag--big">{Filter applied style 4}</span>
       <button type="button" class="usa-button usa-button--unstyled" id="resetSearchFiltersButton">
       Clear filters
       </button>

--- a/app/views/practices/search.html.erb
+++ b/app/views/practices/search.html.erb
@@ -18,7 +18,7 @@
   <div class="grid-row">
     <div class="grid-col-12">
       <h2 class="usa-prose-h2">Search Results {for: search string}</h2>
-      <span class="display-block desktop:display-inline">{NUMBER} Results:</span> <span class="display-block desktop:display-inline usa-tag usa-tag--big">{Filter applied style 1}</span> <span class="display-block desktop:display-inline usa-tag usa-tag--big">{Filter applied style 2}</span><span class="display-block desktop:display-inline usa-tag usa-tag--big">{Filter applied style 3}</span><span class="display-block desktop:display-inline usa-tag usa-tag--big">{Filter applied style 4}</span>
+      <span class="display-block desktop:display-inline">{NUMBER} Results:</span> <span class="applied-filter display-block desktop:display-inline usa-tag usa-tag--big">{Filter applied style 1}</span> <span class="applied-filter display-block desktop:display-inline usa-tag usa-tag--big">{Filter applied style 2}</span><span class="applied-filter display-block desktop:display-inline usa-tag usa-tag--big">{Filter applied style 3}</span><span class="applied-filter display-block desktop:display-inline usa-tag usa-tag--big">{Filter applied style 4}</span>
       <button type="button" class="usa-button usa-button--unstyled" id="resetSearchFiltersButton">
       Clear filters
       </button>

--- a/app/views/practices/search.html.erb
+++ b/app/views/practices/search.html.erb
@@ -24,7 +24,200 @@
       </button>
     </div>
   </div>
-</div> <!-- END DM-4910 -->
+  </div> <!-- END DM-4910 -->
+
+  <div class="grid-container">
+    <div class="grid-row grid-gap">
+      <!-- START DM- 4912-->
+      <div id="REPLACE-with-something-about-filters" class="grid-col-12 tablet:grid-col-4 desktop:grid-col-4">
+        <div class="usa-accordion usa-accordion--bordered">
+          <h2 class="usa-accordion__heading">
+            <button
+              type="button"
+              class="usa-accordion__button"
+              aria-expanded="true"
+              aria-controls="filtersAccordion"
+            >
+              Filter Results
+            </button>
+          </h2>
+        <div id="filtersAccordion" class="usa-accordion__content usa-prose">
+          <fieldset class="usa-fieldset">
+            <legend class="usa-legend">Communities</legend>
+            <div class="usa-checkbox">
+              <input
+                class="usa-checkbox__input"
+                id="check-historical-truth"
+                type="checkbox"
+                name="historical-figures"
+                value="sojourner-truth"
+                checked="checked"
+              />
+              <label class="usa-checkbox__label" for="check-historical-truth"
+                >Sojourner Truth</label
+              >
+            </div>
+            <div class="usa-checkbox">
+              <input
+                class="usa-checkbox__input"
+                id="check-historical-douglass"
+                type="checkbox"
+                name="historical-figures"
+                value="frederick-douglass"
+              />
+              <label class="usa-checkbox__label" for="check-historical-douglass"
+                >Frederick Douglass</label
+              >
+            </div>
+            <div class="usa-checkbox">
+              <input
+                class="usa-checkbox__input"
+                id="check-historical-washington"
+                type="checkbox"
+                name="historical-figures"
+                value="booker-t-washington"
+              />
+              <label class="usa-checkbox__label" for="check-historical-washington"
+                >Booker T. Washington</label
+              >
+            </div>
+          </fieldset>
+          <fieldset class="usa-fieldset">
+            <legend class="usa-legend">Tags</legend>
+            <div class="usa-checkbox">
+              <input
+                class="usa-checkbox__input"
+                id="check-historical-truth"
+                type="checkbox"
+                name="historical-figures"
+                value="sojourner-truth"
+                checked="checked"
+              />
+              <label class="usa-checkbox__label" for="check-historical-truth"
+                >Sojourner Truth</label
+              >
+            </div>
+            <div class="usa-checkbox">
+              <input
+                class="usa-checkbox__input"
+                id="check-historical-douglass"
+                type="checkbox"
+                name="historical-figures"
+                value="frederick-douglass"
+              />
+              <label class="usa-checkbox__label" for="check-historical-douglass"
+                >Frederick Douglass</label
+              >
+            </div>
+            <div class="usa-checkbox">
+              <input
+                class="usa-checkbox__input"
+                id="check-historical-washington"
+                type="checkbox"
+                name="historical-figures"
+                value="booker-t-washington"
+              />
+              <label class="usa-checkbox__label" for="check-historical-washington"
+                >ADD SCROLLBARS for long list</label
+              >
+            </div>
+          </fieldset>
+          <fieldset class="usa-fieldset">
+            <legend class="usa-legend usa-legend">Sort by</legend>
+            <div class="usa-radio">
+              <input
+                class="usa-radio__input"
+                id="historical-truth"
+                type="radio"
+                name="historical-figures"
+                value="sojourner-truth"
+                checked="checked"
+              />
+              <label class="usa-radio__label" for="historical-truth"
+                >Sojourner Truth</label
+              >
+            </div>
+            <div class="usa-radio">
+              <input
+                class="usa-radio__input"
+                id="historical-douglass"
+                type="radio"
+                name="historical-figures"
+                value="frederick-douglass"
+              />
+              <label class="usa-radio__label" for="historical-douglass"
+                >Frederick Douglass</label
+              >
+            </div>
+            <div class="usa-radio">
+              <input
+                class="usa-radio__input"
+                id="historical-washington"
+                type="radio"
+                name="historical-figures"
+                value="booker-t-washington"
+              />
+              <label class="usa-radio__label" for="historical-washington"
+                >Booker T. Washington</label
+              >
+            </div>
+          </fieldset>
+          <!-- TODO: use combobox w/ arrow styling from original partial --> 
+          <label class="usa-label" for="fruit">Originating location</label>
+          <div class="usa-combo-box">
+            <select class="usa-select" name="fruit" id="fruit">
+              <option value>Originating Location</option>
+              <option value="apple">VA Medical Center</option>
+              <option value="apricot">Clinical Resource Hub</option>
+            </select>
+          </div>
+          <!-- TODO: use combobox w/ arrow styling from original partial --> 
+          <label class="usa-label" for="fruit">Adopting location</label>
+          <div class="usa-combo-box">
+            <select class="usa-select" name="fruit" id="fruit">
+              <option value>Adopting Location</option>
+              <option value="apple">VA Medical Center</option>
+              <option value="apricot">Clinical Resource Hub</option>
+            </select>
+          </div>
+        </div>
+      </div> 
+    </div>
+      <!-- END DM-4912 -->
+      <!-- START DM-4913 -->
+      <div id="REPLACE-with-something-about-innovation-results" class="grid-col-12 tablet:grid-col-8 desktop:grid-col-8">
+        <h2 class="usa-prose-h2">Innovations</h2> <!-- TODO: set to "All Innovations" on empty search -->
+        <div class="innovation-preview grid-row padding-y-3"> <!-- TODO: make the entire section clickable as a link -->
+          <img src="#" class="bg-gray grid-col-3">
+          <div class="innovation-preview-body grid-col-fill">
+            <h3 class="usa-prose-h3 innovation-preview-title">{Innovation title}</h3>
+            <p class="innovation-preview-description margin-bottom-3">{Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. And here's stuff after an elipsis}</p>
+            <p class="innovation-preview-origin text-italic">By the Charles George Department of Veterans Affairs Medical Center (Ashville)</p>
+          </div>
+        </div>
+        <div class="innovation-preview grid-row padding-y-3"> <!-- TODO: make the entire section clickable as a link -->
+          <img src="#" class="bg-gray grid-col-3">
+          <div class="innovation-preview-body grid-col-fill">
+            <h3 class="usa-prose-h3 innovation-preview-title">{Innovation title}</h3>
+            <p class="innovation-preview-description margin-bottom-3">{Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. And here's stuff after an elipsis}</p>
+            <p class="innovation-preview-origin text-italic">By the {Facility Long Name} (Facility shortname)</p>
+          </div>
+        </div>
+        <div class="innovation-preview grid-row padding-y-3"> <!-- TODO: make the entire section clickable as a link -->
+          <img src="#" class="bg-gray grid-col-3">
+          <div class="innovation-preview-body grid-col-fill">
+          <h3 class="usa-prose-h3 innovation-preview-title">{Innovation title}</h3>
+          <p class="innovation-preview-description margin-bottom-3">{Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. And here's stuff after an elipsis}</p>
+          <p class="innovation-preview-origin text-italic">By {Non-facility Origin}</p>
+          </div>
+        </div>
+        <button class="usa-button dm-button--outline-secondary">{Load more}</button>
+      </div>
+      <!-- END DM-4913 -->
+    </div>
+  </div>
+
+
   <section class="grid-container margin-bottom-neg-3 margin-top-5">
     <%= render partial: "shared/messages", locals: {small_text: false} %>
     <form id="update-search-results-form">

--- a/app/views/practices/search.html.erb
+++ b/app/views/practices/search.html.erb
@@ -14,6 +14,17 @@
 <% end %>
 
 <div id="search-page">
+  <div class="grid-container"> <!-- START DM-4910 -->
+  <div class="grid-row">
+    <div class="grid-col-12">
+      <h2 class="usa-prose-h2">Search Results {for: search string}</h2>
+      <span class="display-block desktop:display-inline">{NUMBER} Results:</span> <span class="display-block desktop:display-inline usa-tag usa-tag--big">{Filter applied style 1}</span> <span class="display-block desktop:display-inline usa-tag usa-tag--big">{Filter applied style 2}</span><span class="display-block desktop:display-inline usa-tag usa-tag--big">{Filter applied style 3}</span><span class="display-block desktop:display-inline usa-tag usa-tag--big">{Filter applied style 4}</span>
+      <button type="button" class="usa-button usa-button--unstyled" id="resetSearchFiltersButton">
+      Clear filters
+      </button>
+    </div>
+  </div>
+</div> <!-- END DM-4910 -->
   <section class="grid-container margin-bottom-neg-3 margin-top-5">
     <%= render partial: "shared/messages", locals: {small_text: false} %>
     <form id="update-search-results-form">

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -234,7 +234,7 @@ describe 'Search', type: :feature do
       fill_in('dm-practice-search-field', with: 'practice')
       find('#dm-practice-search-button').click
 
-      expect(page).to have_content('13 results')
+      expect(page).to have_content('13 Results')
       expect(page).to_not have_content(@practice2.name)
 
       # show practices that are approved/published
@@ -244,7 +244,7 @@ describe 'Search', type: :feature do
       search
 
       expect(page).to be_accessible.according_to :wcag2a, :section508
-      expect(page).to have_content('14 results')
+      expect(page).to have_content('14 Results')
       expect(page).to have_content(@practice2.name)
     end
 
@@ -255,7 +255,7 @@ describe 'Search', type: :feature do
       find('#dm-practice-search-button').click
 
       expect(page).to have_content(@practice.name)
-      expect(page).to have_content('1 result')
+      expect(page).to have_content('1 Result')
     end
 
     it 'should be able to search based on practice categories related terms' do
@@ -266,7 +266,7 @@ describe 'Search', type: :feature do
       fill_in('dm-practice-search-field', with: 'Coronavirus')
       find('#dm-practice-search-button').click
 
-      expect(page).to have_content('5 results')
+      expect(page).to have_content('5 Results')
       expect(page).to have_content(@practice.name)
       expect(page).to have_content(@practice3.name)
       expect(page).to have_content(@practice5.name)
@@ -283,7 +283,7 @@ describe 'Search', type: :feature do
       find('#dm-practice-search-button').click
 
       expect(page).to have_content(@practice.name)
-      expect(page).to have_content('1 result')
+      expect(page).to have_content('1 Result')
     end
 
     it 'should be able to search based on originating facility name' do
@@ -292,7 +292,7 @@ describe 'Search', type: :feature do
       fill_in('dm-practice-search-field', with: 'Togus VA Medical Center')
       find('#dm-practice-search-button').click
 
-      expect(page).to have_content('2 results')
+      expect(page).to have_content('2 Results')
       expect(page).to have_content(@practice3.name)
       expect(page).to have_content(@practice5.name)
     end
@@ -301,19 +301,19 @@ describe 'Search', type: :feature do
       visit_search_page
       fill_in('dm-practice-search-field', with: 'overview problem foobar')
       find('#dm-practice-search-button').click
-      expect(page).to have_content('1 result')
+      expect(page).to have_content('1 Result')
       expect(page).to have_content(@practice.name)
 
       visit_search_page
       fill_in('dm-practice-search-field', with: 'overview solution fizzbuzz')
       find('#dm-practice-search-button').click
-      expect(page).to have_content('1 result')
+      expect(page).to have_content('1 Result')
       expect(page).to have_content(@practice3.name)
 
       visit_search_page
       fill_in('dm-practice-search-field', with: 'overview results mixmax')
       find('#dm-practice-search-button').click
-      expect(page).to have_content('1 result')
+      expect(page).to have_content('1 Result')
       expect(page).to have_content(@practice5.name)
     end
 
@@ -324,12 +324,12 @@ describe 'Search', type: :feature do
 
       fill_in('dm-practice-search-field', with: 'important')
       search
-      expect(page).to have_content('1 result')
+      expect(page).to have_content('1 Result')
       expect(page).to have_content('The Most Important Practice')
 
       fill_in('dm-practice-search-field', with: 'Rule')
       search
-      expect(page).to_not have_content('results')
+      expect(page).to_not have_content('Results')
       expect(page).to_not have_content('One Practice to Rule Them All')
       expect(page).to have_content('There are currently no matches for your search on the Marketplace.')
 
@@ -345,7 +345,7 @@ describe 'Search', type: :feature do
 
       fill_in('dm-practice-search-field', with: 'Rule')
       search
-      expect(page).to have_content('1 result')
+      expect(page).to have_content('1 Result')
       expect(page).to have_content('One Practice to Rule Them All')
       expect(page).to_not have_content('There are currently no matches for your search on the Marketplace.')
     end
@@ -361,7 +361,7 @@ describe 'Search', type: :feature do
         update_results
 
         expect(page).to have_content('Filters (3)')
-        expect(page).to have_content('6 results')
+        expect(page).to have_content('6 Results')
         expect(page).to have_content(@practice.name)
         expect(page).to have_content(@practice3.name)
         expect(page).to have_content(@practice5.name)
@@ -379,7 +379,7 @@ describe 'Search', type: :feature do
         set_combobox_val(0, 'VISN 8 Clinical Resource Hub (Remote)')
         update_results
 
-        expect(page).to have_content('2 results')
+        expect(page).to have_content('2 Results')
         expect(page).to have_content(@practice13.name)
         expect(page).to have_content(@practice14.name)
 
@@ -388,7 +388,7 @@ describe 'Search', type: :feature do
         set_combobox_val(1, 'VISN 8 Clinical Resource Hub (Remote)')
         update_results
 
-        expect(page).to have_content('2 results')
+        expect(page).to have_content('2 Results')
         expect(page).to have_content(@practice12.name)
         expect(page).to have_content(@practice14.name)
       end
@@ -403,7 +403,7 @@ describe 'Search', type: :feature do
         expect(find("#cat-5-input", visible: false)).to be_checked
         expect(find("#cat-6-input", visible: false)).to be_checked
         update_results
-        expect(page).to have_content('7 results')
+        expect(page).to have_content('7 Results')
         toggle_filters_accordion
         select_category('.cat-2-label')
         expect(find("#cat-all-strategic-input", visible: false)).to_not be_checked
@@ -413,7 +413,7 @@ describe 'Search', type: :feature do
         expect(find("#cat-5-input", visible: false)).to be_checked
         expect(find("#cat-6-input", visible: false)).to be_checked
         update_results
-        expect(page).to have_content('5 results')
+        expect(page).to have_content('5 Results')
       end
 
       it 'should collect practices that match ALL of the conditions if the user selects filters AND uses the search input' do
@@ -426,7 +426,7 @@ describe 'Search', type: :feature do
         select_category('.cat-2-label')
         search
         expect(page).to have_content('Filters (2)')
-        expect(page).to have_content('2 results')
+        expect(page).to have_content('2 Results')
         expect(page).to have_content(@practice3.name)
         expect(page).to have_content(@practice5.name)
 
@@ -436,7 +436,7 @@ describe 'Search', type: :feature do
         update_results
 
         expect(page).to have_content('Filters (3)')
-        expect(page).to have_content('1 result')
+        expect(page).to have_content('1 Result')
         expect(page).to have_content(@practice3.name)
         expect(page).to_not have_content(@practice5.name)
 
@@ -447,7 +447,7 @@ describe 'Search', type: :feature do
         update_results
 
         expect(page).to have_content('Filters (1)')
-        expect(page).to have_content('4 results')
+        expect(page).to have_content('4 Results')
         expect(page).to have_content(@practice3.name)
         expect(page).to have_content(@practice4.name)
         expect(page).to have_content(@practice5.name)
@@ -458,7 +458,7 @@ describe 'Search', type: :feature do
         update_results
 
         expect(page).to have_content('Filters (2)')
-        expect(page).to have_content('2 results')
+        expect(page).to have_content('2 Results')
         expect(page).to have_content(@practice4.name)
         expect(page).to have_content(@practice5.name)
 
@@ -469,7 +469,7 @@ describe 'Search', type: :feature do
         update_results
 
         expect(page).to have_content('Filters (1)')
-        expect(page).to have_content('1 result')
+        expect(page).to have_content('1 Result')
         expect(page).to have_content(@practice6.name)
 
         # search for practices with the search bar and clinical resource hub filters
@@ -483,7 +483,7 @@ describe 'Search', type: :feature do
         update_results
 
         expect(page).to have_content('Filters (2)')
-        expect(page).to have_content('1 result')
+        expect(page).to have_content('1 Result')
         expect(page).to have_content(@practice14.name)
       end
 
@@ -496,7 +496,7 @@ describe 'Search', type: :feature do
           update_results
 
           expect(page).to have_content('Filters (1)')
-          expect(page).to have_content('4 results')
+          expect(page).to have_content('4 Results')
           expect(page).to have_content(@practice3.name)
           expect(page).to have_content(@practice3.name)
           expect(page).to have_content(@practice5.name)
@@ -511,7 +511,7 @@ describe 'Search', type: :feature do
           update_results
 
           expect(page).to have_content('Filters (1)')
-          expect(page).to have_content('2 results')
+          expect(page).to have_content('2 Results')
           expect(page).to have_content(@practice13.name)
           expect(page).to have_content(@practice14.name)
         end
@@ -523,7 +523,7 @@ describe 'Search', type: :feature do
           set_combobox_val(0, 'Vinita VA Clinic')
           update_results
 
-          expect(page).to have_content('1 result')
+          expect(page).to have_content('1 Result')
           expect(page).to have_content(@practice12.name)
         end
       end
@@ -536,7 +536,7 @@ describe 'Search', type: :feature do
           set_combobox_val(1, 'VISN-23')
           update_results
 
-          expect(page).to have_content('2 results')
+          expect(page).to have_content('2 Results')
           expect(page).to have_content(@practice.name)
           expect(page).to have_content(@practice3.name)
 
@@ -549,7 +549,7 @@ describe 'Search', type: :feature do
           update_results
 
           expect(page).to have_content('Filters (1)')
-          expect(page).to have_content('2 results')
+          expect(page).to have_content('2 Results')
           expect(page).to have_content(@practice12.name)
           expect(page).to have_content(@practice14.name)
         end
@@ -561,7 +561,7 @@ describe 'Search', type: :feature do
           set_combobox_val(0, 'Vinita VA Clinic')
           update_results
 
-          expect(page).to have_content('1 result')
+          expect(page).to have_content('1 Result')
           expect(page).to have_content(@practice12.name)
         end
       end
@@ -577,7 +577,7 @@ describe 'Search', type: :feature do
         update_results
 
         # results should be sorted my most relevant(closest match) by default
-        expect(page).to have_content('6 results')
+        expect(page).to have_content('6 Results')
         expect(first('span.dm-practice-title').text).to eq(@practice6.name)
 
         toggle_filters_accordion
@@ -585,7 +585,7 @@ describe 'Search', type: :feature do
         select_category('.cat-4-label')
         update_results
 
-        expect(page).to have_content('6 results')
+        expect(page).to have_content('6 Results')
         expect(first('span.dm-practice-title').text).to_not eq(@practice6.name)
         expect(first('span.dm-practice-title').text).to eq(@practice4.name)
 
@@ -622,7 +622,7 @@ describe 'Search', type: :feature do
         fill_in('dm-practice-search-field', with: 'practice')
         search
 
-        expect(page).to have_content('13 results')
+        expect(page).to have_content('13 Results')
         expect(page).to have_selector('div.dm-practice-card', count: 12)
 
         # show the next set of 12 results
@@ -750,7 +750,7 @@ describe 'Search', type: :feature do
       select_category('.cat-5-label')
       update_results
 
-      expect(page).to have_content('5 results')
+      expect(page).to have_content('5 Results')
       expect(page).to have_content(@practice.name)
       expect(page).to have_content(@practice3.name)
       expect(page).to have_content(@practice5.name)


### PR DESCRIPTION
### JIRA issue link
DM-4935

## Description - what does this code do?
- HTML and CSS templates for the new search results layout. Use this as a starting point for the relevant subtasks. Most of the work is going to be making sure that the JS is pointing at the relevant elements.

## Testing done - how did you test it/steps on how can another person can test it 


## Screenshots, Gifs, Videos from application (if applicable)

![Screenshot 2024-07-05 at 6 41 47 PM](https://github.com/department-of-veterans-affairs/diffusion-marketplace/assets/5402927/cdf7fac8-9f6a-434b-a161-5e24d1e3a7c5)

## Link to mock-ups/mock ups (image file if you have it) (if applicable)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Unit tests written (if applicable)
- [ ] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating JIRA issue
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs