### PR TITLE
Dm 4910 update search page headers

### DIFF
--- a/app/assets/stylesheets/dm/pages/_search.scss
+++ b/app/assets/stylesheets/dm/pages/_search.scss
@@ -6,6 +6,24 @@
     border-radius: 2px;
   }
 
+  #REPLACE-with-something-about-filters {
+    .usa-accordion {
+      width: unset;
+    }
+  }
+
+  #REPLACE-with-something-about-innovation-results {
+    .innovation-preview {
+      border-top: 1px solid color($theme-color-base-lighter);
+
+      img {
+        min-height: 125px;
+        min-width: 195px;
+        object-fit: cover;
+      }
+    }
+  }
+
   .usa-checkbox__label:before {
     border-radius: 0 !important;
   }

--- a/app/assets/stylesheets/dm/pages/_search.scss
+++ b/app/assets/stylesheets/dm/pages/_search.scss
@@ -1,5 +1,11 @@
 // Styles for the practice search page
 #search-page {
+
+  .applied-filter {
+    @include transition-btn-colors;
+    border-radius: 2px;
+  }
+
   .usa-checkbox__label:before {
     border-radius: 0 !important;
   }

--- a/app/views/practices/_search.js.erb
+++ b/app/views/practices/_search.js.erb
@@ -718,7 +718,7 @@ function searchPracticesPage() {
         }
 
         // Print the number of results for the query
-        resultsSummary.innerHTML = results.length + ' result' + (results.length === 1 ? ':' : 's:');
+        resultsSummary.innerHTML = results.length + ' Result' + (results.length === 1 ? ':' : 's:');
 
         // Highlight results (only Fuse.js matching)
         results.forEach(function (result) {

--- a/app/views/practices/_search.js.erb
+++ b/app/views/practices/_search.js.erb
@@ -283,8 +283,11 @@ function searchPracticesPage() {
         // set the search page search bar input value
         searchField.value = query;
 
+        const searchHeader = document.getElementById('searchHeader');
         if (query) {
             trackSearchField(query);
+            searchHeader.textContent = `Search Results for: ${query}`;
+
             var searchBarQueryArray = [];
             search_options.keys.forEach(function(practiceKey) {
                 var queryObj = {};
@@ -292,6 +295,7 @@ function searchPracticesPage() {
                 return searchBarQueryArray.push(queryObj);
             });
         } else {
+            searchHeader.textContent = "Search";
             if (searchLocation[0] === '?filter_by') {
                 trackSearchByFilter(searchLocation[1]);
             }

--- a/app/views/practices/search.html.erb
+++ b/app/views/practices/search.html.erb
@@ -15,15 +15,32 @@
 
 <div id="search-page">
   <div class="grid-container"> <!-- START DM-4910 -->
-  <div class="grid-row">
-    <div class="grid-col-12">
-      <h2 class="usa-prose-h2">Search Results {for: search string}</h2>
-      <span id="results-summary" class="display-block desktop:display-inline">Results:</span> <span class="applied-filter display-block desktop:display-inline usa-tag usa-tag--big">{Filter applied style 1}</span> <span class="applied-filter display-block desktop:display-inline usa-tag usa-tag--big">{Filter applied style 2}</span><span class="applied-filter display-block desktop:display-inline usa-tag usa-tag--big">{Filter applied style 3}</span><span class="applied-filter display-block desktop:display-inline usa-tag usa-tag--big">{Filter applied style 4}</span>
-      <button type="button" class="usa-button usa-button--unstyled" id="resetSearchFiltersButton">
-      Clear filters
-      </button>
+    <div class="grid-row">
+      <div class="grid-col-12">
+        <% if params["query"] %>
+          <h2 class="usa-prose-h2" id="search-results-thingie">Search Results for: <%= params["query"] %></h2>
+          <span
+            id="results-summary"
+            class="display-block desktop:display-inline">Results:
+          </span>
+          <span class="applied-filter display-block desktop:display-inline usa-tag usa-tag--big">
+            {Filter applied style 1}
+          </span>
+          <span class="applied-filter display-block desktop:display-inline usa-tag usa-tag--big">
+            {Filter applied style 2}
+            </span>
+          <span class="applied-filter display-block desktop:display-inline usa-tag usa-tag--big">
+            {Filter applied style 3}
+          </span>
+          <span class="applied-filter display-block desktop:display-inline usa-tag usa-tag--big">
+            {Filter applied style 4}
+          </span>
+          <button type="button" class="usa-button usa-button--unstyled" id="resetSearchFiltersButton">
+            Clear filters
+          </button>
+        <% end %>
+      </div>
     </div>
-  </div>
   </div> <!-- END DM-4910 -->
 
   <div class="grid-container">
@@ -162,7 +179,7 @@
               >
             </div>
           </fieldset>
-          <!-- TODO: use combobox w/ arrow styling from original partial --> 
+          <!-- TODO: use combobox w/ arrow styling from original partial -->
           <label class="usa-label" for="fruit">Originating location</label>
           <div class="usa-combo-box">
             <select class="usa-select" name="fruit" id="fruit">
@@ -171,7 +188,7 @@
               <option value="apricot">Clinical Resource Hub</option>
             </select>
           </div>
-          <!-- TODO: use combobox w/ arrow styling from original partial --> 
+          <!-- TODO: use combobox w/ arrow styling from original partial -->
           <label class="usa-label" for="fruit">Adopting location</label>
           <div class="usa-combo-box">
             <select class="usa-select" name="fruit" id="fruit">
@@ -181,7 +198,7 @@
             </select>
           </div>
         </div>
-      </div> 
+      </div>
     </div>
       <!-- END DM-4912 -->
       <!-- START DM-4913 -->

--- a/app/views/practices/search.html.erb
+++ b/app/views/practices/search.html.erb
@@ -18,7 +18,7 @@
   <div class="grid-row">
     <div class="grid-col-12">
       <h2 class="usa-prose-h2">Search Results {for: search string}</h2>
-      <span class="display-block desktop:display-inline">{NUMBER} Results:</span> <span class="applied-filter display-block desktop:display-inline usa-tag usa-tag--big">{Filter applied style 1}</span> <span class="applied-filter display-block desktop:display-inline usa-tag usa-tag--big">{Filter applied style 2}</span><span class="applied-filter display-block desktop:display-inline usa-tag usa-tag--big">{Filter applied style 3}</span><span class="applied-filter display-block desktop:display-inline usa-tag usa-tag--big">{Filter applied style 4}</span>
+      <span id="results-summary" class="display-block desktop:display-inline">Results:</span> <span class="applied-filter display-block desktop:display-inline usa-tag usa-tag--big">{Filter applied style 1}</span> <span class="applied-filter display-block desktop:display-inline usa-tag usa-tag--big">{Filter applied style 2}</span><span class="applied-filter display-block desktop:display-inline usa-tag usa-tag--big">{Filter applied style 3}</span><span class="applied-filter display-block desktop:display-inline usa-tag usa-tag--big">{Filter applied style 4}</span>
       <button type="button" class="usa-button usa-button--unstyled" id="resetSearchFiltersButton">
       Clear filters
       </button>

--- a/app/views/practices/search.html.erb
+++ b/app/views/practices/search.html.erb
@@ -18,7 +18,7 @@
   <div class="grid-row">
     <div class="grid-col-12">
       <h2 class="usa-prose-h2">Search Results {for: search string}</h2>
-      <span class="display-block desktop:display-inline">{NUMBER} Results:</span> <span class="display-block desktop:display-inline usa-tag usa-tag--big">{Filter applied style 1}</span> <span class="display-block desktop:display-inline usa-tag usa-tag--big">{Filter applied style 2}</span><span class="display-block desktop:display-inline usa-tag usa-tag--big">{Filter applied style 3}</span><span class="display-block desktop:display-inline usa-tag usa-tag--big">{Filter applied style 4}</span>
+      <span class="display-block desktop:display-inline">{NUMBER} Results:</span> <span class="applied-filter display-block desktop:display-inline usa-tag usa-tag--big">{Filter applied style 1}</span> <span class="applied-filter display-block desktop:display-inline usa-tag usa-tag--big">{Filter applied style 2}</span><span class="applied-filter display-block desktop:display-inline usa-tag usa-tag--big">{Filter applied style 3}</span><span class="applied-filter display-block desktop:display-inline usa-tag usa-tag--big">{Filter applied style 4}</span>
       <button type="button" class="usa-button usa-button--unstyled" id="resetSearchFiltersButton">
       Clear filters
       </button>

--- a/app/views/practices/search.html.erb
+++ b/app/views/practices/search.html.erb
@@ -24,7 +24,200 @@
       </button>
     </div>
   </div>
-</div> <!-- END DM-4910 -->
+  </div> <!-- END DM-4910 -->
+
+  <div class="grid-container">
+    <div class="grid-row grid-gap">
+      <!-- START DM- 4912-->
+      <div id="REPLACE-with-something-about-filters" class="grid-col-12 tablet:grid-col-4 desktop:grid-col-4">
+        <div class="usa-accordion usa-accordion--bordered">
+          <h2 class="usa-accordion__heading">
+            <button
+              type="button"
+              class="usa-accordion__button"
+              aria-expanded="true"
+              aria-controls="filtersAccordion"
+            >
+              Filter Results
+            </button>
+          </h2>
+        <div id="filtersAccordion" class="usa-accordion__content usa-prose">
+          <fieldset class="usa-fieldset">
+            <legend class="usa-legend">Communities</legend>
+            <div class="usa-checkbox">
+              <input
+                class="usa-checkbox__input"
+                id="check-historical-truth"
+                type="checkbox"
+                name="historical-figures"
+                value="sojourner-truth"
+                checked="checked"
+              />
+              <label class="usa-checkbox__label" for="check-historical-truth"
+                >Sojourner Truth</label
+              >
+            </div>
+            <div class="usa-checkbox">
+              <input
+                class="usa-checkbox__input"
+                id="check-historical-douglass"
+                type="checkbox"
+                name="historical-figures"
+                value="frederick-douglass"
+              />
+              <label class="usa-checkbox__label" for="check-historical-douglass"
+                >Frederick Douglass</label
+              >
+            </div>
+            <div class="usa-checkbox">
+              <input
+                class="usa-checkbox__input"
+                id="check-historical-washington"
+                type="checkbox"
+                name="historical-figures"
+                value="booker-t-washington"
+              />
+              <label class="usa-checkbox__label" for="check-historical-washington"
+                >Booker T. Washington</label
+              >
+            </div>
+          </fieldset>
+          <fieldset class="usa-fieldset">
+            <legend class="usa-legend">Tags</legend>
+            <div class="usa-checkbox">
+              <input
+                class="usa-checkbox__input"
+                id="check-historical-truth"
+                type="checkbox"
+                name="historical-figures"
+                value="sojourner-truth"
+                checked="checked"
+              />
+              <label class="usa-checkbox__label" for="check-historical-truth"
+                >Sojourner Truth</label
+              >
+            </div>
+            <div class="usa-checkbox">
+              <input
+                class="usa-checkbox__input"
+                id="check-historical-douglass"
+                type="checkbox"
+                name="historical-figures"
+                value="frederick-douglass"
+              />
+              <label class="usa-checkbox__label" for="check-historical-douglass"
+                >Frederick Douglass</label
+              >
+            </div>
+            <div class="usa-checkbox">
+              <input
+                class="usa-checkbox__input"
+                id="check-historical-washington"
+                type="checkbox"
+                name="historical-figures"
+                value="booker-t-washington"
+              />
+              <label class="usa-checkbox__label" for="check-historical-washington"
+                >ADD SCROLLBARS for long list</label
+              >
+            </div>
+          </fieldset>
+          <fieldset class="usa-fieldset">
+            <legend class="usa-legend usa-legend">Sort by</legend>
+            <div class="usa-radio">
+              <input
+                class="usa-radio__input"
+                id="historical-truth"
+                type="radio"
+                name="historical-figures"
+                value="sojourner-truth"
+                checked="checked"
+              />
+              <label class="usa-radio__label" for="historical-truth"
+                >Sojourner Truth</label
+              >
+            </div>
+            <div class="usa-radio">
+              <input
+                class="usa-radio__input"
+                id="historical-douglass"
+                type="radio"
+                name="historical-figures"
+                value="frederick-douglass"
+              />
+              <label class="usa-radio__label" for="historical-douglass"
+                >Frederick Douglass</label
+              >
+            </div>
+            <div class="usa-radio">
+              <input
+                class="usa-radio__input"
+                id="historical-washington"
+                type="radio"
+                name="historical-figures"
+                value="booker-t-washington"
+              />
+              <label class="usa-radio__label" for="historical-washington"
+                >Booker T. Washington</label
+              >
+            </div>
+          </fieldset>
+          <!-- TODO: use combobox w/ arrow styling from original partial --> 
+          <label class="usa-label" for="fruit">Originating location</label>
+          <div class="usa-combo-box">
+            <select class="usa-select" name="fruit" id="fruit">
+              <option value>Originating Location</option>
+              <option value="apple">VA Medical Center</option>
+              <option value="apricot">Clinical Resource Hub</option>
+            </select>
+          </div>
+          <!-- TODO: use combobox w/ arrow styling from original partial --> 
+          <label class="usa-label" for="fruit">Adopting location</label>
+          <div class="usa-combo-box">
+            <select class="usa-select" name="fruit" id="fruit">
+              <option value>Adopting Location</option>
+              <option value="apple">VA Medical Center</option>
+              <option value="apricot">Clinical Resource Hub</option>
+            </select>
+          </div>
+        </div>
+      </div> 
+    </div>
+      <!-- END DM-4912 -->
+      <!-- START DM-4913 -->
+      <div id="REPLACE-with-something-about-innovation-results" class="grid-col-12 tablet:grid-col-8 desktop:grid-col-8">
+        <h2 class="usa-prose-h2">Innovations</h2> <!-- TODO: set to "All Innovations" on empty search -->
+        <div class="innovation-preview grid-row padding-y-3"> <!-- TODO: make the entire section clickable as a link -->
+          <img src="#" class="bg-gray grid-col-3">
+          <div class="innovation-preview-body grid-col-fill">
+            <h3 class="usa-prose-h3 innovation-preview-title">{Innovation title}</h3>
+            <p class="innovation-preview-description margin-bottom-3">{Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. And here's stuff after an elipsis}</p>
+            <p class="innovation-preview-origin text-italic">By the Charles George Department of Veterans Affairs Medical Center (Ashville)</p>
+          </div>
+        </div>
+        <div class="innovation-preview grid-row padding-y-3"> <!-- TODO: make the entire section clickable as a link -->
+          <img src="#" class="bg-gray grid-col-3">
+          <div class="innovation-preview-body grid-col-fill">
+            <h3 class="usa-prose-h3 innovation-preview-title">{Innovation title}</h3>
+            <p class="innovation-preview-description margin-bottom-3">{Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. And here's stuff after an elipsis}</p>
+            <p class="innovation-preview-origin text-italic">By the {Facility Long Name} (Facility shortname)</p>
+          </div>
+        </div>
+        <div class="innovation-preview grid-row padding-y-3"> <!-- TODO: make the entire section clickable as a link -->
+          <img src="#" class="bg-gray grid-col-3">
+          <div class="innovation-preview-body grid-col-fill">
+          <h3 class="usa-prose-h3 innovation-preview-title">{Innovation title}</h3>
+          <p class="innovation-preview-description margin-bottom-3">{Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. And here's stuff after an elipsis}</p>
+          <p class="innovation-preview-origin text-italic">By {Non-facility Origin}</p>
+          </div>
+        </div>
+        <button class="usa-button dm-button--outline-secondary">{Load more}</button>
+      </div>
+      <!-- END DM-4913 -->
+    </div>
+  </div>
+
+
   <section class="grid-container margin-bottom-neg-3 margin-top-5">
     <%= render partial: "shared/messages", locals: {small_text: false} %>
     <form id="update-search-results-form">

--- a/app/views/practices/search.html.erb
+++ b/app/views/practices/search.html.erb
@@ -14,6 +14,17 @@
 <% end %>
 
 <div id="search-page">
+  <div class="grid-container"> <!-- START DM-4910 -->
+  <div class="grid-row">
+    <div class="grid-col-12">
+      <h2 class="usa-prose-h2">Search Results {for: search string}</h2>
+      <span class="display-block desktop:display-inline">{NUMBER} Results:</span> <span class="display-block desktop:display-inline usa-tag usa-tag--big">{Filter applied style 1}</span> <span class="display-block desktop:display-inline usa-tag usa-tag--big">{Filter applied style 2}</span><span class="display-block desktop:display-inline usa-tag usa-tag--big">{Filter applied style 3}</span><span class="display-block desktop:display-inline usa-tag usa-tag--big">{Filter applied style 4}</span>
+      <button type="button" class="usa-button usa-button--unstyled" id="resetSearchFiltersButton">
+      Clear filters
+      </button>
+    </div>
+  </div>
+</div> <!-- END DM-4910 -->
   <section class="grid-container margin-bottom-neg-3 margin-top-5">
     <%= render partial: "shared/messages", locals: {small_text: false} %>
     <form id="update-search-results-form">

--- a/app/views/practices/search.html.erb
+++ b/app/views/practices/search.html.erb
@@ -14,36 +14,18 @@
 <% end %>
 
 <div id="search-page">
-  <div class="grid-container"> <!-- START DM-4910 -->
-    <div class="grid-row">
+  <div class="grid-container" id="searchResultsContainer"> <!-- START DM-4910 -->
+    <div class="grid-row margin-bottom-5">
       <div class="grid-col-12">
-        <% if params["query"] %>
-          <h2 class="usa-prose-h2" id="search-results-thingie">Search Results for: <%= params["query"] %></h2>
-          <span
-            id="results-summary"
-            class="display-block desktop:display-inline">Results:
-          </span>
-          <span class="applied-filter display-block desktop:display-inline usa-tag usa-tag--big">
-            {Filter applied style 1}
-          </span>
-          <span class="applied-filter display-block desktop:display-inline usa-tag usa-tag--big">
-            {Filter applied style 2}
-            </span>
-          <span class="applied-filter display-block desktop:display-inline usa-tag usa-tag--big">
-            {Filter applied style 3}
-          </span>
-          <span class="applied-filter display-block desktop:display-inline usa-tag usa-tag--big">
-            {Filter applied style 4}
-          </span>
-          <button type="button" class="usa-button usa-button--unstyled" id="resetSearchFiltersButton">
-            Clear filters
-          </button>
-        <% end %>
+        <h2 class="usa-prose-h2 margin-bottom-5" id="searchHeader"> Search </h2>
+        <span id="results-summary" class="display-block desktop:display-inline">Results:</span>
+        <span class="applied-filter display-block desktop:display-inline usa-tag usa-tag--big" id="filterStyle1">{Filter applied style 1}</span>
+        <span class="applied-filter display-block desktop:display-inline usa-tag usa-tag--big" id="filterStyle2">{Filter applied style 2}</span>
+
+        <button type="button" class="usa-button usa-button--unstyled" id="resetSearchFiltersButton">Clear filters</button>
       </div>
     </div>
-  </div> <!-- END DM-4910 -->
 
-  <div class="grid-container">
     <div class="grid-row grid-gap">
       <!-- START DM- 4912-->
       <div id="REPLACE-with-something-about-filters" class="grid-col-12 tablet:grid-col-4 desktop:grid-col-4">
@@ -304,4 +286,3 @@
     <%= render partial: 'shared/search_no_results', locals: { display_no_query_msg: true } %>
   </section>
 </div>
-

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -234,7 +234,7 @@ describe 'Search', type: :feature do
       fill_in('dm-practice-search-field', with: 'practice')
       find('#dm-practice-search-button').click
 
-      expect(page).to have_content('13 results')
+      expect(page).to have_content('13 Results')
       expect(page).to_not have_content(@practice2.name)
 
       # show practices that are approved/published
@@ -244,7 +244,7 @@ describe 'Search', type: :feature do
       search
 
       expect(page).to be_accessible.according_to :wcag2a, :section508
-      expect(page).to have_content('14 results')
+      expect(page).to have_content('14 Results')
       expect(page).to have_content(@practice2.name)
     end
 
@@ -255,7 +255,7 @@ describe 'Search', type: :feature do
       find('#dm-practice-search-button').click
 
       expect(page).to have_content(@practice.name)
-      expect(page).to have_content('1 result')
+      expect(page).to have_content('1 Result')
     end
 
     it 'should be able to search based on practice categories related terms' do
@@ -266,7 +266,7 @@ describe 'Search', type: :feature do
       fill_in('dm-practice-search-field', with: 'Coronavirus')
       find('#dm-practice-search-button').click
 
-      expect(page).to have_content('5 results')
+      expect(page).to have_content('5 Results')
       expect(page).to have_content(@practice.name)
       expect(page).to have_content(@practice3.name)
       expect(page).to have_content(@practice5.name)
@@ -283,7 +283,7 @@ describe 'Search', type: :feature do
       find('#dm-practice-search-button').click
 
       expect(page).to have_content(@practice.name)
-      expect(page).to have_content('1 result')
+      expect(page).to have_content('1 Result')
     end
 
     it 'should be able to search based on originating facility name' do
@@ -292,7 +292,7 @@ describe 'Search', type: :feature do
       fill_in('dm-practice-search-field', with: 'Togus VA Medical Center')
       find('#dm-practice-search-button').click
 
-      expect(page).to have_content('2 results')
+      expect(page).to have_content('2 Results')
       expect(page).to have_content(@practice3.name)
       expect(page).to have_content(@practice5.name)
     end
@@ -301,19 +301,19 @@ describe 'Search', type: :feature do
       visit_search_page
       fill_in('dm-practice-search-field', with: 'overview problem foobar')
       find('#dm-practice-search-button').click
-      expect(page).to have_content('1 result')
+      expect(page).to have_content('1 Result')
       expect(page).to have_content(@practice.name)
 
       visit_search_page
       fill_in('dm-practice-search-field', with: 'overview solution fizzbuzz')
       find('#dm-practice-search-button').click
-      expect(page).to have_content('1 result')
+      expect(page).to have_content('1 Result')
       expect(page).to have_content(@practice3.name)
 
       visit_search_page
       fill_in('dm-practice-search-field', with: 'overview results mixmax')
       find('#dm-practice-search-button').click
-      expect(page).to have_content('1 result')
+      expect(page).to have_content('1 Result')
       expect(page).to have_content(@practice5.name)
     end
 
@@ -324,12 +324,12 @@ describe 'Search', type: :feature do
 
       fill_in('dm-practice-search-field', with: 'important')
       search
-      expect(page).to have_content('1 result')
+      expect(page).to have_content('1 Result')
       expect(page).to have_content('The Most Important Practice')
 
       fill_in('dm-practice-search-field', with: 'Rule')
       search
-      expect(page).to_not have_content('results')
+      expect(page).to_not have_content('Results')
       expect(page).to_not have_content('One Practice to Rule Them All')
       expect(page).to have_content('There are currently no matches for your search on the Marketplace.')
 
@@ -345,7 +345,7 @@ describe 'Search', type: :feature do
 
       fill_in('dm-practice-search-field', with: 'Rule')
       search
-      expect(page).to have_content('1 result')
+      expect(page).to have_content('1 Result')
       expect(page).to have_content('One Practice to Rule Them All')
       expect(page).to_not have_content('There are currently no matches for your search on the Marketplace.')
     end
@@ -361,7 +361,7 @@ describe 'Search', type: :feature do
         update_results
 
         expect(page).to have_content('Filters (3)')
-        expect(page).to have_content('6 results')
+        expect(page).to have_content('6 Results')
         expect(page).to have_content(@practice.name)
         expect(page).to have_content(@practice3.name)
         expect(page).to have_content(@practice5.name)
@@ -379,7 +379,7 @@ describe 'Search', type: :feature do
         set_combobox_val(0, 'VISN 8 Clinical Resource Hub (Remote)')
         update_results
 
-        expect(page).to have_content('2 results')
+        expect(page).to have_content('2 Results')
         expect(page).to have_content(@practice13.name)
         expect(page).to have_content(@practice14.name)
 
@@ -388,7 +388,7 @@ describe 'Search', type: :feature do
         set_combobox_val(1, 'VISN 8 Clinical Resource Hub (Remote)')
         update_results
 
-        expect(page).to have_content('2 results')
+        expect(page).to have_content('2 Results')
         expect(page).to have_content(@practice12.name)
         expect(page).to have_content(@practice14.name)
       end
@@ -403,7 +403,7 @@ describe 'Search', type: :feature do
         expect(find("#cat-5-input", visible: false)).to be_checked
         expect(find("#cat-6-input", visible: false)).to be_checked
         update_results
-        expect(page).to have_content('7 results')
+        expect(page).to have_content('7 Results')
         toggle_filters_accordion
         select_category('.cat-2-label')
         expect(find("#cat-all-strategic-input", visible: false)).to_not be_checked
@@ -413,7 +413,7 @@ describe 'Search', type: :feature do
         expect(find("#cat-5-input", visible: false)).to be_checked
         expect(find("#cat-6-input", visible: false)).to be_checked
         update_results
-        expect(page).to have_content('5 results')
+        expect(page).to have_content('5 Results')
       end
 
       it 'should collect practices that match ALL of the conditions if the user selects filters AND uses the search input' do
@@ -426,7 +426,7 @@ describe 'Search', type: :feature do
         select_category('.cat-2-label')
         search
         expect(page).to have_content('Filters (2)')
-        expect(page).to have_content('2 results')
+        expect(page).to have_content('2 Results')
         expect(page).to have_content(@practice3.name)
         expect(page).to have_content(@practice5.name)
 
@@ -436,7 +436,7 @@ describe 'Search', type: :feature do
         update_results
 
         expect(page).to have_content('Filters (3)')
-        expect(page).to have_content('1 result')
+        expect(page).to have_content('1 Result')
         expect(page).to have_content(@practice3.name)
         expect(page).to_not have_content(@practice5.name)
 
@@ -447,7 +447,7 @@ describe 'Search', type: :feature do
         update_results
 
         expect(page).to have_content('Filters (1)')
-        expect(page).to have_content('4 results')
+        expect(page).to have_content('4 Results')
         expect(page).to have_content(@practice3.name)
         expect(page).to have_content(@practice4.name)
         expect(page).to have_content(@practice5.name)
@@ -458,7 +458,7 @@ describe 'Search', type: :feature do
         update_results
 
         expect(page).to have_content('Filters (2)')
-        expect(page).to have_content('2 results')
+        expect(page).to have_content('2 Results')
         expect(page).to have_content(@practice4.name)
         expect(page).to have_content(@practice5.name)
 
@@ -469,7 +469,7 @@ describe 'Search', type: :feature do
         update_results
 
         expect(page).to have_content('Filters (1)')
-        expect(page).to have_content('1 result')
+        expect(page).to have_content('1 Result')
         expect(page).to have_content(@practice6.name)
 
         # search for practices with the search bar and clinical resource hub filters
@@ -483,7 +483,7 @@ describe 'Search', type: :feature do
         update_results
 
         expect(page).to have_content('Filters (2)')
-        expect(page).to have_content('1 result')
+        expect(page).to have_content('1 Result')
         expect(page).to have_content(@practice14.name)
       end
 
@@ -496,7 +496,7 @@ describe 'Search', type: :feature do
           update_results
 
           expect(page).to have_content('Filters (1)')
-          expect(page).to have_content('4 results')
+          expect(page).to have_content('4 Results')
           expect(page).to have_content(@practice3.name)
           expect(page).to have_content(@practice3.name)
           expect(page).to have_content(@practice5.name)
@@ -511,7 +511,7 @@ describe 'Search', type: :feature do
           update_results
 
           expect(page).to have_content('Filters (1)')
-          expect(page).to have_content('2 results')
+          expect(page).to have_content('2 Results')
           expect(page).to have_content(@practice13.name)
           expect(page).to have_content(@practice14.name)
         end
@@ -523,7 +523,7 @@ describe 'Search', type: :feature do
           set_combobox_val(0, 'Vinita VA Clinic')
           update_results
 
-          expect(page).to have_content('1 result')
+          expect(page).to have_content('1 Result')
           expect(page).to have_content(@practice12.name)
         end
       end
@@ -536,7 +536,7 @@ describe 'Search', type: :feature do
           set_combobox_val(1, 'VISN-23')
           update_results
 
-          expect(page).to have_content('2 results')
+          expect(page).to have_content('2 Results')
           expect(page).to have_content(@practice.name)
           expect(page).to have_content(@practice3.name)
 
@@ -549,7 +549,7 @@ describe 'Search', type: :feature do
           update_results
 
           expect(page).to have_content('Filters (1)')
-          expect(page).to have_content('2 results')
+          expect(page).to have_content('2 Results')
           expect(page).to have_content(@practice12.name)
           expect(page).to have_content(@practice14.name)
         end
@@ -561,7 +561,7 @@ describe 'Search', type: :feature do
           set_combobox_val(0, 'Vinita VA Clinic')
           update_results
 
-          expect(page).to have_content('1 result')
+          expect(page).to have_content('1 Result')
           expect(page).to have_content(@practice12.name)
         end
       end
@@ -577,7 +577,7 @@ describe 'Search', type: :feature do
         update_results
 
         # results should be sorted my most relevant(closest match) by default
-        expect(page).to have_content('6 results')
+        expect(page).to have_content('6 Results')
         expect(first('span.dm-practice-title').text).to eq(@practice6.name)
 
         toggle_filters_accordion
@@ -585,7 +585,7 @@ describe 'Search', type: :feature do
         select_category('.cat-4-label')
         update_results
 
-        expect(page).to have_content('6 results')
+        expect(page).to have_content('6 Results')
         expect(first('span.dm-practice-title').text).to_not eq(@practice6.name)
         expect(first('span.dm-practice-title').text).to eq(@practice4.name)
 
@@ -622,7 +622,7 @@ describe 'Search', type: :feature do
         fill_in('dm-practice-search-field', with: 'practice')
         search
 
-        expect(page).to have_content('13 results')
+        expect(page).to have_content('13 Results')
         expect(page).to have_selector('div.dm-practice-card', count: 12)
 
         # show the next set of 12 results
@@ -750,7 +750,7 @@ describe 'Search', type: :feature do
       select_category('.cat-5-label')
       update_results
 
-      expect(page).to have_content('5 results')
+      expect(page).to have_content('5 Results')
       expect(page).to have_content(@practice.name)
       expect(page).to have_content(@practice3.name)
       expect(page).to have_content(@practice5.name)

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -758,4 +758,32 @@ describe 'Search', type: :feature do
       expect(page).to have_content(@practice10.name)
     end
   end
+
+  describe 'search header' do
+    it 'should display appropriate header text when page loads' do
+      visit_search_page
+      expect(find('#searchHeader')).to have_text('Search')
+      expect(find('#searchHeader')).not_to have_text('Search Results for:')
+
+      visit '/'
+      find('#dm-homepage-search-field').click
+      fill_in('dm-homepage-search-field', with: 'test')
+      find_button('dm-homepage-search-button').click
+
+      expect(find('#searchHeader')).to have_text('Search Results for: test')
+    end
+
+    it 'should update the search header when a query is entered and removed in search bar' do
+      visit_search_page
+
+      fill_in('dm-practice-search-field', with: 'test')
+      search
+      expect(find('#searchHeader')).to have_text('Search Results for: test')
+
+      fill_in('dm-practice-search-field', with: '')
+      search
+      expect(find('#searchHeader')).to have_text('Search')
+      expect(find('#searchHeader')).not_to have_text('Search Results for:')
+    end
+  end
 end


### PR DESCRIPTION
### JIRA issue link
https://agile6.atlassian.net/browse/DM-4910

## Description - what does this code do?
Updates new search page header section to interpolate query term if present

## Testing done - how did you test it/steps on how can another person can test it 
1. Locally, from the home page enter something into the search bar and click the search button
2. Verify on the `/search` page that the new headers appear above the new search results section and that your search query is interpolated
3. While on the page enter another search and verify that upon submission the new search headers update with the new search query interpolated
5. From the landing page, click the "Search" button with nothing in the input
6. Verify that the `/search` page header displays only the text "Search"

## Screenshots, Gifs, Videos from application (if applicable)
with no search query:
<img width="1544" alt="Screenshot 2024-07-10 at 5 40 30 PM" src="https://github.com/department-of-veterans-affairs/diffusion-marketplace/assets/65036872/096be3f1-e38f-4e0c-8083-5d09fa80dd67">

with search query:
<img width="1546" alt="Screenshot 2024-07-10 at 5 41 41 PM" src="https://github.com/department-of-veterans-affairs/diffusion-marketplace/assets/65036872/9fd9545e-ee1e-4100-ab0f-0a20bc06d31c">

## Link to mock-ups/mock ups (image file if you have it) (if applicable)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Unit tests written (if applicable)
- [ ] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating JIRA issue
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs