### PR TITLE
DM-4965: fix ellipses truncation on homepage search

### DIFF
--- a/app/assets/stylesheets/dm/pages/_home.scss
+++ b/app/assets/stylesheets/dm/pages/_home.scss
@@ -73,6 +73,7 @@
         text-overflow: ellipsis;
         overflow: hidden;
         white-space: nowrap;
+        display: block;
 
         &:hover,
         &:active,


### PR DESCRIPTION
### JIRA issue link
[DM-4965](https://agile6.atlassian.net/browse/DM-4965)

## Description - what does this code do?
- Fixes a bug where homepage search results were overflowing the dropdown container
- Update CSS to make sure that ellipses truncation is applied to homepage search results

## Testing done - how did you test it/steps on how can another person can test it 
1. Update a fixture practice to have a very long title
2. Search for your practice on the homepage
3. Confirm that the practice title is truncated with ellipses

## Screenshots, Gifs, Videos from application (if applicable)

### Before
![Screenshot 2024-07-15 at 2 42 06 PM](https://github.com/user-attachments/assets/bf057629-a597-43c3-8357-898bfb1a687d)

### After
![Screenshot 2024-07-15 at 2 41 52 PM](https://github.com/user-attachments/assets/5d6c8d34-cfef-4f88-b73e-37003ecd5f8a)
