### PR TITLE
DM-4968:  Remove legacy data from VaEmployee

### DIFF
--- a/app/helpers/va_employees_helper.rb
+++ b/app/helpers/va_employees_helper.rb
@@ -1,2 +1,0 @@
-module VaEmployeesHelper
-end

--- a/db/migrate/20240716000712_change_va_employees.rb
+++ b/db/migrate/20240716000712_change_va_employees.rb
@@ -1,0 +1,9 @@
+class ChangeVaEmployees < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :va_employees, :prefix, :string
+    remove_column :va_employees, :suffix, :string
+    remove_column :va_employees, :email, :string
+    remove_column :va_employees, :bio, :text
+    remove_column :va_employees, :job_title, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_07_09_160927) do
+ActiveRecord::Schema.define(version: 2024_07_16_000712) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -1344,11 +1344,6 @@ ActiveRecord::Schema.define(version: 2024_07_09_160927) do
 
   create_table "va_employees", force: :cascade do |t|
     t.string "name"
-    t.string "prefix"
-    t.string "suffix"
-    t.string "email"
-    t.text "bio"
-    t.string "job_title"
     t.string "role"
     t.integer "position"
     t.datetime "created_at", null: false


### PR DESCRIPTION
### JIRA issue link
[DM-4968](https://agile6.atlassian.net/browse/DM-4968) (see ticket for info on data analysis)

## Description - what does this code do?
- VaEmployee is used for the About section to list members of the original innovation team. We do not collect data via the UI for the fields being dropped. 
![Screenshot 2024-07-12 at 11 59 41 AM](https://github.com/user-attachments/assets/c3e06ca8-b173-462f-882b-e73c69080c4c)