### PR TITLE
Bump rexml to 3.3.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -663,8 +663,8 @@ GEM
     responders (3.1.1)
       actionpack (>= 5.2)
       railties (>= 5.2)
-    rexml (3.2.8)
-      strscan (>= 3.0.9)
+    rexml (3.3.2)
+      strscan
     rolify (6.0.1)
     roo (2.8.3)
       nokogiri (~> 1)


### PR DESCRIPTION
### JIRA issue link
https://www.ruby-lang.org/en/news/2024/07/16/dos-rexml-cve-2024-39908/

## Description - what does this code do?
- Updates rexml to version 3.3.2

