### PR TITLE
DM-5004: Set up a courtesy redirect for renamed innovation

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -133,4 +133,7 @@ Rails.application.routes.draw do
   get '/communities/:page_group_friendly_id' => "page#show"
   get '/communities/:page_group_friendly_id/:page_slug' => 'page#show'
   get '/communities', to: redirect('/communities/va-immersive') # temporary redirect until more communities are added
+
+  # Permanent redirects
+  get '/innovations/save-a-trip-to-primary-care-tool', to: redirect('/innovations/patient-facing-materials-for-care-coordination-in-va-primary-care', status: 301) # remove 10/25/24
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,6 +20,9 @@ Rails.application.routes.draw do
   patch '/close_edit_session', action: 'close_edit_session', controller: 'practices', as: 'close_edit_session'
   post '/accept_terms', action: 'accept_terms', controller: 'users', as: 'accept_terms'
 
+  # Permanent redirects
+  get '/innovations/save-a-trip-to-primary-care-tool', to: redirect('/innovations/patient-facing-materials-for-care-coordination-in-va-primary-care', status: 301) # remove 10/25/
+
   resources :practices, path: 'innovations', except: :index do
     get '/edit/metrics', action: 'metrics', as: 'metrics'
     get '/edit/instructions', action: 'instructions', as: 'instructions'
@@ -121,8 +124,6 @@ Rails.application.routes.draw do
   get '/about', controller: 'about', action: 'index', as: 'about'
   post '/about', controller: 'about', action: 'email'
   get '/terms-and-conditions', controller: 'terms_and_conditions', action: 'index'
-  match '/404', to: 'errors#page_not_found_404', via: :all
-  match '/500', to: 'errors#internal_server_error_500', via: :all
 
   get '/signed_resource', controller: 'application', action: 'signed_resource'
 
@@ -134,6 +135,7 @@ Rails.application.routes.draw do
   get '/communities/:page_group_friendly_id/:page_slug' => 'page#show'
   get '/communities', to: redirect('/communities/va-immersive') # temporary redirect until more communities are added
 
-  # Permanent redirects
-  get '/innovations/save-a-trip-to-primary-care-tool', to: redirect('/innovations/patient-facing-materials-for-care-coordination-in-va-primary-care', status: 301) # remove 10/25/24
+  # Catchall error codes
+  match '/404', to: 'errors#page_not_found_404', via: :all
+  match '/500', to: 'errors#internal_server_error_500', via: :all
 end


### PR DESCRIPTION
### JIRA issue link
[DM-5004](https://agile6.atlassian.net/browse/DM-5004)

## Description - what does this code do?
- Sets up a permanent redirect for a renamed innovation. This should help with any instances of the old URL showing up in search engine results.

## Testing done - how did you test it/steps on how can another person can test it 
On DEV, visit `/innovations/save-a-trip-to-primary-care-tool` and confirm that it redirects to `/innovations/patient-facing-materials-for-care-coordination-in-va-primary-care`
