### PR TITLE
DM-4894: Remove featured practices workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@
 | `rails dm:full_import` | Set up data using the full flow of the importer  |
 | `rails dm:reset_up` | Re-sets up database and imports all data from the full flow of the importer  |
 | `rails importer:import_answers` | import an xlsx and create practices  |
-| `rails importer:initial_featured` | sets up the "original" featured practices to show up on the landing page - depends on spreadsheet being imported |
 | `rails surveymonkey:download_response_files` (DEPRECATED) | Rake task to download files from our SurveyMonkey practice submission form. **Do not use this anymore. Ever.**  |
 | `rails visns:create_visns_and_transfer_data` | Creates new VISN records based on the data from the "practice_origin_lookup.json" file
 | `rails va_facilities:create_or_update_va_facilities` | Creates or updates VA facility records based on the data from the "va_facilities.json" file
@@ -153,7 +152,6 @@ S3_TEST_MARKETPLACE_SECRET_ACCESS_KEY
 This will run:
 1. `rails dm:db_setup` - sets up the db with `rails db:create db:migrate db:seed`
 2. `rails importer:import_answers` - imports the initial practice data the Diffusion Marketplace team collected via Survey Monkey, images and all~
-3. `rails importer:initial_featured` - sets the first three initial featured practices for the homepage
 4. `rails visns:create_visns_and_transfer_data` - Creates new VISN records based on the data from the "practice_origin_lookup.json" file
 5. `rails va_facilities:create_or_update_va_facilities` - Creates or updates VA facility records based on the data from the "va_facilities.json" file
 6. `rails visns:create_visn_liaisons_and_transfer_data` - Creates new VISN liaison records based on the data from the "practice_origin_lookup.json" file

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -4,7 +4,6 @@ class HomeController < ApplicationController
 
 
   def index
-    @highlighted_pr = Practice.where(highlight: true, published: true, enabled: true, approved: true).first
     @dropdown_categories = get_categories_by_popularity
     @dropdown_communities = get_categories_by_popularity(true)
     @dropdown_practices, @practice_names = get_dropdown_practices

--- a/app/controllers/practices_controller.rb
+++ b/app/controllers/practices_controller.rb
@@ -1,11 +1,10 @@
 class PracticesController < ApplicationController # rubocop:disable Metrics/ClassLength
   include CropperUtils, PracticesHelper, PracticeEditorUtils, EditorSessionUtils, PracticeEditorSessionsHelper, PracticeUtils, ThreeColumnDataHelper, UsersHelper
   prepend_before_action :skip_timeout, only: [:session_time_remaining]
-  before_action :set_practice, only: [:show, :edit, :update, :destroy, :highlight, :un_highlight, :feature,
-                                      :un_feature, :favorite, :instructions, :overview, :impact, :resources, :documentation,
-                                      :departments, :timeline, :risk_and_mitigation, :checklist, :publication_validation, :adoptions,
-                                      :create_or_update_diffusion_history, :implementation, :introduction, :about, :metrics, :editors,
-                                      :extend_editor_session_time, :session_time_remaining, :close_edit_session]
+  before_action :set_practice, only: [:show, :edit, :update, :destroy, :favorite, :instructions, :overview, :impact, :resources,
+                                      :documentation, :departments, :timeline, :risk_and_mitigation, :checklist, :publication_validation,
+                                      :adoptions, :create_or_update_diffusion_history, :implementation, :introduction, :about, :metrics,
+                                      :editors, :extend_editor_session_time, :session_time_remaining, :close_edit_session]
   before_action :set_facility_data, only: [:show]
   before_action :set_office_data, only: [:show]
   before_action :set_visn_data, only: [:show]
@@ -237,28 +236,6 @@ class PracticesController < ApplicationController # rubocop:disable Metrics/Clas
         format.json { render json: user_practice.errors, status: :unprocessable_entity }
       end
     end
-  end
-
-  def highlight
-    old_highlight = Practice.find_by_highlight(true)
-    old_highlight.update(highlight: false) if old_highlight.present?
-    @practice.update(highlight: true, featured: false)
-    redirect_to edit_practice_path(@practice)
-  end
-
-  def un_highlight
-    @practice.update(highlight: false)
-    redirect_to edit_practice_path(@practice)
-  end
-
-  def feature
-    @practice.update(featured: true)
-    redirect_to edit_practice_path(@practice)
-  end
-
-  def un_feature
-    @practice.update(featured: false)
-    redirect_to edit_practice_path(@practice)
   end
 
   # GET /practices/1/instructions

--- a/app/models/practice.rb
+++ b/app/models/practice.rb
@@ -115,12 +115,6 @@ class Practice < ApplicationRecord
     object_presigned_url(origin_picture, style)
   end
 
-  has_attached_file :highlight_attachment, styles: {thumb: '768x432>'} # TODO: modify thumb size
-
-  def highlight_attachment_s3_presigned_url(style = nil)
-    object_presigned_url(highlight_attachment, style)
-  end
-
   PRACTICE_EDITOR_SLUGS =
       {
           'introduction': 'editors',
@@ -170,7 +164,6 @@ class Practice < ApplicationRecord
   validates_attachment_content_type :origin_picture, content_type: /\Aimage\/.*\z/
   validates_uniqueness_of :name, {message: 'Innovation name already exists'}
   validates :user, presence: true, format: valid_va_email
-  validates_attachment_content_type :highlight_attachment, content_type: /\Aimage\/.*\z/
   # validates :tagline, presence: { message: 'Practice tagline can\'t be blank'}
 
   scope :published,   -> { where(published: true) }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -44,12 +44,6 @@ Rails.application.routes.draw do
     get '/published', action: 'published', as: 'published'
     post '/favorite', action: 'favorite', as: 'favorite'
     delete '/diffusion_history/:diffusion_history_id', action: 'destroy_diffusion_history', as: 'destroy_diffusion_history'
-    member do
-      post :highlight
-      post :un_highlight
-      post :feature
-      post :un_feature
-    end
     resources :comments do
       member do
           put 'like' => 'commontator/comments#upvote'

--- a/db/migrate/20240726002037_remove_highlight_from_practices.rb
+++ b/db/migrate/20240726002037_remove_highlight_from_practices.rb
@@ -1,0 +1,15 @@
+class RemoveHighlightFromPractices < ActiveRecord::Migration[6.1]
+  def up
+    remove_attachment :practices, :highlight_attachment
+    remove_column :practices, :featured, :boolean
+    remove_column :practices, :highlight, :boolean
+    remove_column :practices, :highlight_body, :string
+  end
+
+  def down
+    add_attachment :practices, :highlight_attachment
+    add_column :practices, :featured, :boolean
+    add_column :practices, :highlight, :boolean
+    add_column :practices, :highlight_body, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_07_25_224021) do
+ActiveRecord::Schema.define(version: 2024_07_26_002037) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -1100,8 +1100,6 @@ ActiveRecord::Schema.define(version: 2024_07_25_224021) do
     t.boolean "published", default: false
     t.boolean "approved", default: false
     t.string "slug"
-    t.boolean "highlight", default: false, null: false
-    t.boolean "featured", default: false, null: false
     t.integer "ahoy_visit_id"
     t.string "training_provider_role"
     t.boolean "enabled", default: true, null: false
@@ -1113,15 +1111,10 @@ ActiveRecord::Schema.define(version: 2024_07_25_224021) do
     t.integer "maturity_level"
     t.datetime "date_published"
     t.datetime "practice_pages_updated"
-    t.string "highlight_body"
     t.boolean "retired", default: false, null: false
     t.string "retired_reason"
     t.boolean "is_public", default: false
     t.boolean "hidden", default: false, null: false
-    t.string "highlight_attachment_file_name"
-    t.string "highlight_attachment_content_type"
-    t.bigint "highlight_attachment_file_size"
-    t.datetime "highlight_attachment_updated_at"
     t.text "main_display_image_alt_text"
     t.integer "diffusion_histories_count", default: 0
     t.datetime "last_email_date"

--- a/lib/tasks/dm.rake
+++ b/lib/tasks/dm.rake
@@ -14,7 +14,6 @@ namespace :dm do
   task :full_import => :environment do
     Rake::Task['dm:db_setup'].execute
     Rake::Task['importer:import_answers'].execute
-    Rake::Task['importer:initial_featured'].execute
     Rake::Task['visns:create_visns_and_transfer_data'].execute
     Rake::Task['va_facilities:create_or_update_va_facilities'].execute
     Rake::Task['visns:create_visn_liaisons_and_transfer_data'].execute

--- a/lib/tasks/importer.rake
+++ b/lib/tasks/importer.rake
@@ -132,22 +132,6 @@ namespace :importer do
     end
     puts "*********** Completed Importing Practices! ***********".green
   end
-
-  task initial_featured: :environment do |t, args|
-    puts "*********** Initializing Featured Practices **********".green
-    options = {}
-    highlighted = Practice.find_by_slug('project-happen')
-    features = []
-    features << Practice.find_by_slug('flow3')
-    features << Practice.find_by_slug('vione')
-    features << Practice.find_by_slug('vha-rapid-naloxone')
-
-    highlighted.update(highlight: true) if highlighted.present?
-    features.each do |f|
-      f.update(featured: true)
-    end
-    puts "*********** Completed Featured Practices **********".green
-  end
 end
 
 def destroy_practice

--- a/spec/features/admin/admin_spec.rb
+++ b/spec/features/admin/admin_spec.rb
@@ -32,7 +32,6 @@ describe 'The admin dashboard', type: :feature do
       Department.create!(name: 'All departments equally - not a search differentiator', short_name: 'all'),
     ]
     @practice_partner = PracticePartner.create!(name: 'Diffusion of Excellence', short_name: '', description: 'The Diffusion of Excellence Initiative', icon: 'fas fa-heart', color: '#E4A002')
-    @featured_image = "#{Rails.root}/spec/assets/charmander.png"
   end
 
   after(:all) do
@@ -261,9 +260,6 @@ describe 'The admin dashboard', type: :feature do
       click_link('New Practice')
       expect(page).to have_current_path(new_admin_practice_path)
 
-      expect(page).to have_no_content('Highlighted Innovation Title')
-      expect(page).to have_no_content('Highlighted Innovation Body')
-
       # add extra whitespace to practice name
       fill_in('Innovation name', with: ' The Newest Practice   ')
       fill_in('User email', with: 'practice_owner@va.gov')
@@ -421,58 +417,6 @@ describe 'The admin dashboard', type: :feature do
       click_button('Update Practice')
       click_link('Edit', href: edit_admin_practice_path(@practice))
       expect(page).not_to have_selector('option[selected]')
-    end
-
-    it 'should be able to feature a practice, if one is not already featured' do
-      login_as(@admin, scope: :user, run_callbacks: false)
-      pr_2 = Practice.create!(name: 'Another Test Practice', user: @user, initiating_facility: 'Test facility name', tagline: 'Test tagline', published: true, approved: true)
-      pr_3 = Practice.create!(name: 'Another Test Practice 2', user: @user, initiating_facility: 'Test facility name', tagline: 'Test tagline')
-
-      visit '/'
-      expect(page).to have_no_content('Featured Innovation')
-      # feature practice
-      visit '/admin'
-      click_link('Practices')
-      expect(page).to have_content('Feature')
-      click_link('Feature', href: highlight_practice_admin_practice_path(@practice))
-      expect(page).to have_content("\"#{@practice.name}\" is now the featured innovation.")
-      expect(find_all('.col-featured > span')[3].text).to eq 'YES'
-      click_link('Feature', href: highlight_practice_admin_practice_path(pr_2))
-      expect(page).to have_content("Only one innovation can be featured at a time.")
-      expect(find_all('.col-featured > span')[1].text).to eq 'NO'
-      click_link('Feature', href: highlight_practice_admin_practice_path(pr_3))
-      expect(page).to have_content("Innovation must be published to be featured.")
-      expect(find_all('.col-featured > span')[0].text).to eq 'NO'
-      visit '/'
-      # Should not show featured section unless featured fields have been completed
-      expect(page).to_not have_content(@practice.name)
-      # add featured content
-      visit '/admin'
-      click_link('Practices')
-      click_link('Edit', href: edit_admin_practice_path(@practice))
-      expect(page).to have_content('FEATURED INNOVATION BODY')
-      expect(page).to have_content('FEATURED INNOVATION ATTACHMENT')
-      fill_in('Featured Innovation Body', with: 'pretty cool practice')
-      # practice should not update unless both featured fields are completed
-      click_button('Update Practice')
-      expect(page).to_not have_content('Innovation was successfully updated.')
-      expect(page).to have_content('ERROR - The following required \'featured\' field was not completed: \'featured innovation attachment\'')
-      fill_in('Featured Innovation Body', with: 'pretty cool practice')
-      find('#practice_highlight_attachment').attach_file(@featured_image)
-      click_button('Update Practice')
-      expect(page).to have_content('Innovation was successfully updated.')
-      visit '/'
-      expect(page).to have_content(@practice.name)
-      expect(page).to have_content('pretty cool practice')
-      # unfeature practice
-      visit '/admin'
-      click_link('Practices')
-      expect(page).to have_content('Unfeature')
-      click_link('Unfeature', href: highlight_practice_admin_practice_path(@practice))
-      expect(find_all('.col-featured > span').first.text).to eq 'NO'
-      expect(page).to have_content("\"#{@practice.name}\" is no longer the featured innovation.")
-      visit '/'
-      expect(page).to have_no_content(@practice.name)
     end
 
     it 'should be able to toggle between retired and active states from actions column' do

--- a/spec/features/favorite_spec.rb
+++ b/spec/features/favorite_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 describe 'Favorites', type: :feature do
   before do
     @user = User.create!(email: 'spongebob.squarepants@va.gov', password: 'Password123', password_confirmation: 'Password123', skip_va_validation: true, confirmed_at: Time.now, accepted_terms: true)
-    @practice1 = Practice.create!(name: 'A public practice', slug: 'a-public-practice', approved: true, published: true, tagline: 'Test tagline', featured: true, user: @user)
+    @practice1 = Practice.create!(name: 'A public practice', slug: 'a-public-practice', approved: true, published: true, tagline: 'Test tagline', user: @user)
     @user_practice = UserPractice.create!(user: @user, practice: @practice1, favorited: true)
   end
 

--- a/spec/features/practice_spec.rb
+++ b/spec/features/practice_spec.rb
@@ -12,7 +12,6 @@ describe 'Practices', type: :feature do
     @practice = Practice.create!(name: 'A public practice', approved: true, published: true, tagline: 'Test tagline', date_initiated: Time.now(), user: @user2)
     @enabled_practice = Practice.create!(name: 'Enabled practice', approved: true, published: true, enabled: true, date_initiated: Time.now(), user: @user2)
     @disabled_practice = Practice.create!(name: 'Disabled practice', approved: true, published: true, enabled: false, date_initiated: Time.now(), user: @user2)
-    @highlighted_practice = Practice.create!(name: 'Highlighted practice', approved: true, published: true, enabled: true, highlight: true, highlight_body: 'Highlight body text', date_initiated: Time.now(), highlight_attachment: File.new("#{Rails.root}/spec/assets/charmander.png"), user: @user2)
 
     visn_20 = Visn.create!(id: 15, name: "Northwest Network", number: 20)
     @facility_1 = VaFacility.create!(visn: visn_20, station_number: "687HA", official_station_name: "Yakima VA Clinic", common_name: "Yakima", street_address_state: "WA")

--- a/spec/features/retire_practice_spec.rb
+++ b/spec/features/retire_practice_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 describe 'retired practices', type: :feature do
   before do
     @user = User.create!(email: 'spongebob.squarepants@va.gov', password: 'Password123', password_confirmation: 'Password123', skip_va_validation: true, confirmed_at: Time.now, accepted_terms: true)
-    @practice = Practice.create!(name: 'A public practice', slug: 'a-public-practice', approved: true, published: true, tagline: 'Test tagline', featured: true, highlight: true, user: @user, retired: true, retired_reason: 'Was not a good practice')
+    @practice = Practice.create!(name: 'A public practice', slug: 'a-public-practice', approved: true, published: true, tagline: 'Test tagline', user: @user, retired: true, retired_reason: 'Was not a good practice')
   end
 
   it 'Should display retirement blurbs and reason' do

--- a/spec/features/shared/breadcrumbs_spec.rb
+++ b/spec/features/shared/breadcrumbs_spec.rb
@@ -12,7 +12,7 @@ describe 'Breadcrumbs', type: :feature do
     @admin.add_role(User::USER_ROLES[0].to_sym)
     @approver.add_role(User::USER_ROLES[0].to_sym)
     @user_practice = Practice.create!(name: 'The Best Innovation Ever', user: @user, initiating_facility: 'Test facility name', initiating_facility_type: 'other', tagline: 'Test tagline', is_public: true, published: true, approved: true, enabled: true, summary: 'test innovation summary')
-    @user_practice2 = Practice.create!(name: 'Another Best Innovation', user: @user, initiating_facility: 'vc_0508V', tagline: 'Test tagline 2', highlight_attachment: File.new(@img_path_1), highlight: true, highlight_body: 'highlighted innovation', is_public: true, published: true, approved: true, enabled: true)
+    @user_practice2 = Practice.create!(name: 'Another Best Innovation', user: @user, initiating_facility: 'vc_0508V', tagline: 'Test tagline 2', is_public: true, published: true, approved: true, enabled: true)
     visn_1 = Visn.create!(name: 'VISN 1', number: 1)
     fac_1 = VaFacility.create!(
       visn: visn_1,

--- a/spec/features/users/user_profile_spec.rb
+++ b/spec/features/users/user_profile_spec.rb
@@ -76,8 +76,8 @@ describe 'The user index', type: :feature do
   end
 
   it 'should have a favorited practice' do
-    @practice1 = Practice.create!(name: 'A public practice', approved: true, published: true, tagline: 'Test tagline', featured: true, user: @user)
-    @practice2 = Practice.create!(name: 'The Best Innovation Ever!', approved: true, published: true, tagline: 'Test tagline', featured: true, user: @user2)
+    @practice1 = Practice.create!(name: 'A public practice', approved: true, published: true, tagline: 'Test tagline', user: @user)
+    @practice2 = Practice.create!(name: 'The Best Innovation Ever!', approved: true, published: true, tagline: 'Test tagline', user: @user2)
     UserPractice.create!(user: @user, practice: @practice2, favorited: true)
 
     login_as(@user, scope: :user, run_callbacks: false)
@@ -90,8 +90,8 @@ describe 'The user index', type: :feature do
   end
 
     it 'should have created practices' do
-    @practice1 = Practice.create!(name: 'A public practice', approved: true, published: true, tagline: 'Test tagline', featured: true, user: @user)
-    @practice2 = Practice.create!(name: 'The Best Innovation Ever!', approved: true, published: true, tagline: 'Test tagline', featured: true, user: @user2)
+    @practice1 = Practice.create!(name: 'A public practice', approved: true, published: true, tagline: 'Test tagline', user: @user)
+    @practice2 = Practice.create!(name: 'The Best Innovation Ever!', approved: true, published: true, tagline: 'Test tagline', user: @user2)
     @user_pr1_editor = PracticeEditor.create!(practice: @practice1, user: @user, email: @user.email)
 
     login_as(@user, scope: :user, run_callbacks: false)


### PR DESCRIPTION
### JIRA issue link
Part of [DM-4894](https://agile6.atlassian.net/browse/DM-4894) / #956 
Rebase after #958

## Description - what does this code do?
We are moving towards a less record-centric content management system for homepage content. This PR drops the notion of featured innovations. Many of the fields dropped refer to "highlight". An earlier version of the VADM homepage differentiated between featured practices and a single highlighted practice. 

## Testing done - how did you test it/steps on how can another person can test it 
- Visit the `/admin/practices` panel and confirm that a practice can no longer be featured

