### PR TITLE
fix search specs

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -10,6 +10,7 @@ on:
     branches:
       [
         "master",
+        "feature/DM-4866-search-results-refresh",
         "ci-migration",
         "ci-migration-cv",
         "ci-migration-en",
@@ -17,7 +18,7 @@ on:
         "ci-migration-bj",
       ]
   pull_request:
-    branches: ["master"]
+    branches: ["master", "feature/DM-4866-search-results-refresh"]
 jobs:
   build:
     name: rspec

--- a/app/assets/stylesheets/dm/pages/_search.scss
+++ b/app/assets/stylesheets/dm/pages/_search.scss
@@ -1,5 +1,29 @@
 // Styles for the practice search page
 #search-page {
+
+  .applied-filter {
+    @include transition-btn-colors;
+    border-radius: 2px;
+  }
+
+  #REPLACE-with-something-about-filters {
+    .usa-accordion {
+      width: unset;
+    }
+  }
+
+  #REPLACE-with-something-about-innovation-results {
+    .innovation-preview {
+      border-top: 1px solid color($theme-color-base-lighter);
+
+      img {
+        min-height: 125px;
+        min-width: 195px;
+        object-fit: cover;
+      }
+    }
+  }
+
   .usa-checkbox__label:before {
     border-radius: 0 !important;
   }

--- a/app/assets/stylesheets/dm/pages/_search.scss
+++ b/app/assets/stylesheets/dm/pages/_search.scss
@@ -1,9 +1,55 @@
 // Styles for the practice search page
 #search-page {
-
   .applied-filter {
+    @extend .usa-tag;
+    @extend .usa-tag--big;
+    display: block;
+    @include at-media(tablet) {
+      display: inline-block;
+    }
+  }
+
+  .applied-filter-1 {
     @include transition-btn-colors;
-    border-radius: 2px;
+  }
+
+  .applied-filter-2 {
+    background-color: color("blue-10");
+    color: color("blue-60");
+
+    &:hover {
+      background-color: color("blue-20");
+    }
+
+    &:active {
+      background-color: color("blue-40");
+    }
+  }
+
+  .applied-filter-3 {
+    background-color: color("gray-60");
+    color: white;
+
+    &:hover {
+      background-color: color("gray-50");
+    }
+
+    &:active {
+      background-color: color("gray-80");
+    }
+  }
+
+  .applied-filter-4 {
+    background-color: color("gray-30");
+    color: black;
+
+    &:hover {
+      background-color: color("gray-20");
+    }
+
+    &:active {
+      background-color: color("gray-50");
+    }
   }
 
   #REPLACE-with-something-about-filters {
@@ -28,7 +74,8 @@
     border-radius: 0 !important;
   }
 
-  .usa-combo-box__toggle-list, .usa-combo-box__clear-input {
+  .usa-combo-box__toggle-list,
+  .usa-combo-box__clear-input {
     top: 2.3em !important;
   }
 
@@ -81,7 +128,7 @@
     height: calc(1em * 1.5 * 2);
   }
   .three-lines {
-    -webkit-line-clamp : 3;
+    -webkit-line-clamp: 3;
     height: calc(1em * 1.5 * 3);
   }
   .four-lines {
@@ -97,7 +144,7 @@
   /* Adapted from: http://www.mademyday.de/css-height-equals-width-with-pure-css.html */
   .img-box {
     position: relative;
-    width: 100%;  /* desired width */
+    width: 100%; /* desired width */
   }
 
   .img-box-content {
@@ -106,11 +153,11 @@
     width: 100%;
     height: 210px;
 
-    @media all and (min-width: 640px){
+    @media all and (min-width: 640px) {
       height: 200px;
     }
 
-    @media all and (min-width: 870px){
+    @media all and (min-width: 870px) {
       width: 254px;
       height: 257px;
     }
@@ -145,7 +192,9 @@
     display: block !important;
   }
 
-  .search-category-filters, .search-originating-facility-filter, .search-adopting-facility-filter {
+  .search-category-filters,
+  .search-originating-facility-filter,
+  .search-adopting-facility-filter {
     @include u-margin-bottom(1);
 
     @media screen and (min-width: 1024px) {
@@ -189,7 +238,9 @@
   padding: 0 !important;
 }
 
-.category-container, .originating-facility-container, .adopting-facility-container {
+.category-container,
+.originating-facility-container,
+.adopting-facility-container {
   background-color: color($theme-color-secondary-light);
 
   @media screen and (min-width: 1024px) {
@@ -197,9 +248,9 @@
   }
 }
 
-.category-container, {
+.category-container {
   .desktop\:grid-col-4 {
-    @include u-padding-right('05');
+    @include u-padding-right("05");
   }
   div:last-child {
     .usa-checkbox {

--- a/app/views/practices/_search.js.erb
+++ b/app/views/practices/_search.js.erb
@@ -941,6 +941,26 @@ function searchPracticesPage() {
         updateResults();
     });
 
+    function getSelectedCategories() {
+        // Get the values for any chosen categories
+        var selectedCategoryCheckboxes = $('#update-search-results-form [type="checkbox"]:checked:not(".all-clinical-checkbox"):not(".all-operational-checkbox"):not(".all-strategic-checkbox"):not(".all-communities-checkbox")');
+
+        var chosenCategories = {};
+
+        selectedCategoryCheckboxes.each(function () {
+            var parentCategory = this.dataset.parentCategory;
+            var value = this.value;
+
+            if (!chosenCategories[parentCategory]) {
+                chosenCategories[parentCategory] = [];
+            }
+
+            chosenCategories[parentCategory].push(value);
+        });
+        allChosenCategories = Object.values(chosenCategories).flat();
+        return chosenCategories;
+    }
+
     function updateResults() {
         var urlQuery = searchField.value === '' ? '/search' : '/search?query=' + searchField.value;
         window.history.pushState({ turbolinks: {} }, "", urlQuery);
@@ -957,40 +977,25 @@ function searchPracticesPage() {
 
         var adoptingFacility = getComboBoxVal(adoptingFacilityInput, adoptingFacilityLi);
 
-        // Get the values for any chosen categories
-        var selectedCategoryCheckboxes = $('#update-search-results-form [type="checkbox"]:checked:not(".all-clinical-checkbox"):not(".all-operational-checkbox"):not(".all-strategic-checkbox"):not(".all-communities-checkbox")');
-
-        var chosenCategories = {};
-
-        selectedCategoryCheckboxes.each(function () {
-            var parentCategory = this.dataset.parentCategory;
-            var value = this.value;
-
-            if (!chosenCategories[parentCategory]) {
-                chosenCategories[parentCategory] = [];
-            }
-
-            chosenCategories[parentCategory].push(value);
-        });
+        var chosenCategories = getSelectedCategories();
 
         if (Object.keys(chosenCategories).length === 0) {
             chosenCategories = null;
-        } else {
-            // Update Category Usage....
-            allChosenCategories = Object.values(chosenCategories).flat();
-            Rails.ajax({
-                type: 'patch',
-                url: "/update_category_usage",
-                data: jQuery.param({query: searchField.value, chosenCategories: allChosenCategories})
-            });
         }
+
+        // Update Category Usage....
+        Rails.ajax({
+            type: 'patch',
+            url: "/update_category_usage",
+            data: jQuery.param({query: searchField.value, chosenCategories: allChosenCategories})
+        });
 
 
         // Run the search
         search(searchField.value, chosenCategories, originatingFacility, adoptingFacility);
 
         // Display the amount of filters used(if any)
-        var checkboxCount = selectedCategoryCheckboxes.length;
+        var checkboxCount = allChosenCategories.length;
         var noOriginatingFacilityText = originatingFacilityInput.val() === '';
         var originatingFacilityTextPresent = originatingFacilityInput.val() !== '';
         var noAdoptingFacilityText = adoptingFacilityInput.val() === '';
@@ -1078,22 +1083,19 @@ function searchPracticesPage() {
             search(decodeURI(query));
             searchField.value = decodeURI(query);
         } else if (allCommunities) {
+            // check the 'All Communities' checkbox
             let allCommunitiesCheckbox = document.querySelector('.all-communities-checkbox');
             if (allCommunitiesCheckbox) {
                 allCommunitiesCheckbox.checked = true;
                 $(allCommunitiesCheckbox).trigger('change');
             }
-
-            let selectedCategoryCheckboxes = $('#update-search-results-form [type="checkbox"]:checked:not(".all-clinical-checkbox"):not(".all-operational-checkbox"):not(".all-strategic-checkbox"):not(".all-communities-checkbox")');
-            let chosenCategories = selectedCategoryCheckboxes.map(function () {
-                return this.value;
-            }).get();
-
-            if (!chosenCategories.length) {
-                chosenCategories = null;
-            } else {
-                accordionText(chosenCategories.length, 0)
+            // Collect the applied category filters
+            var chosenCategories = getSelectedCategories();
+            // udpate the applied filters count in filter dropdown text
+            if (allChosenCategories.length !== 0)  {
+                accordionText(allChosenCategories.length, 0)
             }
+            // run search with applied category filters
             search('', chosenCategories);
         } else {
             // No query or category filter

--- a/app/views/practices/_search.js.erb
+++ b/app/views/practices/_search.js.erb
@@ -311,10 +311,14 @@ function searchPracticesPage() {
             }
         }
 
+        $('.applied-filter').remove();
+        $('#resetSearchFiltersButton').addClass('display-none');
+
         if (categories) {
             // Collect any practice that has a category that matches the selected category/categories.
             var categoryFilters = [];
             categories.forEach(function (categorySelection) {
+                addAppliedFilter('TAG', categorySelection)
                 return categoryFilters.push({'category_names': "=\"" + categorySelection + "\""});
             });
         }
@@ -338,6 +342,8 @@ function searchPracticesPage() {
                 } else {
                     originFacilityArray.push({'origin_facilities': "=\"" + vf.official_station_name + "\""});
                 }
+
+                addAppliedFilter('ORIGIN', vf.official_station_name)
             });
         } else if (originatingFacility && !originatingFacility.includes('VISN-')){
             // Collect the practices that have an origin facility matching the selected facility
@@ -348,6 +354,7 @@ function searchPracticesPage() {
                     return originatingFacility === f.official_station_name;
                 }
             });
+            addAppliedFilter('ORIGIN', foundOriginatingFacility.official_station_name)
 
             originFacilityArray.push({'origin_facilities': "=\"" + (foundOriginatingFacility.hasOwnProperty('station_number') ? foundOriginatingFacility.station_number : foundOriginatingFacility.official_station_name) + "\""});
         }
@@ -381,6 +388,7 @@ function searchPracticesPage() {
                     } else {
                         stationNumbers.push(ff.official_station_name);
                     }
+                    addAppliedFilter('ADOPTION', ff.official_station_name)
                 });
 
                 getAdoptionFacilities(stationNumbers, adoptionFacilityArray);
@@ -390,6 +398,7 @@ function searchPracticesPage() {
 
                 foundAdoptingFacility.station_number ? stationNumbers.push(foundAdoptingFacility.station_number) : stationNumbers.push(foundAdoptingFacility.official_station_name)
                 getAdoptionFacilities(stationNumbers, adoptionFacilityArray);
+                addAppliedFilter('ADOPTION', foundAdoptingFacility.official_station_name)
             }
         }
 
@@ -744,6 +753,53 @@ function searchPracticesPage() {
         mark.mark(query);
     }
 
+    function addAppliedFilter(filterType, filter) {
+        const resultsSummary = document.getElementById('results-summary');
+        const resetButton = document.getElementById('resetSearchFiltersButton');
+        const appliedFilterString = `${filterType}: ${filter} `;
+
+        const span = document.createElement('span');
+        span.className = 'applied-filter display-block desktop:display-inline usa-tag usa-tag--big';
+        span.textContent = appliedFilterString;
+
+        const removeButton = document.createElement('span');
+        removeButton.textContent = 'X';
+        removeButton.style.cursor = 'pointer';
+        removeButton.style.marginLeft = '5px';
+
+        span.appendChild(removeButton);
+        resultsSummary.parentNode.insertBefore(span, resetButton);
+
+        removeButton.addEventListener('click', function(event) {
+            uncheckFilter(filterType, filter);
+            $('#resetSearchFiltersButton').addClass('display-none');
+            updateResults();
+            event.stopPropagation();
+        });
+
+        resetButton.classList.remove('display-none');
+    }
+
+    function uncheckFilter(filterType, filter) {
+        if (filterType === 'TAG') {
+            const checkbox = Array.from(document.querySelectorAll('.usa-checkbox__input')).find(c =>
+            c.labels && c.labels.length && c.labels[0].textContent.trim() === filter);
+            if (checkbox) {
+                checkbox.checked = false;
+            }
+        } else if (filterType === 'ORIGIN') {
+            const button = document.querySelector('.originating-facility-container .usa-combo-box__clear-input');
+            if (button) {
+                button.click();
+            }
+        } else if (filterType === 'ADOPTION') {
+            const button = document.querySelector('.adopting-facility-container .usa-combo-box__clear-input');
+            if (button) {
+                button.click();
+            }
+        }
+    }
+
     // Highlight Fuse.js results
     // Adapted from: https://github.com/brunocechet/Fuse.js-with-highlight
     function highlighter(resultItem) {
@@ -861,6 +917,10 @@ function searchPracticesPage() {
             $(window).scrollTop(pagePosition.original);
         }
 
+        updateResults();
+    });
+
+    function updateResults() {
         var urlQuery = searchField.value === '' ? '/search' : '/search?query=' + searchField.value;
         window.history.pushState({ turbolinks: {} }, "", urlQuery);
 
@@ -919,7 +979,7 @@ function searchPracticesPage() {
         } else if (checkboxCount === 0 && originatingFacilityTextPresent && adoptingFacilityTextPresent) {
             accordionText(0, 2);
         }
-    });
+    }
 
     // Sort the results based on each sort option
     var sortSelect = $(SORT_EL);
@@ -948,6 +1008,7 @@ function searchPracticesPage() {
     $(document).on('click', '#resetSearchFiltersButton, #resetSearchFiltersButtonMobile', function(e) {
         e.preventDefault();
 
+        // uncheck all filter checkboxes
         $('.usa-combo-box__clear-input').each(function() {
             $(this).trigger('click');
         });
@@ -957,10 +1018,13 @@ function searchPracticesPage() {
                 $(this).prop('checked', false);
             }
         });
+
         // Move the focus area back to the top of the filters window
         $(".usa-combo-box__clear-input__wrapper").attr("tabindex",-1).focus();
         // Reset filter count text
         $('.search-filters-accordion-button').text('Filters');
+        // reset search results
+        searchPracticesPage();
     })
 
     if (window.location.pathname === '/search' && window.location.search !== '' && searchLocation[0] !== '?filter_by') {

--- a/app/views/practices/_search.js.erb
+++ b/app/views/practices/_search.js.erb
@@ -293,8 +293,11 @@ function searchPracticesPage() {
         // set the search page search bar input value
         searchField.value = query;
 
+        const searchHeader = document.getElementById('searchHeader');
         if (query) {
             trackSearchField(query);
+            searchHeader.textContent = `Search Results for: ${query}`;
+
             var searchBarQueryArray = [];
             search_options.keys.forEach(function(practiceKey) {
                 var queryObj = {};
@@ -302,6 +305,7 @@ function searchPracticesPage() {
                 return searchBarQueryArray.push(queryObj);
             });
         } else {
+            searchHeader.textContent = "Search";
             if (searchLocation[0] === '?filter_by') {
                 trackSearchByFilter(searchLocation[1]);
             }
@@ -728,7 +732,7 @@ function searchPracticesPage() {
         }
 
         // Print the number of results for the query
-        resultsSummary.innerHTML = results.length + ' result' + (results.length === 1 ? ':' : 's:');
+        resultsSummary.innerHTML = results.length + ' Result' + (results.length === 1 ? ':' : 's:');
 
         // Highlight results (only Fuse.js matching)
         results.forEach(function (result) {

--- a/app/views/practices/_search.js.erb
+++ b/app/views/practices/_search.js.erb
@@ -23,6 +23,7 @@
         }
     }
     var all_categories = <%= raw @categories.to_json %>;
+    var allChosenCategories = [];
 <% end %>
 
 
@@ -315,12 +316,25 @@ function searchPracticesPage() {
         $('#resetSearchFiltersButton').addClass('display-none');
 
         if (categories) {
-            // Collect any practice that has a category that matches the selected category/categories.
+            //     // Collect any practice that has a category that matches the selected category/categories.
             var categoryFilters = [];
-            categories.forEach(function (categorySelection) {
-                addAppliedFilter('TAG', categorySelection)
-                return categoryFilters.push({'category_names': "=\"" + categorySelection + "\""});
+
+            Object.entries(categories).forEach(function ([parentCategory, selectedValues]) {
+                if (parentCategory !== 'communities') {
+                    selectedValues.forEach(function (categorySelection) {
+                        addAppliedFilter('TAG', categorySelection);
+                        categoryFilters.push({'category_names': "=\"" + categorySelection + "\""});
+                    });
+                }
             });
+
+            // Iterate over 'communities' categories
+            if (categories['communities']) {
+                categories['communities'].forEach(function (categorySelection) {
+                    addAppliedFilter('COMMUNITY', categorySelection);
+                    categoryFilters.push({'category_names': "=\"" + categorySelection + "\""});
+                });
+            }
         }
 
         var originFacilityArray = originatingFacility ? [] : null;
@@ -417,7 +431,7 @@ function searchPracticesPage() {
                 var cat_names = result.item.category_names;
                 if (cat_names && Array.isArray(cat_names)) {
                     cat_names.forEach(function (cn) {
-                        if (categories.includes(cn)) {
+                        if (allChosenCategories.includes(cn)) {
                             resultScore = result.score / 2;
                         }
                         result.score = resultScore;
@@ -753,37 +767,44 @@ function searchPracticesPage() {
         mark.mark(query);
     }
 
-    function addAppliedFilter(filterType, filter) {
+    function addAppliedFilter(filterType, filterName) {
         const resultsSummary = document.getElementById('results-summary');
         const resetButton = document.getElementById('resetSearchFiltersButton');
-        const appliedFilterString = `${filterType}: ${filter} `;
+        const appliedFilterName = filterName.toUpperCase();
+        const appliedFilterString = `${filterType}: ${appliedFilterName} `;
+        const appliedFilterButton = document.createElement('button');
+        const filterClassIndexMap = {
+            'TAG': 1,
+            'COMMUNITY': 2,
+            'ORIGIN': 3,
+            'ADOPTION': 4
+        };
+        const filterClassIndex = filterClassIndexMap[filterType] || 1;
 
-        const span = document.createElement('span');
-        span.className = 'applied-filter display-block desktop:display-inline usa-tag usa-tag--big';
-        span.textContent = appliedFilterString;
+        appliedFilterButton.className = `usa-button applied-filter applied-filter-${filterClassIndex}`;
+        appliedFilterButton.id = `${filterName}`;
+        appliedFilterButton.textContent = appliedFilterString + ' X';
+        appliedFilterButton.style.cursor = 'pointer';
+        appliedFilterButton.setAttribute(
+            'aria-label',
+            `Remove ${filterType} filter for ${filterName} and update search results`
+        );
 
-        const removeButton = document.createElement('span');
-        removeButton.textContent = 'X';
-        removeButton.style.cursor = 'pointer';
-        removeButton.style.marginLeft = '5px';
-
-        span.appendChild(removeButton);
-        resultsSummary.parentNode.insertBefore(span, resetButton);
-
-        removeButton.addEventListener('click', function(event) {
-            uncheckFilter(filterType, filter);
+        appliedFilterButton.addEventListener('click', function(event) {
+            uncheckFilter(filterType, filterName);
             $('#resetSearchFiltersButton').addClass('display-none');
             updateResults();
             event.stopPropagation();
         });
 
+        resultsSummary.parentNode.insertBefore(appliedFilterButton, resetButton);
         resetButton.classList.remove('display-none');
     }
 
-    function uncheckFilter(filterType, filter) {
-        if (filterType === 'TAG') {
+    function uncheckFilter(filterType, filterName) {
+        if (filterType === 'TAG' || filterType === 'COMMUNITY') {
             const checkbox = Array.from(document.querySelectorAll('.usa-checkbox__input')).find(c =>
-            c.labels && c.labels.length && c.labels[0].textContent.trim() === filter);
+                c.labels && c.labels.length && c.labels[0].textContent.trim() === filterName);
             if (checkbox) {
                 checkbox.checked = false;
             }
@@ -938,19 +959,32 @@ function searchPracticesPage() {
 
         // Get the values for any chosen categories
         var selectedCategoryCheckboxes = $('#update-search-results-form [type="checkbox"]:checked:not(".all-clinical-checkbox"):not(".all-operational-checkbox"):not(".all-strategic-checkbox"):not(".all-communities-checkbox")');
-        var chosenCategories = selectedCategoryCheckboxes.map(function () {
-            return this.value;
-        }).get();
-        if (!chosenCategories.length) {
+
+        var chosenCategories = {};
+
+        selectedCategoryCheckboxes.each(function () {
+            var parentCategory = this.dataset.parentCategory;
+            var value = this.value;
+
+            if (!chosenCategories[parentCategory]) {
+                chosenCategories[parentCategory] = [];
+            }
+
+            chosenCategories[parentCategory].push(value);
+        });
+
+        if (Object.keys(chosenCategories).length === 0) {
             chosenCategories = null;
+        } else {
+            // Update Category Usage....
+            allChosenCategories = Object.values(chosenCategories).flat();
+            Rails.ajax({
+                type: 'patch',
+                url: "/update_category_usage",
+                data: jQuery.param({query: searchField.value, chosenCategories: allChosenCategories})
+            });
         }
 
-        // Update Category Usage....
-        Rails.ajax({
-            type: 'patch',
-            url: "/update_category_usage",
-            data: jQuery.param({query: searchField.value, chosenCategories: chosenCategories})
-        });
 
         // Run the search
         search(searchField.value, chosenCategories, originatingFacility, adoptingFacility);

--- a/app/views/practices/search.html.erb
+++ b/app/views/practices/search.html.erb
@@ -18,11 +18,8 @@
     <div class="grid-row margin-bottom-5">
       <div class="grid-col-12">
         <h2 class="usa-prose-h2 margin-bottom-5" id="searchHeader"> Search </h2>
-        <span id="results-summary" class="display-block desktop:display-inline">Results:</span>
-        <span class="applied-filter display-block desktop:display-inline usa-tag usa-tag--big" id="filterStyle1">{Filter applied style 1}</span>
-        <span class="applied-filter display-block desktop:display-inline usa-tag usa-tag--big" id="filterStyle2">{Filter applied style 2}</span>
-
-        <button type="button" class="usa-button usa-button--unstyled" id="resetSearchFiltersButton">Clear filters</button>
+        <span id="results-summary" class="display-block desktop:display-inline margin-right-2">Results:</span>
+        <button type="button" class="usa-button usa-button--unstyled display-none" id="resetSearchFiltersButton">Clear filters</button>
       </div>
     </div>
 

--- a/app/views/practices/search.html.erb
+++ b/app/views/practices/search.html.erb
@@ -26,7 +26,7 @@
       </div>
     </div>
 
-    <div class="grid-row grid-gap">
+<%#     <div class="grid-row grid-gap">
       <!-- START DM- 4912-->
       <div id="REPLACE-with-something-about-filters" class="grid-col-12 tablet:grid-col-4 desktop:grid-col-4">
         <div class="usa-accordion usa-accordion--bordered">
@@ -213,7 +213,7 @@
         <button class="usa-button dm-button--outline-secondary">{Load more}</button>
       </div>
       <!-- END DM-4913 -->
-    </div>
+    </div> %>
   </div>
 
 

--- a/app/views/practices/search.html.erb
+++ b/app/views/practices/search.html.erb
@@ -14,6 +14,209 @@
 <% end %>
 
 <div id="search-page">
+  <div class="grid-container" id="searchResultsContainer"> <!-- START DM-4910 -->
+    <div class="grid-row margin-bottom-5">
+      <div class="grid-col-12">
+        <h2 class="usa-prose-h2 margin-bottom-5" id="searchHeader"> Search </h2>
+        <span id="results-summary" class="display-block desktop:display-inline">Results:</span>
+        <span class="applied-filter display-block desktop:display-inline usa-tag usa-tag--big" id="filterStyle1">{Filter applied style 1}</span>
+        <span class="applied-filter display-block desktop:display-inline usa-tag usa-tag--big" id="filterStyle2">{Filter applied style 2}</span>
+
+        <button type="button" class="usa-button usa-button--unstyled" id="resetSearchFiltersButton">Clear filters</button>
+      </div>
+    </div>
+
+    <div class="grid-row grid-gap">
+      <!-- START DM- 4912-->
+      <div id="REPLACE-with-something-about-filters" class="grid-col-12 tablet:grid-col-4 desktop:grid-col-4">
+        <div class="usa-accordion usa-accordion--bordered">
+          <h2 class="usa-accordion__heading">
+            <button
+              type="button"
+              class="usa-accordion__button"
+              aria-expanded="true"
+              aria-controls="filtersAccordion"
+            >
+              Filter Results
+            </button>
+          </h2>
+        <div id="filtersAccordion" class="usa-accordion__content usa-prose">
+          <fieldset class="usa-fieldset">
+            <legend class="usa-legend">Communities</legend>
+            <div class="usa-checkbox">
+              <input
+                class="usa-checkbox__input"
+                id="check-historical-truth"
+                type="checkbox"
+                name="historical-figures"
+                value="sojourner-truth"
+                checked="checked"
+              />
+              <label class="usa-checkbox__label" for="check-historical-truth"
+                >Sojourner Truth</label
+              >
+            </div>
+            <div class="usa-checkbox">
+              <input
+                class="usa-checkbox__input"
+                id="check-historical-douglass"
+                type="checkbox"
+                name="historical-figures"
+                value="frederick-douglass"
+              />
+              <label class="usa-checkbox__label" for="check-historical-douglass"
+                >Frederick Douglass</label
+              >
+            </div>
+            <div class="usa-checkbox">
+              <input
+                class="usa-checkbox__input"
+                id="check-historical-washington"
+                type="checkbox"
+                name="historical-figures"
+                value="booker-t-washington"
+              />
+              <label class="usa-checkbox__label" for="check-historical-washington"
+                >Booker T. Washington</label
+              >
+            </div>
+          </fieldset>
+          <fieldset class="usa-fieldset">
+            <legend class="usa-legend">Tags</legend>
+            <div class="usa-checkbox">
+              <input
+                class="usa-checkbox__input"
+                id="check-historical-truth"
+                type="checkbox"
+                name="historical-figures"
+                value="sojourner-truth"
+                checked="checked"
+              />
+              <label class="usa-checkbox__label" for="check-historical-truth"
+                >Sojourner Truth</label
+              >
+            </div>
+            <div class="usa-checkbox">
+              <input
+                class="usa-checkbox__input"
+                id="check-historical-douglass"
+                type="checkbox"
+                name="historical-figures"
+                value="frederick-douglass"
+              />
+              <label class="usa-checkbox__label" for="check-historical-douglass"
+                >Frederick Douglass</label
+              >
+            </div>
+            <div class="usa-checkbox">
+              <input
+                class="usa-checkbox__input"
+                id="check-historical-washington"
+                type="checkbox"
+                name="historical-figures"
+                value="booker-t-washington"
+              />
+              <label class="usa-checkbox__label" for="check-historical-washington"
+                >ADD SCROLLBARS for long list</label
+              >
+            </div>
+          </fieldset>
+          <fieldset class="usa-fieldset">
+            <legend class="usa-legend usa-legend">Sort by</legend>
+            <div class="usa-radio">
+              <input
+                class="usa-radio__input"
+                id="historical-truth"
+                type="radio"
+                name="historical-figures"
+                value="sojourner-truth"
+                checked="checked"
+              />
+              <label class="usa-radio__label" for="historical-truth"
+                >Sojourner Truth</label
+              >
+            </div>
+            <div class="usa-radio">
+              <input
+                class="usa-radio__input"
+                id="historical-douglass"
+                type="radio"
+                name="historical-figures"
+                value="frederick-douglass"
+              />
+              <label class="usa-radio__label" for="historical-douglass"
+                >Frederick Douglass</label
+              >
+            </div>
+            <div class="usa-radio">
+              <input
+                class="usa-radio__input"
+                id="historical-washington"
+                type="radio"
+                name="historical-figures"
+                value="booker-t-washington"
+              />
+              <label class="usa-radio__label" for="historical-washington"
+                >Booker T. Washington</label
+              >
+            </div>
+          </fieldset>
+          <!-- TODO: use combobox w/ arrow styling from original partial -->
+          <label class="usa-label" for="fruit">Originating location</label>
+          <div class="usa-combo-box">
+            <select class="usa-select" name="fruit" id="fruit">
+              <option value>Originating Location</option>
+              <option value="apple">VA Medical Center</option>
+              <option value="apricot">Clinical Resource Hub</option>
+            </select>
+          </div>
+          <!-- TODO: use combobox w/ arrow styling from original partial -->
+          <label class="usa-label" for="fruit">Adopting location</label>
+          <div class="usa-combo-box">
+            <select class="usa-select" name="fruit" id="fruit">
+              <option value>Adopting Location</option>
+              <option value="apple">VA Medical Center</option>
+              <option value="apricot">Clinical Resource Hub</option>
+            </select>
+          </div>
+        </div>
+      </div>
+    </div>
+      <!-- END DM-4912 -->
+      <!-- START DM-4913 -->
+      <div id="REPLACE-with-something-about-innovation-results" class="grid-col-12 tablet:grid-col-8 desktop:grid-col-8">
+        <h2 class="usa-prose-h2">Innovations</h2> <!-- TODO: set to "All Innovations" on empty search -->
+        <div class="innovation-preview grid-row padding-y-3"> <!-- TODO: make the entire section clickable as a link -->
+          <img src="#" class="bg-gray grid-col-3">
+          <div class="innovation-preview-body grid-col-fill">
+            <h3 class="usa-prose-h3 innovation-preview-title">{Innovation title}</h3>
+            <p class="innovation-preview-description margin-bottom-3">{Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. And here's stuff after an elipsis}</p>
+            <p class="innovation-preview-origin text-italic">By the Charles George Department of Veterans Affairs Medical Center (Ashville)</p>
+          </div>
+        </div>
+        <div class="innovation-preview grid-row padding-y-3"> <!-- TODO: make the entire section clickable as a link -->
+          <img src="#" class="bg-gray grid-col-3">
+          <div class="innovation-preview-body grid-col-fill">
+            <h3 class="usa-prose-h3 innovation-preview-title">{Innovation title}</h3>
+            <p class="innovation-preview-description margin-bottom-3">{Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. And here's stuff after an elipsis}</p>
+            <p class="innovation-preview-origin text-italic">By the {Facility Long Name} (Facility shortname)</p>
+          </div>
+        </div>
+        <div class="innovation-preview grid-row padding-y-3"> <!-- TODO: make the entire section clickable as a link -->
+          <img src="#" class="bg-gray grid-col-3">
+          <div class="innovation-preview-body grid-col-fill">
+          <h3 class="usa-prose-h3 innovation-preview-title">{Innovation title}</h3>
+          <p class="innovation-preview-description margin-bottom-3">{Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. And here's stuff after an elipsis}</p>
+          <p class="innovation-preview-origin text-italic">By {Non-facility Origin}</p>
+          </div>
+        </div>
+        <button class="usa-button dm-button--outline-secondary">{Load more}</button>
+      </div>
+      <!-- END DM-4913 -->
+    </div>
+  </div>
+
+
   <section class="grid-container margin-bottom-neg-3 margin-top-5">
     <%= render partial: "shared/messages", locals: {small_text: false} %>
     <form id="update-search-results-form">
@@ -83,4 +286,3 @@
     <%= render partial: 'shared/search_no_results', locals: { display_no_query_msg: true } %>
   </section>
 </div>
-

--- a/app/views/practices/search_partials/_category_checkbox.html.erb
+++ b/app/views/practices/search_partials/_category_checkbox.html.erb
@@ -11,6 +11,7 @@
          type="checkbox"
          name="<%= category_name %>"
          value="<%= category_name %>"
+         data-parent-category="<%= parent_category_name %>"
   >
   <label class="usa-checkbox__label margin-bottom-2 cat-<%= category_id %>-label" for="cat-<%= category_id %>-input">
     <%= category_name %>

--- a/app/views/practices/search_partials/_search_filters.html.erb
+++ b/app/views/practices/search_partials/_search_filters.html.erb
@@ -82,7 +82,4 @@
   <button type="submit" id="update-search-results-button" class="usa-button usa-button--primary display-block width-full desktop:margin-bottom-1 line-height-19px" name="button">
     Update results
   </button>
-  <button type="button" class="usa-button usa-button--secondary display-none desktop:display-block width-full line-height-19px" id="resetSearchFiltersButton">
-    Reset filters
-  </button>
 </div>

--- a/app/views/shared/_search_sort_select_section.html.erb
+++ b/app/views/shared/_search_sort_select_section.html.erb
@@ -1,7 +1,7 @@
 <% label_text =  local_assigns[:is_crh_show] ? 'Sort by' : '' %>
 <section id="<%= section_id %>" class="<%= section_classes %>">
   <div class="<%= first_div_classes %>">
-    <p class="font-sans-normal grid-col-8 line-height-26 margin-top-5" id="results-summary"></p>
+    <p class="font-sans-normal grid-col-8 line-height-26 margin-top-5" id="results-sort"></p>
     <div class="<%= second_div_classes %>" id="search_sort_options">
       <%= label_tag 'search_sort_option', label_text, class: 'usa-label margin-0', 'aria-label': 'Search sort options'%>
       <%= select_tag('', options_for_select(sort_options), id: 'search_sort_option', name: 'search_sort_option', class: 'height-5 usa-select margin-0') %>

--- a/app/views/visns/_show.js.erb
+++ b/app/views/visns/_show.js.erb
@@ -64,7 +64,7 @@ function searchPracticesByVisn() {
         $(SEARCH_RESULTS).removeClass('display-none');
         // Print results to the page
         document.querySelector('#search-results').innerHTML = finalResults;
-        
+
         $(SEARCH_RESULTS).showMoreItems({
             startNum: 6,
             afterNum: 6,
@@ -78,7 +78,7 @@ function searchPracticesByVisn() {
         // Trim whitespace from the query (can cause matching problems)
         query = query.trim();
         // Set variables
-        var resultsSummary = document.querySelector('#results-summary');
+        var resultsSummary = document.querySelector('#results-sort');
         // set the search page search bar input value
         searchField.value = query;
         if (query !== '') {

--- a/spec/features/about_spec.rb
+++ b/spec/features/about_spec.rb
@@ -26,7 +26,7 @@ describe 'About us page', type: :feature do
       all('.usa-accordion__heading')[2].click
       click_link('Emerging')
       expect(page).to have_content('Search')
-      expect(page).to have_content('2 results:')
+      expect(page).to have_content('2 Results:')
       expect(page).to have_content('Project HAPPEN')
       expect(page).to have_content('Best Practice Ever')
     end

--- a/spec/features/homepage_spec.rb
+++ b/spec/features/homepage_spec.rb
@@ -49,7 +49,7 @@ describe 'Homepage', type: :feature do
       fill_in('dm-homepage-search-field', with: 'James A. Haley')
       find('#dm-homepage-search-button').click
 
-      expect(page).to have_content('1 result:')
+      expect(page).to have_content('1 Result:')
       expect(page).to have_content(@practice.name)
     end
   end
@@ -186,7 +186,7 @@ describe 'Homepage', type: :feature do
         expect(page).to have_current_path('/search?all_communities=true')
         filter_button = find('button.search-filters-accordion-button')
         expect(filter_button).to have_text('Filters (1)')
-        expect(page).to have_content("1 result:")
+        expect(page).to have_content("1 Result:")
         expect(page).to have_content(@practice_3.name)
       end
     end

--- a/spec/features/practice_viewer/introduction_spec.rb
+++ b/spec/features/practice_viewer/introduction_spec.rb
@@ -194,7 +194,7 @@ describe 'Practice viewer - introduction', type: :feature, js: true do
       all('.usa-tag').first.click
       expect(page).to have_current_path('/search?filter_by=COVID')
       expect(page).to have_selector('#search-page', visible: true)
-      expect(page).to have_content('2 results')
+      expect(page).to have_content('2 Results')
       expect(page).to have_content('A public maximum practice')
       expect(page).to have_content('Another public maximum practice')
     end
@@ -215,7 +215,7 @@ describe 'Practice viewer - introduction', type: :feature, js: true do
     it 'should take the user to the search results page when the See more practices link is clicked' do
       click_link('See more emerging innovations')
       expect(page).to have_selector('#search-page', visible: true)
-      expect(page).to have_content('1 result')
+      expect(page).to have_content('1 Result')
       expect(page).to have_content('A public maximum practice')
     end
   end

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -234,7 +234,7 @@ describe 'Search', type: :feature do
       fill_in('dm-practice-search-field', with: 'practice')
       find('#dm-practice-search-button').click
 
-      expect(page).to have_content('13 results')
+      expect(page).to have_content('13 Results')
       expect(page).to_not have_content(@practice2.name)
 
       # show practices that are approved/published
@@ -244,7 +244,7 @@ describe 'Search', type: :feature do
       search
 
       expect(page).to be_accessible.according_to :wcag2a, :section508
-      expect(page).to have_content('14 results')
+      expect(page).to have_content('14 Results')
       expect(page).to have_content(@practice2.name)
     end
 
@@ -255,7 +255,7 @@ describe 'Search', type: :feature do
       find('#dm-practice-search-button').click
 
       expect(page).to have_content(@practice.name)
-      expect(page).to have_content('1 result')
+      expect(page).to have_content('1 Result')
     end
 
     it 'should be able to search based on practice categories related terms' do
@@ -266,7 +266,7 @@ describe 'Search', type: :feature do
       fill_in('dm-practice-search-field', with: 'Coronavirus')
       find('#dm-practice-search-button').click
 
-      expect(page).to have_content('5 results')
+      expect(page).to have_content('5 Results')
       expect(page).to have_content(@practice.name)
       expect(page).to have_content(@practice3.name)
       expect(page).to have_content(@practice5.name)
@@ -283,7 +283,7 @@ describe 'Search', type: :feature do
       find('#dm-practice-search-button').click
 
       expect(page).to have_content(@practice.name)
-      expect(page).to have_content('1 result')
+      expect(page).to have_content('1 Result')
     end
 
     it 'should be able to search based on originating facility name' do
@@ -292,7 +292,7 @@ describe 'Search', type: :feature do
       fill_in('dm-practice-search-field', with: 'Togus VA Medical Center')
       find('#dm-practice-search-button').click
 
-      expect(page).to have_content('2 results')
+      expect(page).to have_content('2 Results')
       expect(page).to have_content(@practice3.name)
       expect(page).to have_content(@practice5.name)
     end
@@ -301,19 +301,19 @@ describe 'Search', type: :feature do
       visit_search_page
       fill_in('dm-practice-search-field', with: 'overview problem foobar')
       find('#dm-practice-search-button').click
-      expect(page).to have_content('1 result')
+      expect(page).to have_content('1 Result')
       expect(page).to have_content(@practice.name)
 
       visit_search_page
       fill_in('dm-practice-search-field', with: 'overview solution fizzbuzz')
       find('#dm-practice-search-button').click
-      expect(page).to have_content('1 result')
+      expect(page).to have_content('1 Result')
       expect(page).to have_content(@practice3.name)
 
       visit_search_page
       fill_in('dm-practice-search-field', with: 'overview results mixmax')
       find('#dm-practice-search-button').click
-      expect(page).to have_content('1 result')
+      expect(page).to have_content('1 Result')
       expect(page).to have_content(@practice5.name)
     end
 
@@ -324,12 +324,12 @@ describe 'Search', type: :feature do
 
       fill_in('dm-practice-search-field', with: 'important')
       search
-      expect(page).to have_content('1 result')
+      expect(page).to have_content('1 Result')
       expect(page).to have_content('The Most Important Practice')
 
       fill_in('dm-practice-search-field', with: 'Rule')
       search
-      expect(page).to_not have_content('results')
+      expect(page).to_not have_content('Results')
       expect(page).to_not have_content('One Practice to Rule Them All')
       expect(page).to have_content('There are currently no matches for your search on the Marketplace.')
 
@@ -345,7 +345,7 @@ describe 'Search', type: :feature do
 
       fill_in('dm-practice-search-field', with: 'Rule')
       search
-      expect(page).to have_content('1 result')
+      expect(page).to have_content('1 Result')
       expect(page).to have_content('One Practice to Rule Them All')
       expect(page).to_not have_content('There are currently no matches for your search on the Marketplace.')
     end
@@ -361,7 +361,7 @@ describe 'Search', type: :feature do
         update_results
 
         expect(page).to have_content('Filters (3)')
-        expect(page).to have_content('6 results')
+        expect(page).to have_content('6 Results')
         expect(page).to have_content(@practice.name)
         expect(page).to have_content(@practice3.name)
         expect(page).to have_content(@practice5.name)
@@ -379,7 +379,7 @@ describe 'Search', type: :feature do
         set_combobox_val(0, 'VISN 8 Clinical Resource Hub (Remote)')
         update_results
 
-        expect(page).to have_content('2 results')
+        expect(page).to have_content('2 Results')
         expect(page).to have_content(@practice13.name)
         expect(page).to have_content(@practice14.name)
 
@@ -388,7 +388,7 @@ describe 'Search', type: :feature do
         set_combobox_val(1, 'VISN 8 Clinical Resource Hub (Remote)')
         update_results
 
-        expect(page).to have_content('2 results')
+        expect(page).to have_content('2 Results')
         expect(page).to have_content(@practice12.name)
         expect(page).to have_content(@practice14.name)
       end
@@ -403,7 +403,7 @@ describe 'Search', type: :feature do
         expect(find("#cat-5-input", visible: false)).to be_checked
         expect(find("#cat-6-input", visible: false)).to be_checked
         update_results
-        expect(page).to have_content('7 results')
+        expect(page).to have_content('7 Results')
         toggle_filters_accordion
         select_category('.cat-2-label')
         expect(find("#cat-all-strategic-input", visible: false)).to_not be_checked
@@ -413,7 +413,7 @@ describe 'Search', type: :feature do
         expect(find("#cat-5-input", visible: false)).to be_checked
         expect(find("#cat-6-input", visible: false)).to be_checked
         update_results
-        expect(page).to have_content('5 results')
+        expect(page).to have_content('5 Results')
       end
 
       it 'should collect practices that match ALL of the conditions if the user selects filters AND uses the search input' do
@@ -426,7 +426,7 @@ describe 'Search', type: :feature do
         select_category('.cat-2-label')
         search
         expect(page).to have_content('Filters (2)')
-        expect(page).to have_content('2 results')
+        expect(page).to have_content('2 Results')
         expect(page).to have_content(@practice3.name)
         expect(page).to have_content(@practice5.name)
 
@@ -436,7 +436,7 @@ describe 'Search', type: :feature do
         update_results
 
         expect(page).to have_content('Filters (3)')
-        expect(page).to have_content('1 result')
+        expect(page).to have_content('1 Result')
         expect(page).to have_content(@practice3.name)
         expect(page).to_not have_content(@practice5.name)
 
@@ -447,7 +447,7 @@ describe 'Search', type: :feature do
         update_results
 
         expect(page).to have_content('Filters (1)')
-        expect(page).to have_content('4 results')
+        expect(page).to have_content('4 Results')
         expect(page).to have_content(@practice3.name)
         expect(page).to have_content(@practice4.name)
         expect(page).to have_content(@practice5.name)
@@ -458,7 +458,7 @@ describe 'Search', type: :feature do
         update_results
 
         expect(page).to have_content('Filters (2)')
-        expect(page).to have_content('2 results')
+        expect(page).to have_content('2 Results')
         expect(page).to have_content(@practice4.name)
         expect(page).to have_content(@practice5.name)
 
@@ -469,7 +469,7 @@ describe 'Search', type: :feature do
         update_results
 
         expect(page).to have_content('Filters (1)')
-        expect(page).to have_content('1 result')
+        expect(page).to have_content('1 Result')
         expect(page).to have_content(@practice6.name)
 
         # search for practices with the search bar and clinical resource hub filters
@@ -483,7 +483,7 @@ describe 'Search', type: :feature do
         update_results
 
         expect(page).to have_content('Filters (2)')
-        expect(page).to have_content('1 result')
+        expect(page).to have_content('1 Result')
         expect(page).to have_content(@practice14.name)
       end
 
@@ -496,7 +496,7 @@ describe 'Search', type: :feature do
           update_results
 
           expect(page).to have_content('Filters (1)')
-          expect(page).to have_content('4 results')
+          expect(page).to have_content('4 Results')
           expect(page).to have_content(@practice3.name)
           expect(page).to have_content(@practice3.name)
           expect(page).to have_content(@practice5.name)
@@ -511,7 +511,7 @@ describe 'Search', type: :feature do
           update_results
 
           expect(page).to have_content('Filters (1)')
-          expect(page).to have_content('2 results')
+          expect(page).to have_content('2 Results')
           expect(page).to have_content(@practice13.name)
           expect(page).to have_content(@practice14.name)
         end
@@ -523,7 +523,7 @@ describe 'Search', type: :feature do
           set_combobox_val(0, 'Vinita VA Clinic')
           update_results
 
-          expect(page).to have_content('1 result')
+          expect(page).to have_content('1 Result')
           expect(page).to have_content(@practice12.name)
         end
       end
@@ -536,7 +536,7 @@ describe 'Search', type: :feature do
           set_combobox_val(1, 'VISN-23')
           update_results
 
-          expect(page).to have_content('2 results')
+          expect(page).to have_content('2 Results')
           expect(page).to have_content(@practice.name)
           expect(page).to have_content(@practice3.name)
 
@@ -549,7 +549,7 @@ describe 'Search', type: :feature do
           update_results
 
           expect(page).to have_content('Filters (1)')
-          expect(page).to have_content('2 results')
+          expect(page).to have_content('2 Results')
           expect(page).to have_content(@practice12.name)
           expect(page).to have_content(@practice14.name)
         end
@@ -561,7 +561,7 @@ describe 'Search', type: :feature do
           set_combobox_val(0, 'Vinita VA Clinic')
           update_results
 
-          expect(page).to have_content('1 result')
+          expect(page).to have_content('1 Result')
           expect(page).to have_content(@practice12.name)
         end
       end
@@ -577,7 +577,7 @@ describe 'Search', type: :feature do
         update_results
 
         # results should be sorted my most relevant(closest match) by default
-        expect(page).to have_content('6 results')
+        expect(page).to have_content('6 Results')
         expect(first('span.dm-practice-title').text).to eq(@practice6.name)
 
         toggle_filters_accordion
@@ -585,7 +585,7 @@ describe 'Search', type: :feature do
         select_category('.cat-4-label')
         update_results
 
-        expect(page).to have_content('6 results')
+        expect(page).to have_content('6 Results')
         expect(first('span.dm-practice-title').text).to_not eq(@practice6.name)
         expect(first('span.dm-practice-title').text).to eq(@practice4.name)
 
@@ -622,7 +622,7 @@ describe 'Search', type: :feature do
         fill_in('dm-practice-search-field', with: 'practice')
         search
 
-        expect(page).to have_content('13 results')
+        expect(page).to have_content('13 Results')
         expect(page).to have_selector('div.dm-practice-card', count: 12)
 
         # show the next set of 12 results
@@ -750,12 +750,40 @@ describe 'Search', type: :feature do
       select_category('.cat-5-label')
       update_results
 
-      expect(page).to have_content('5 results')
+      expect(page).to have_content('5 Results')
       expect(page).to have_content(@practice.name)
       expect(page).to have_content(@practice3.name)
       expect(page).to have_content(@practice5.name)
       expect(page).to have_content(@practice7.name)
       expect(page).to have_content(@practice10.name)
+    end
+  end
+
+  describe 'search header' do
+    it 'should display appropriate header text when page loads' do
+      visit_search_page
+      expect(find('#searchHeader')).to have_text('Search')
+      expect(find('#searchHeader')).not_to have_text('Search Results for:')
+
+      visit '/'
+      find('#dm-homepage-search-field').click
+      fill_in('dm-homepage-search-field', with: 'test')
+      find_button('dm-homepage-search-button').click
+
+      expect(find('#searchHeader')).to have_text('Search Results for: test')
+    end
+
+    it 'should update the search header when a query is entered and removed in search bar' do
+      visit_search_page
+
+      fill_in('dm-practice-search-field', with: 'test')
+      search
+      expect(find('#searchHeader')).to have_text('Search Results for: test')
+
+      fill_in('dm-practice-search-field', with: '')
+      search
+      expect(find('#searchHeader')).to have_text('Search')
+      expect(find('#searchHeader')).not_to have_text('Search Results for:')
     end
   end
 end

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -329,7 +329,7 @@ describe 'Search', type: :feature do
 
       fill_in('dm-practice-search-field', with: 'Rule')
       search
-      expect(page).to_not have_content('Results')
+      expect(page).to have_content('0 Results')
       expect(page).to_not have_content('One Practice to Rule Them All')
       expect(page).to have_content('There are currently no matches for your search on the Marketplace.')
 
@@ -375,7 +375,7 @@ describe 'Search', type: :feature do
         visit_search_page
 
         toggle_filters_accordion
-        click_button('Reset filters')
+        click_button('Clear filters')
         set_combobox_val(0, 'VISN 8 Clinical Resource Hub (Remote)')
         update_results
 
@@ -384,7 +384,7 @@ describe 'Search', type: :feature do
         expect(page).to have_content(@practice14.name)
 
         toggle_filters_accordion
-        click_button('Reset filters')
+        click_button('Clear filters')
         set_combobox_val(1, 'VISN 8 Clinical Resource Hub (Remote)')
         update_results
 
@@ -442,7 +442,7 @@ describe 'Search', type: :feature do
 
         # Reset filters and select a VISN from the Originating Facility combo box
         toggle_filters_accordion
-        click_button('Reset filters')
+        click_button('Clear filters')
         set_combobox_val(0, 'VISN-1')
         update_results
 
@@ -464,7 +464,7 @@ describe 'Search', type: :feature do
 
         # Reset filters and select a VISN from the Adopting Facility combo box
         toggle_filters_accordion
-        click_button('Reset filters')
+        click_button('Clear filters')
         set_combobox_val(1, 'VISN-7')
         update_results
 

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -566,7 +566,7 @@ describe 'Search', type: :feature do
         end
       end
 
-      describe 'Dynamic applied filters' do
+      describe 'Dynamic applied filters', js: true do
         before do
           visit_search_page
 
@@ -589,8 +589,7 @@ describe 'Search', type: :feature do
         it 'should allow filters to be individually removed to update results' do
           expect(page).to have_content('6 Results')
           within('#searchResultsContainer') do
-            tag_a = all('span.applied-filter').first
-            tag_a.find('span', text: 'X').click
+            all('button.applied-filter').first.click
           end
           # expect updated applied filters
           expect(page).not_to have_content('TAG: COVID')
@@ -619,12 +618,10 @@ describe 'Search', type: :feature do
         end
 
         it "should remove the 'Clear filters' button when all applied filters are removed" do
-          4.times do
-            within('#searchResultsContainer') do
-              tag_a = all('span.applied-filter').first
-              tag_a.find('span', text: 'X').click
-            end
-          end
+          find_button('COVID').click
+          find_button('Pulmonary Care').click
+          find_button('Norwood VA Clinic').click
+          find_button('Marietta VA Clinic').click
 
           expect(page).not_to have_button('Clear filters')
         end

--- a/spec/features/shared/header_spec.rb
+++ b/spec/features/shared/header_spec.rb
@@ -177,7 +177,7 @@ describe 'Diffusion Marketplace header', type: :feature, js: true do
         find('#dm-navbar-search-desktop-button').click
       end
 
-      expect(page).to have_content('1 result')
+      expect(page).to have_content('1 Result')
       expect(page).to have_content('A public practice')
       expect(page).to have_current_path('/search?query=test')
 
@@ -214,7 +214,7 @@ describe 'Diffusion Marketplace header', type: :feature, js: true do
       open_mobile_menu
       fill_in('dm-navbar-search-mobile-field', with: 'test')
       find('#dm-navbar-search-mobile-button').click
-      expect(page).to have_content('1 result')
+      expect(page).to have_content('1 Result')
       expect(page).to have_content('A public practice')
       expect(page).to have_current_path('/search?query=test')
 

--- a/spec/features/users/recommended_for_you_spec.rb
+++ b/spec/features/users/recommended_for_you_spec.rb
@@ -110,7 +110,7 @@ describe 'Recommended for you page', type: :feature do
 
       click_link('See more innovations')
       expect(page).to have_selector('#search-page', visible: true)
-      expect(page).to have_content('4 results')
+      expect(page).to have_content('4 Results')
     end
   end
 


### PR DESCRIPTION
### JIRA issue link


## Description - what does this code do?
updates to search js:

1. Reverts change to search page ajax call that updates category usage, back to making call regardless of presence of selected categories, the original intent is for a search query that matches a category to be saved as a "Category selected" ahoy event.
2. Updates logic responsible for selecting "All Communities" tags in filters when the "Browse all Community Innovations" link is clicked from the homepage search dropdown. I forgot this was a thing when I worked on the applied filter tags, I believe we need to keep the logic that updates the count of applied filters because it will still be used in the dropdown copy in the mobile view.

## Testing done - how did you test it/steps on how can another person can test it 
1. Locally, verify that when you click the  "Browse all Community Innovations"  link from the homepage search dropdown it navs to the search page with all the "Communities" tags checked and reflected in the search results shown.
2. Verify that when you search for a query that matches a category it creates a "Category selected" event in the db.

## Screenshots, Gifs, Videos from application (if applicable)


## Link to mock-ups/mock ups (image file if you have it) (if applicable)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Unit tests written (if applicable)
- [ ] e2e/accessibility tests written (if applicable)
- [x] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating JIRA issue
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs