### PR TITLE
Dm 4940 add community tags to seeds

### DIFF
--- a/app/models/practice_editor.rb
+++ b/app/models/practice_editor.rb
@@ -16,7 +16,9 @@ class PracticeEditor < ApplicationRecord
   def self.create_and_invite(practice, user)
     # Email param ensures the user associated with the practice editor has a valid va.gov email address
     self.create!(practice: practice, user: user, email: user.email)
-    PracticeEditorMailer.invite_to_edit_practice_email(practice, user).deliver
+    if (Rails.env.production? && ENV['PROD_SERVERNAME'] == 'PROD') || Rails.env.test?
+      PracticeEditorMailer.invite_to_edit_practice_email(practice, user).deliver
+    end
   end
 
   def ensure_practice_has_at_least_one_practice_editor

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -49,8 +49,9 @@ _domains = [
 
 
 impact_categories = [
-    Category.find_or_create_by!(name: 'Clinical', short_name: 'clinical', description: 'Categorys on clinical domains'),
-    Category.find_or_create_by!(name: 'Operational', short_name: 'operational', description: 'Categorys on operational domains'),
+    Category.find_or_create_by!(name: 'Clinical', short_name: 'clinical', description: 'Categories on clinical domains'),
+    Category.find_or_create_by!(name: 'Operational', short_name: 'operational', description: 'Categories on operational domains'),
+    Category.find_or_create_by!(name: 'Communities', short_name: 'communities', description: 'Community categories'),
 ]
 
 _clinical_impacts = [
@@ -109,6 +110,13 @@ _operational_impacts = [
     Category.find_or_create_by!(name: 'Social Services', short_name: 'social_services', description: 'Social Services', parent_category: impact_categories[1]),
     Category.find_or_create_by!(name: 'Contracting & Purchasing', short_name: 'contracting_purchasing', description: 'Contracting & Purchasing', parent_category: impact_categories[1]),
     Category.find_or_create_by!(name: 'None', short_name: 'none', description: 'No clinical impact', parent_category: impact_categories[1]),
+]
+
+_community_impacts = [
+    Category.find_or_create_by!(name: 'VA Immersive', short_name: 'va immersive', description: 'VA Immersive', parent_category: impact_categories[2]),
+    Category.find_or_create_by!(name: 'Suicide Prevention', short_name: 'suicide prevention', description: 'Suicide Prevention', parent_category: impact_categories[2]),
+    Category.find_or_create_by!(name: 'Age-Friendly', short_name: 'age-friendly', description: 'Age-Friendly', parent_category: impact_categories[2]),
+    Category.find_or_create_by!(name: 'QUERI', short_name: 'queri', description: 'QUERI', parent_category: impact_categories[2]),
 ]
 
 

--- a/lib/tasks/categories.rake
+++ b/lib/tasks/categories.rake
@@ -192,4 +192,43 @@ namespace :categories do
 
     puts "Existing categories have been successfully updated!"
   end
+
+  desc 'Add Communities categories to practices'
+  task :add_communities_cats => :environment do
+    community_practices = {
+      'VA Immersive' => [
+        'Cards for Connection',
+        'Healthier Kidneys Through Your Kitchen',
+        'WHoOpSafe'
+      ],
+      'QUERI' => [
+        'Green Gloves Program',
+        'GERI-VET',
+        'Preoperative Frailty Screening & Prehabilitation'
+      ],
+      'Age-Friendly' => [
+        'PRIDE In All Who Served: Reducing Healthcare Disparities for LGBT Veterans',
+        'Red Coat Ambassador Program',
+        'Red Coat Ambassador Program'
+      ],
+      'Suicide Prevention' => [
+        'Transcending Self Therapy: Integrative Cognitive Behavioral Treatment',
+        'Tour Of Duty',
+        'Gerofit'
+      ]
+    }
+
+    community_practices.each do |category_name, practice_names|
+      category =  Category.find_by(name: category_name)
+
+      if category
+        practice_names.each do |practice_name|
+          practice = Practice.find_by(name: practice_name)
+          if practice
+            CategoryPractice.find_or_create_by!(practice: practice, category: category)
+          end
+        end
+      end
+    end
+  end
 end

--- a/lib/tasks/dm.rake
+++ b/lib/tasks/dm.rake
@@ -22,6 +22,7 @@ namespace :dm do
     Rake::Task['diffusion_history:all'].execute
     Rake::Task['inet_partner_practices:assign_inet_partner'].execute
     Rake::Task['categories:add_covid_cats'].execute
+    Rake::Task['categories:add_communities_cats'].execute
     Rake::Task['practice_origin_facilities:move_practice_initiating_facility'].execute
     Rake::Task['milestones:port_milestones_to_timelines'].execute
     Rake::Task['practice_multimedia:transfer_practice_impact_photos'].execute


### PR DESCRIPTION
### JIRA issue link
https://agile6.atlassian.net/browse/DM-4940

## Description - what does this code do?
1. Adds "Communities" parent category with 4 sub-categories to seeds file
2. Adds `categories:add_communities_cats` rake task that associates 3 innovations with each Community sub category
3. Adds `categories:add_communities_cats` to sequentially called tasks within the `dm:full_import` task
4. Updates `PracticeEditor#create_and_invite` method to send invite emails only when not in development environment (QOL improvement so that when running the `dm:full_import` task it won't open a new browser window for each simulated email notification as users are associated with innovations, not necessarily needed)

## Testing done - how did you test it/steps on how can another person can test it 
1. Reset your db with `rails db:{drop,create,migrate}`
2. Run the `dm:full_import` task
3. Verify that emails are not generated and rendered in your browser as the task runs
4. Verify that on the `/search` page you see 4 "Communities" tags to select, with each returning 3 innovations when selected.

## Screenshots, Gifs, Videos from application (if applicable)


## Link to mock-ups/mock ups (image file if you have it) (if applicable)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Unit tests written (if applicable)
- [ ] e2e/accessibility tests written (if applicable)
- [x] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating JIRA issue
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs