### PR TITLE
dm-4912 search refresh new filter panel

### DIFF
--- a/app/assets/stylesheets/dm/pages/_search.scss
+++ b/app/assets/stylesheets/dm/pages/_search.scss
@@ -70,10 +70,6 @@
     }
   }
 
-  .usa-checkbox__label:before {
-    border-radius: 0 !important;
-  }
-
   .usa-combo-box__toggle-list,
   .usa-combo-box__clear-input {
     top: 2.3em !important;
@@ -93,6 +89,34 @@
 
   .button-box {
     margin-bottom: 24px;
+  }
+
+  .filters-scrollbar {
+    scrollbar-width: thin;
+    scrollbar-color: rgba(0, 0, 0, 0.2) rgba(0, 0, 0, 0.1);
+    overflow-y: scroll;
+  }
+
+  .filters-scrollbar::-webkit-scrollbar {
+    width: 8px;
+  }
+
+  .filters-scrollbar::-webkit-scrollbar-track {
+    background: rgba(0, 0, 0, 0.1);
+  }
+
+  .filters-scrollbar::-webkit-scrollbar-thumb {
+    background-color: rgba(0, 0, 0, 0.2);
+    border-radius: 10px;
+    border: 2px solid rgba(0, 0, 0, 0.1);
+  }
+
+  .filters-scrollbar::-webkit-scrollbar-thumb:hover {
+    background-color: rgba(0, 0, 0, 0.3);
+  }
+
+  .filter-submit-button {
+    @include transition-btn-colors;
   }
 }
 
@@ -201,10 +225,6 @@
       @include u-margin-bottom(0);
     }
   }
-
-  #update-search-results-button {
-    @include transition-btn-colors;
-  }
 }
 
 #update-search-results-form {
@@ -285,7 +305,6 @@
 
 #filter_button_container {
   @media screen and (max-width: 1023px) {
-    position: absolute;
     bottom: 0;
     width: 100%;
   }

--- a/app/assets/stylesheets/dm/pages/_search.scss
+++ b/app/assets/stylesheets/dm/pages/_search.scss
@@ -91,28 +91,28 @@
     margin-bottom: 24px;
   }
 
-  .filters-scrollbar {
+  .category-filters {
     scrollbar-width: thin;
     scrollbar-color: rgba(0, 0, 0, 0.2) rgba(0, 0, 0, 0.1);
     overflow-y: scroll;
     scroll-behavior: smooth;
   }
 
-  .filters-scrollbar::-webkit-scrollbar {
+  .category-filters::-webkit-scrollbar {
     width: 8px;
   }
 
-  .filters-scrollbar::-webkit-scrollbar-track {
+  .category-filters::-webkit-scrollbar-track {
     background: rgba(0, 0, 0, 0.1);
   }
 
-  .filters-scrollbar::-webkit-scrollbar-thumb {
+  .category-filters::-webkit-scrollbar-thumb {
     background-color: rgba(0, 0, 0, 0.2);
     border-radius: 10px;
     border: 2px solid rgba(0, 0, 0, 0.1);
   }
 
-  .filters-scrollbar::-webkit-scrollbar-thumb:hover {
+  .category-filters::-webkit-scrollbar-thumb:hover {
     background-color: rgba(0, 0, 0, 0.3);
   }
 

--- a/app/assets/stylesheets/dm/pages/_search.scss
+++ b/app/assets/stylesheets/dm/pages/_search.scss
@@ -95,6 +95,7 @@
     scrollbar-width: thin;
     scrollbar-color: rgba(0, 0, 0, 0.2) rgba(0, 0, 0, 0.1);
     overflow-y: scroll;
+    scroll-behavior: smooth;
   }
 
   .filters-scrollbar::-webkit-scrollbar {

--- a/app/assets/stylesheets/dm/pages/_search.scss
+++ b/app/assets/stylesheets/dm/pages/_search.scss
@@ -216,16 +216,6 @@
   .fa-times {
     display: block !important;
   }
-
-  .search-category-filters,
-  .search-originating-facility-filter,
-  .search-adopting-facility-filter {
-    @include u-margin-bottom(1);
-
-    @media screen and (min-width: 1024px) {
-      @include u-margin-bottom(0);
-    }
-  }
 }
 
 #update-search-results-form {

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -66,7 +66,7 @@
                   </li>
                 <% end %>
               </ul>
-              <a class="browse-all-link text-bold" href="<%= search_path %>?filters=open">Browse all Tags</a>
+              <a class="browse-all-link text-bold" href="<%= search_path %>">Browse all Tags</a>
             </div>
 
             <div class="result-section" data-type="community">

--- a/app/views/practices/_search.js.erb
+++ b/app/views/practices/_search.js.erb
@@ -319,22 +319,15 @@ function searchPracticesPage() {
             //     // Collect any practice that has a category that matches the selected category/categories.
             var categoryFilters = [];
 
-            Object.entries(categories).forEach(function ([parentCategory, selectedValues]) {
-                if (parentCategory !== 'communities' && selectedValues.length) {
-                    selectedValues.forEach(function (categorySelection) {
-                        addAppliedFilter('TAG', categorySelection);
-                        categoryFilters.push({'category_names': "=\"" + categorySelection + "\""});
+            Object.entries(categories).forEach(function ([parentCat, subCats]) {
+                if (subCats.length) {
+                    var catType = parentCat === 'communities' ? 'COMMUNITY' : 'TAG';
+                    subCats.forEach(function (subCat) {
+                        addAppliedFilter(catType, subCat);
+                        categoryFilters.push({'category_names': "=\"" + subCat + "\""});
                     });
                 }
             });
-
-            // Iterate over 'communities' categories
-            if (categories['communities'] && categories['communities'].length) {
-                categories['communities'].forEach(function (categorySelection) {
-                    addAppliedFilter('COMMUNITY', categorySelection);
-                    categoryFilters.push({'category_names': "=\"" + categorySelection + "\""});
-                });
-            }
         }
 
         var originFacilityArray = originatingFacility ? [] : null;

--- a/app/views/practices/_search.js.erb
+++ b/app/views/practices/_search.js.erb
@@ -158,61 +158,6 @@ function hideResultsElAndShowSpinner() {
     showSpinner();
 }
 
-function openMobileFiltersModal(openOnPageLoad) {
-    $(document).on('click', '#mobile_filters_button', function() {
-        $('.search-filters-accordion-button').attr('aria-expanded', 'true');
-        $('#search_filters_dropdown').removeAttr('hidden');
-        // Return the user to their original spot on the page, before opening the mobile modal
-        pagePosition.getScrollPosition();
-    });
-
-    if (openOnPageLoad) {
-        $('#mobile_filters_button').trigger('click');
-    }
-}
-
-function toggleAccordion(accordionEl, containerEl) {
-    if (($(accordionEl).attr('aria-expanded') === 'true')) {
-        $(accordionEl).attr('aria-expanded', 'false');
-        $(containerEl).addClass('display-none');
-    } else {
-        $(accordionEl).attr('aria-expanded', 'true');
-        $(containerEl).removeClass('display-none');
-    }
-}
-
-function toggleMobileCategoriesAccordion(openOnPageLoad) {
-    $(document).on('click', '.mobile-category-accordion', function() {
-        toggleAccordion(this, '.category-container');
-    });
-
-    if (openOnPageLoad) {
-        $('.mobile-category-accordion').each(function() {
-            toggleAccordion(this, '.category-container');
-        });
-    }
-}
-
-function toggleMobileOriginAccordion() {
-    $(document).on('click', '.mobile-origin-accordion', function() {
-        toggleAccordion(this, '.originating-facility-container');
-    });
-}
-
-function toggleMobileAdoptingAccordion() {
-    $(document).on('click', '.mobile-adopting-accordion', function() {
-        toggleAccordion(this, '.adopting-facility-container');
-    });
-}
-
-function closeMobileFiltersModal() {
-    $(document).on('click', '#close_filters_modal', function () {
-        $('.search-filters-accordion-button').attr('aria-expanded', 'false')
-        $('#search_filters_dropdown').attr('hidden', 'true');
-        // Bring the user back to their original spot on the page, in case they scrolled down while in the modal
-        $(window).scrollTop(pagePosition.original);
-    });
-}
 
 function searchPracticesPage() {
     const searchField = document.querySelector('#dm-practice-search-field');
@@ -802,12 +747,12 @@ function searchPracticesPage() {
                 checkbox.checked = false;
             }
         } else if (filterType === 'ORIGIN') {
-            const button = document.querySelector('.originating-facility-container .usa-combo-box__clear-input');
+            const button = document.querySelector('#originating-facility-container .usa-combo-box__clear-input');
             if (button) {
                 button.click();
             }
         } else if (filterType === 'ADOPTION') {
-            const button = document.querySelector('.adopting-facility-container .usa-combo-box__clear-input');
+            const button = document.querySelector('#adopting-facility-container .usa-combo-box__clear-input');
             if (button) {
                 button.click();
             }
@@ -901,16 +846,6 @@ function searchPracticesPage() {
         }
     }
 
-    function closeAccordion(accordionEl, containerEl) {
-        $(accordionEl).attr('aria-expanded', 'false');
-        $(containerEl).addClass('display-none');
-    }
-
-    var accordionButton = $('.search-filters-accordion-button')
-    // function accordionText(checkboxCount, inputCount) {
-    //     return accordionButton.text('Filters ' + '(' + (checkboxCount + inputCount) + ')');
-    // }
-
     $(document).on('submit', '#update-search-results-form', function (e) {
         e.preventDefault();
         hideResultsSectionElAndShowSpinner();
@@ -920,11 +855,6 @@ function searchPracticesPage() {
             accordionButton.attr('aria-expanded', 'false');
             $('#search_filters_dropdown').attr('hidden', 'true');
         }
-
-        // Close mobile accordions
-        closeAccordion('.mobile-origin-accordion', '.originating-facility-container');
-        closeAccordion('.mobile-adopting-accordion', '.adopting-facility-container');
-        closeAccordion('.mobile-category-accordion', '.category-container');
 
         // Bring the user back to their original spot on the page, before they opened the mobile modal
         if ($(window).width() < 1024) {
@@ -984,31 +914,6 @@ function searchPracticesPage() {
 
         // Run the search
         search(searchField.value, chosenCategories, originatingFacility, adoptingFacility);
-
-        // // Display the amount of filters used(if any)
-        // var checkboxCount = selectedCategoryCheckboxes.length;
-        // var noOriginatingFacilityText = originatingFacilityInput.val() === '';
-        // var originatingFacilityTextPresent = originatingFacilityInput.val() !== '';
-        // var noAdoptingFacilityText = adoptingFacilityInput.val() === '';
-        // var adoptingFacilityTextPresent = adoptingFacilityInput.val() !== '';
-
-        // if (checkboxCount > 0 && originatingFacilityTextPresent && noAdoptingFacilityText) {
-        //     accordionText(checkboxCount, 1);
-        // } else if (checkboxCount > 0 && noOriginatingFacilityText && adoptingFacilityTextPresent) {
-        //     accordionText(checkboxCount, 1);
-        // } else if (checkboxCount > 0 && noOriginatingFacilityText && noAdoptingFacilityText) {
-        //     accordionText(checkboxCount, 0);
-        // } else if (checkboxCount > 0 && originatingFacilityTextPresent && adoptingFacilityTextPresent) {
-        //     accordionText(checkboxCount, 2);
-        // } else if (checkboxCount === 0 && originatingFacilityTextPresent && noAdoptingFacilityText) {
-        //     accordionText(0, 1);
-        // } else if (checkboxCount === 0 && noOriginatingFacilityText && adoptingFacilityTextPresent) {
-        //     accordionText(0, 1);
-        // } else if (checkboxCount === 0 && noOriginatingFacilityText && noAdoptingFacilityText) {
-        //     return accordionButton.text('Filters');
-        // } else if (checkboxCount === 0 && originatingFacilityTextPresent && adoptingFacilityTextPresent) {
-        //     accordionText(0, 2);
-        // }
     }
 
     // Sort the results based on each sort option
@@ -1051,9 +956,6 @@ function searchPracticesPage() {
 
         // Move the focus area back to the top of the filters window
         $(".usa-combo-box__clear-input__wrapper").attr("tabindex",-1).focus();
-        // Reset filter count text
-        // $('.search-filters-accordion-button').text('Filters');
-        // reset search results
         searchPracticesPage();
     })
 
@@ -1112,12 +1014,6 @@ function trackSearchByFilter(filterTerm) {
     }
 }
 
-function preventFiltersAccordionContentFlickerOnPageLoad() {
-    $(document).arrive('.desktop-filters-accordion-heading', { existing: true }, (el) => {
-        $(el).next().removeClass('display-none');
-    });
-}
-
 function addAllCheckBoxListener(allCheckboxSelector, standardCheckboxSelector) {
     let allCheckbox = allCheckboxSelector;
     let checkbox = standardCheckboxSelector;
@@ -1143,8 +1039,12 @@ function addAllCheckBoxListener(allCheckboxSelector, standardCheckboxSelector) {
 function moveFilters() {
   const width = window.innerWidth;
   const filtersContainer = document.getElementById('filtersContainer');
-  const mobileContainer = document.getElementById('filtersAccordion');
-  const desktopContainer = document.getElementById('desktopFilters');
+  const mobileContainer = document.getElementById('mobileFiltersContainer');
+  const desktopContainer = document.getElementById('desktopFiltersContainer');
+
+  if (!filtersContainer || !mobileContainer || !desktopContainer) {
+    return;
+  }
 
   if (width < 1024) {
     if (desktopContainer.contains(filtersContainer)) {
@@ -1166,14 +1066,7 @@ function moveFilters() {
 
 function execSearchFunctions() {
     const urlParams = new URLSearchParams(window.location.search);
-    const openFiltersOnPageLoad = urlParams.get('filters') === 'open';
 
-    openMobileFiltersModal(openFiltersOnPageLoad);
-    toggleMobileCategoriesAccordion(openFiltersOnPageLoad);
-    toggleMobileOriginAccordion();
-    toggleMobileAdoptingAccordion();
-    closeMobileFiltersModal();
-    preventFiltersAccordionContentFlickerOnPageLoad();
     addAllCheckBoxListener('.all-clinical-checkbox', '.clinical-checkbox');
     addAllCheckBoxListener('.all-operational-checkbox', '.operational-checkbox');
     addAllCheckBoxListener('.all-strategic-checkbox', '.strategic-checkbox');

--- a/app/views/practices/_search.js.erb
+++ b/app/views/practices/_search.js.erb
@@ -151,7 +151,7 @@ function hideResultsElAndShowSpinner() {
 }
 
 
-function searchPracticesPage() {
+function searchPracticesPage(skipSearchTracking=false) {
     const searchField = document.querySelector('#dm-practice-search-field');
     // Skip if not the search page
     if (location.pathname !== '/search') return;
@@ -253,7 +253,6 @@ function searchPracticesPage() {
         $('#resetSearchFiltersButton').addClass('display-none');
 
         if (categories) {
-            //     // Collect any practice that has a category that matches the selected category/categories.
             var categoryFilters = [];
 
             Object.entries(categories).forEach(function ([parentCat, subCats]) {
@@ -356,6 +355,7 @@ function searchPracticesPage() {
         the results will have the same score because it stops after the first match.
         */
         function improveResultScoreBasedOnAmountOfCategoryMatches(results) {
+            allChosenCategories = Object.values(categories).flat();
             results.map(function(result) {
                 var resultScore = result.score;
                 var cat_names = result.item.category_names;
@@ -723,7 +723,7 @@ function searchPracticesPage() {
         appliedFilterButton.addEventListener('click', function(event) {
             uncheckFilter(filterType, filterName);
             $('#resetSearchFiltersButton').addClass('display-none');
-            updateResults();
+            updateResults(false);
             event.stopPropagation();
         });
 
@@ -882,7 +882,7 @@ function searchPracticesPage() {
 
         if (Object.keys(chosenCategories).length === 0) {
             chosenCategories = null;
-        } else {
+        } else if (!skipSearchTracking) {
             // Update Category Usage....
             allChosenCategories = Object.values(chosenCategories).flat();
             Rails.ajax({
@@ -1045,11 +1045,14 @@ function moveFilters() {
 }
 
 function execSearchFunctions() {
+    const urlParams = new URLSearchParams(window.location.search);
+    const skipSearchTracking = urlParams.has('all_communities') || urlParams.has('category');;
+
     addAllCheckBoxListener('.all-clinical-checkbox', '.clinical-checkbox');
     addAllCheckBoxListener('.all-operational-checkbox', '.operational-checkbox');
     addAllCheckBoxListener('.all-strategic-checkbox', '.strategic-checkbox');
     addAllCheckBoxListener('.all-communities-checkbox', '.communities-checkbox');
-    searchPracticesPage();
+    searchPracticesPage(skipSearchTracking);
     moveFilters();
 }
 

--- a/app/views/practices/_search.js.erb
+++ b/app/views/practices/_search.js.erb
@@ -14,16 +14,8 @@
     var SORT_EL = '#search_sort_option';
     var isBlankSearch = false;
     var NO_SEARCH_RESULTS_TEXT = '.no-query-results-p';
-    // Add Namespace for scroll position
-    var pagePosition = {
-        original: 0,
-        // Log the user's spot on the page when they open the filters modal on mobile
-        getScrollPosition: function () {
-            this.original = $(window).scrollTop();
-        }
-    }
+
     var all_categories = <%= raw @categories.to_json %>;
-    var allChosenCategories = [];
 <% end %>
 
 
@@ -849,18 +841,6 @@ function searchPracticesPage() {
     $(document).on('submit', '#update-search-results-form', function (e) {
         e.preventDefault();
         hideResultsSectionElAndShowSpinner();
-
-        // Close search filter accordion if it's open
-        if (accordionButton.attr('aria-expanded') == 'true') {
-            accordionButton.attr('aria-expanded', 'false');
-            $('#search_filters_dropdown').attr('hidden', 'true');
-        }
-
-        // Bring the user back to their original spot on the page, before they opened the mobile modal
-        if ($(window).width() < 1024) {
-            $(window).scrollTop(pagePosition.original);
-        }
-
         updateResults();
     });
 
@@ -1065,8 +1045,6 @@ function moveFilters() {
 }
 
 function execSearchFunctions() {
-    const urlParams = new URLSearchParams(window.location.search);
-
     addAllCheckBoxListener('.all-clinical-checkbox', '.clinical-checkbox');
     addAllCheckBoxListener('.all-operational-checkbox', '.operational-checkbox');
     addAllCheckBoxListener('.all-strategic-checkbox', '.strategic-checkbox');

--- a/app/views/practices/_search.js.erb
+++ b/app/views/practices/_search.js.erb
@@ -1161,6 +1161,30 @@ function addAllCheckBoxListener(allCheckboxSelector, standardCheckboxSelector) {
     });
 }
 
+function moveFilters() {
+  const width = window.innerWidth;
+  const filtersContainer = document.getElementById('filtersContainer');
+  const mobileContainer = document.getElementById('filtersAccordion');
+  const desktopContainer = document.getElementById('desktopFilters');
+
+  if (width < 1024) {
+    if (desktopContainer.contains(filtersContainer)) {
+      desktopContainer.removeChild(filtersContainer);
+    }
+    if (!mobileContainer.contains(filtersContainer)) {
+      mobileContainer.appendChild(filtersContainer);
+    }
+  } else {
+    if (mobileContainer.contains(filtersContainer)) {
+      mobileContainer.removeChild(filtersContainer);
+    }
+    if (!desktopContainer.contains(filtersContainer)) {
+      desktopContainer.appendChild(filtersContainer);
+    }
+  }
+  filtersContainer.style.display = 'block';
+}
+
 function execSearchFunctions() {
     const urlParams = new URLSearchParams(window.location.search);
     const openFiltersOnPageLoad = urlParams.get('filters') === 'open';
@@ -1176,7 +1200,10 @@ function execSearchFunctions() {
     addAllCheckBoxListener('.all-strategic-checkbox', '.strategic-checkbox');
     addAllCheckBoxListener('.all-communities-checkbox', '.communities-checkbox');
     searchPracticesPage();
+    moveFilters();
 }
+
+window.addEventListener('resize', moveFilters);
 
 document.addEventListener('turbolinks:load', function () {
     execSearchFunctions();

--- a/app/views/practices/_search.js.erb
+++ b/app/views/practices/_search.js.erb
@@ -320,7 +320,7 @@ function searchPracticesPage() {
             var categoryFilters = [];
 
             Object.entries(categories).forEach(function ([parentCategory, selectedValues]) {
-                if (parentCategory !== 'communities') {
+                if (parentCategory !== 'communities' && selectedValues.length) {
                     selectedValues.forEach(function (categorySelection) {
                         addAppliedFilter('TAG', categorySelection);
                         categoryFilters.push({'category_names': "=\"" + categorySelection + "\""});
@@ -329,7 +329,7 @@ function searchPracticesPage() {
             });
 
             // Iterate over 'communities' categories
-            if (categories['communities']) {
+            if (categories['communities'] && categories['communities'].length) {
                 categories['communities'].forEach(function (categorySelection) {
                     addAppliedFilter('COMMUNITY', categorySelection);
                     categoryFilters.push({'category_names': "=\"" + categorySelection + "\""});
@@ -914,9 +914,9 @@ function searchPracticesPage() {
     }
 
     var accordionButton = $('.search-filters-accordion-button')
-    function accordionText(checkboxCount, inputCount) {
-        return accordionButton.text('Filters ' + '(' + (checkboxCount + inputCount) + ')');
-    }
+    // function accordionText(checkboxCount, inputCount) {
+    //     return accordionButton.text('Filters ' + '(' + (checkboxCount + inputCount) + ')');
+    // }
 
     $(document).on('submit', '#update-search-results-form', function (e) {
         e.preventDefault();
@@ -941,21 +941,25 @@ function searchPracticesPage() {
         updateResults();
     });
 
-    function updateResults() {
+    function updateResults(checkFacilityInputs=true) {
         var urlQuery = searchField.value === '' ? '/search' : '/search?query=' + searchField.value;
         window.history.pushState({ turbolinks: {} }, "", urlQuery);
 
-        // Get the value of the originating facility combo box
-        var originatingFacilityInput = $('#originating-facility-and-visn-select');
-        var originatingFacilityLi = $('#originating-facility-and-visn-select--list > li[aria-selected=true]');
+        var originatingFacility = null;
+        var adoptingFacility = null;
+        if (checkFacilityInputs) {
+            // Get the value of the originating facility combo box
+            var originatingFacilityInput = $('#originating-facility-and-visn-select');
+            var originatingFacilityLi = $('#originating-facility-and-visn-select--list > li[aria-selected=true]');
 
-        var originatingFacility =  getComboBoxVal(originatingFacilityInput, originatingFacilityLi);
+            originatingFacility =  getComboBoxVal(originatingFacilityInput, originatingFacilityLi);
 
-        // Get the value of the adopting facility combo box
-        var adoptingFacilityInput = $('#adopting-facility-and-visn-select');
-        var adoptingFacilityLi = $('#adopting-facility-and-visn-select--list > li[aria-selected=true]');
+            // Get the value of the adopting facility combo box
+            var adoptingFacilityInput = $('#adopting-facility-and-visn-select');
+            var adoptingFacilityLi = $('#adopting-facility-and-visn-select--list > li[aria-selected=true]');
 
-        var adoptingFacility = getComboBoxVal(adoptingFacilityInput, adoptingFacilityLi);
+            adoptingFacility = getComboBoxVal(adoptingFacilityInput, adoptingFacilityLi);
+        }
 
         // Get the values for any chosen categories
         var selectedCategoryCheckboxes = $('#update-search-results-form [type="checkbox"]:checked:not(".all-clinical-checkbox"):not(".all-operational-checkbox"):not(".all-strategic-checkbox"):not(".all-communities-checkbox")');
@@ -985,34 +989,33 @@ function searchPracticesPage() {
             });
         }
 
-
         // Run the search
         search(searchField.value, chosenCategories, originatingFacility, adoptingFacility);
 
-        // Display the amount of filters used(if any)
-        var checkboxCount = selectedCategoryCheckboxes.length;
-        var noOriginatingFacilityText = originatingFacilityInput.val() === '';
-        var originatingFacilityTextPresent = originatingFacilityInput.val() !== '';
-        var noAdoptingFacilityText = adoptingFacilityInput.val() === '';
-        var adoptingFacilityTextPresent = adoptingFacilityInput.val() !== '';
+        // // Display the amount of filters used(if any)
+        // var checkboxCount = selectedCategoryCheckboxes.length;
+        // var noOriginatingFacilityText = originatingFacilityInput.val() === '';
+        // var originatingFacilityTextPresent = originatingFacilityInput.val() !== '';
+        // var noAdoptingFacilityText = adoptingFacilityInput.val() === '';
+        // var adoptingFacilityTextPresent = adoptingFacilityInput.val() !== '';
 
-        if (checkboxCount > 0 && originatingFacilityTextPresent && noAdoptingFacilityText) {
-            accordionText(checkboxCount, 1);
-        } else if (checkboxCount > 0 && noOriginatingFacilityText && adoptingFacilityTextPresent) {
-            accordionText(checkboxCount, 1);
-        } else if (checkboxCount > 0 && noOriginatingFacilityText && noAdoptingFacilityText) {
-            accordionText(checkboxCount, 0);
-        } else if (checkboxCount > 0 && originatingFacilityTextPresent && adoptingFacilityTextPresent) {
-            accordionText(checkboxCount, 2);
-        } else if (checkboxCount === 0 && originatingFacilityTextPresent && noAdoptingFacilityText) {
-            accordionText(0, 1);
-        } else if (checkboxCount === 0 && noOriginatingFacilityText && adoptingFacilityTextPresent) {
-            accordionText(0, 1);
-        } else if (checkboxCount === 0 && noOriginatingFacilityText && noAdoptingFacilityText) {
-            return accordionButton.text('Filters');
-        } else if (checkboxCount === 0 && originatingFacilityTextPresent && adoptingFacilityTextPresent) {
-            accordionText(0, 2);
-        }
+        // if (checkboxCount > 0 && originatingFacilityTextPresent && noAdoptingFacilityText) {
+        //     accordionText(checkboxCount, 1);
+        // } else if (checkboxCount > 0 && noOriginatingFacilityText && adoptingFacilityTextPresent) {
+        //     accordionText(checkboxCount, 1);
+        // } else if (checkboxCount > 0 && noOriginatingFacilityText && noAdoptingFacilityText) {
+        //     accordionText(checkboxCount, 0);
+        // } else if (checkboxCount > 0 && originatingFacilityTextPresent && adoptingFacilityTextPresent) {
+        //     accordionText(checkboxCount, 2);
+        // } else if (checkboxCount === 0 && originatingFacilityTextPresent && noAdoptingFacilityText) {
+        //     accordionText(0, 1);
+        // } else if (checkboxCount === 0 && noOriginatingFacilityText && adoptingFacilityTextPresent) {
+        //     accordionText(0, 1);
+        // } else if (checkboxCount === 0 && noOriginatingFacilityText && noAdoptingFacilityText) {
+        //     return accordionButton.text('Filters');
+        // } else if (checkboxCount === 0 && originatingFacilityTextPresent && adoptingFacilityTextPresent) {
+        //     accordionText(0, 2);
+        // }
     }
 
     // Sort the results based on each sort option
@@ -1056,7 +1059,7 @@ function searchPracticesPage() {
         // Move the focus area back to the top of the filters window
         $(".usa-combo-box__clear-input__wrapper").attr("tabindex",-1).focus();
         // Reset filter count text
-        $('.search-filters-accordion-button').text('Filters');
+        // $('.search-filters-accordion-button').text('Filters');
         // reset search results
         searchPracticesPage();
     })
@@ -1072,34 +1075,17 @@ function searchPracticesPage() {
             const checkboxSelector = `input[type="checkbox"][name="${category}"]`;
             const checkbox = $(checkboxSelector);
             checkbox.prop('checked', true);
-            accordionText(1, 0)
-            search('', [category]);
-        } else if (query) {
-            search(decodeURI(query));
-            searchField.value = decodeURI(query);
         } else if (allCommunities) {
             let allCommunitiesCheckbox = document.querySelector('.all-communities-checkbox');
             if (allCommunitiesCheckbox) {
                 allCommunitiesCheckbox.checked = true;
                 $(allCommunitiesCheckbox).trigger('change');
             }
-
-            let selectedCategoryCheckboxes = $('#update-search-results-form [type="checkbox"]:checked:not(".all-clinical-checkbox"):not(".all-operational-checkbox"):not(".all-strategic-checkbox"):not(".all-communities-checkbox")');
-            let chosenCategories = selectedCategoryCheckboxes.map(function () {
-                return this.value;
-            }).get();
-
-            if (!chosenCategories.length) {
-                chosenCategories = null;
-            } else {
-                accordionText(chosenCategories.length, 0)
-            }
-            search('', chosenCategories);
-        } else {
-            // No query or category filter
-            searchField.value = '';
-            search('');
-        }
+        } else if (query) {
+            searchField.value = decodeURI(query);
+        };
+        // update search results but skip checking facility checkboxes
+        updateResults(false);
     } else if ((searchLocation[0] === '?filter_by') || (window.location.pathname === '/search' && window.location.search === '')) {
         hideResultsSectionElAndShowSpinner();
         search('');

--- a/app/views/practices/_search.js.erb
+++ b/app/views/practices/_search.js.erb
@@ -355,7 +355,7 @@ function searchPracticesPage(skipSearchTracking=false) {
         the results will have the same score because it stops after the first match.
         */
         function improveResultScoreBasedOnAmountOfCategoryMatches(results) {
-            allChosenCategories = Object.values(categories).flat();
+            var allChosenCategories = Object.values(categories).flat();
             results.map(function(result) {
                 var resultScore = result.score;
                 var cat_names = result.item.category_names;
@@ -723,7 +723,7 @@ function searchPracticesPage(skipSearchTracking=false) {
         appliedFilterButton.addEventListener('click', function(event) {
             uncheckFilter(filterType, filterName);
             $('#resetSearchFiltersButton').addClass('display-none');
-            updateResults(false);
+            updateResults();
             event.stopPropagation();
         });
 
@@ -844,56 +844,71 @@ function searchPracticesPage(skipSearchTracking=false) {
         updateResults();
     });
 
-    function updateResults(checkFacilityInputs=true) {
-        var urlQuery = searchField.value === '' ? '/search' : '/search?query=' + searchField.value;
+    function updateResults(checkFacilityInputs = true) {
+        const searchFieldValue = searchField.value.trim();
+        const urlQuery = searchFieldValue === '' ? '/search' : `/search?query=${searchFieldValue}`;
         window.history.pushState({ turbolinks: {} }, "", urlQuery);
 
-        var originatingFacility = null;
-        var adoptingFacility = null;
+        let originatingFacility = null;
+        let adoptingFacility = null;
+
         if (checkFacilityInputs) {
-            // Get the value of the originating facility combo box
-            var originatingFacilityInput = $('#originating-facility-and-visn-select');
-            var originatingFacilityLi = $('#originating-facility-and-visn-select--list > li[aria-selected=true]');
+            originatingFacility = getFacilityValue(
+                '#originating-facility-and-visn-select',
+                '#originating-facility-and-visn-select--list > li[aria-selected=true]'
+            );
 
-            originatingFacility =  getComboBoxVal(originatingFacilityInput, originatingFacilityLi);
-
-            // Get the value of the adopting facility combo box
-            var adoptingFacilityInput = $('#adopting-facility-and-visn-select');
-            var adoptingFacilityLi = $('#adopting-facility-and-visn-select--list > li[aria-selected=true]');
-
-            adoptingFacility = getComboBoxVal(adoptingFacilityInput, adoptingFacilityLi);
+            adoptingFacility = getFacilityValue(
+                '#adopting-facility-and-visn-select',
+                '#adopting-facility-and-visn-select--list > li[aria-selected=true]'
+            );
         }
 
-        // Get the values for any chosen categories
-        var selectedCategoryCheckboxes = $('#update-search-results-form [type="checkbox"]:checked:not(".all-clinical-checkbox"):not(".all-operational-checkbox"):not(".all-strategic-checkbox"):not(".all-communities-checkbox")');
+        const { chosenCategoriesByParent, allCategories } = getSelectedCategories();
 
-        var chosenCategories = {};
+        if (!skipSearchTracking) {
+            updateCategoryUsage(searchFieldValue, allCategories);
+        }
+
+        search(searchFieldValue, chosenCategoriesByParent, originatingFacility, adoptingFacility);
+    }
+
+    function getFacilityValue(inputSelector, listItemSelector) {
+        const facilityInput = $(inputSelector);
+        const facilityLi = $(listItemSelector);
+        return getComboBoxVal(facilityInput, facilityLi);
+    }
+
+    function getSelectedCategories() {
+        const selectedCategoryCheckboxes = $('#update-search-results-form [type="checkbox"]:checked:not(".all-clinical-checkbox"):not(".all-operational-checkbox"):not(".all-strategic-checkbox"):not(".all-communities-checkbox")');
+
+        const chosenCategoriesByParent = {};
+        const allCategories = [];
 
         selectedCategoryCheckboxes.each(function () {
-            var parentCategory = this.dataset.parentCategory;
-            var value = this.value;
+            const parentCategory = this.dataset.parentCategory;
+            const value = this.value;
 
-            if (!chosenCategories[parentCategory]) {
-                chosenCategories[parentCategory] = [];
+            if (!chosenCategoriesByParent[parentCategory]) {
+                chosenCategoriesByParent[parentCategory] = [];
             }
 
-            chosenCategories[parentCategory].push(value);
+            chosenCategoriesByParent[parentCategory].push(value);
+            allCategories.push(value);
         });
 
-        if (Object.keys(chosenCategories).length === 0) {
-            chosenCategories = null;
-        } else if (!skipSearchTracking) {
-            // Update Category Usage....
-            allChosenCategories = Object.values(chosenCategories).flat();
-            Rails.ajax({
-                type: 'patch',
-                url: "/update_category_usage",
-                data: jQuery.param({query: searchField.value, chosenCategories: allChosenCategories})
-            });
-        }
+        return {
+            chosenCategoriesByParent: Object.keys(chosenCategoriesByParent).length === 0 ? null : chosenCategoriesByParent,
+            allCategories
+        };
+    }
 
-        // Run the search
-        search(searchField.value, chosenCategories, originatingFacility, adoptingFacility);
+    function updateCategoryUsage(query, chosenCategories) {
+        Rails.ajax({
+            type: 'patch',
+            url: "/update_category_usage",
+            data: jQuery.param({ query, chosenCategories })
+        });
     }
 
     // Sort the results based on each sort option
@@ -959,7 +974,7 @@ function searchPracticesPage(skipSearchTracking=false) {
         } else if (query) {
             searchField.value = decodeURI(query);
         };
-        // update search results but skip checking facility checkboxes
+        // update search results but skip checking Location comboboxes
         updateResults(false);
     } else if ((searchLocation[0] === '?filter_by') || (window.location.pathname === '/search' && window.location.search === '')) {
         hideResultsSectionElAndShowSpinner();

--- a/app/views/practices/search.html.erb
+++ b/app/views/practices/search.html.erb
@@ -14,15 +14,84 @@
 <% end %>
 
 <div id="search-page">
-  <div class="grid-container" id="searchResultsContainer"> <!-- START DM-4910 -->
-    <div class="grid-row margin-bottom-5">
-      <div class="grid-col-12">
-        <h2 class="usa-prose-h2 margin-bottom-5" id="searchHeader"> Search </h2>
-        <span id="results-summary" class="display-block desktop:display-inline margin-right-2">Results:</span>
-        <button type="button" class="usa-button usa-button--unstyled display-none" id="resetSearchFiltersButton">Clear filters</button>
+  <section class="grid-container margin-bottom-neg-3 margin-top-5" id="searchResultsContainer">
+    <%= render partial: "shared/messages", locals: {small_text: false} %>
+    <form id="update-search-results-form">
+      <div class="grid-row margin-bottom-5">
+        <div class="grid-col-12">
+          <h2 class="usa-prose-h2 margin-bottom-5" id="searchHeader"> Search </h2>
+          <div class="usa-search usa-search--big margin-bottom-2 grid-col-12">
+            <div role="search" class="flex-column">
+              <label for="dm-practice-search-field"></label>
+              <div id="search-bar-container" class="display-flex">
+                <input
+                  class="usa-input"
+                  id="dm-practice-search-field"
+                  title="Type at least three characters to search."
+                  autocomplete="off"
+                  type="search"
+                  name="search"
+                  placeholder="Search innovations, tags, communities..."
+                >
+                <button id="dm-practice-search-button" class="usa-button" type="submit" name="search-button">
+                  <span class="usa-search__submit-text text-bold">Search</span>
+                </button>
+              </div>
+            </div>
+          </div>
+          <span id="results-summary" class="display-block desktop:display-inline margin-right-2">Results:</span>
+          <button type="button" class="usa-button usa-button--unstyled display-none" id="resetSearchFiltersButton">Clear filters</button>
+        </div>
       </div>
-    </div>
 
+      <div class="grid-row grid-gap">
+        <div id="dynamicFilters" class="grid-col-12">
+          <div id="filtersContainer" class="display-none">
+              <%= render 'practices/search_partials/search_filters' %>
+          </div>
+
+          <div class="desktop:grid-col-4 mobile-hide tablet-hide" id="desktopFilters">
+            <!-- Content will be injected here via js -->
+          </div>
+
+          <div class="usa-accordion usa-accordion--bordered desktop-hide tablet:grid-col-4 mobile:grid-col-4">
+            <h2 class="usa-accordion__heading">
+              <button
+                type="button"
+                class="usa-accordion__button"
+                aria-expanded="false"
+                aria-controls="filtersAccordion"
+              >
+                Filter Results
+              </button>
+            </h2>
+            <div class="usa-accordion__content usa-prose" id="filtersAccordion" >
+              <!-- Content will be injected here via js -->
+            </div>
+          </div>
+        </div>
+      </div>
+    </form>
+    <%= render partial: 'shared/search_sort_select_section',
+      locals: {
+        sort_options: [
+          ['Sort by most relevant', 'most_relevant', selected: true, class: 'usa-select'],
+          ['Sort by A to Z', 'a_to_z', class: 'usa-select'],
+          ['Sort by most adopted innovations', 'adoptions', class: 'usa-select'],
+          ['Sort by most recently added', 'added', class: 'usa-select']
+        ],
+        section_id: 'dm-search-practices',
+        section_classes: 'dm-search-practices display-none margin-top-2',
+        first_div_classes: 'grid-row margin-bottom-105 flex-align-center',
+        second_div_classes: 'grid-col-12 order-first margin-top-0 dm-sort-container margin-bottom-3 desktop:margin-top-1 desktop:margin-bottom-0 desktop:margin-top-0 desktop:order-last desktop:grid-col-4'
+      }
+    %>
+    <%= render partial: 'shared/loading_spinner', locals: { display: false, classes: "dm-loading-spinner display-none flex-justify-center flex-align-self-center margin-y-8 desktop:margin-y-10" } %>
+    <%= render partial: 'shared/search_no_results', locals: { display_no_query_msg: true } %>
+  </section>
+</div>
+
+<!-- FOR REFERENCE - REMOVE UPON COMPLETION OF DM-4866 -->
 <%#     <div class="grid-row grid-gap">
       <!-- START DM- 4912-->
       <div id="REPLACE-with-something-about-filters" class="grid-col-12 tablet:grid-col-4 desktop:grid-col-4">
@@ -211,75 +280,3 @@
       </div>
       <!-- END DM-4913 -->
     </div> %>
-  </div>
-
-
-  <section class="grid-container margin-bottom-neg-3 margin-top-5">
-    <%= render partial: "shared/messages", locals: {small_text: false} %>
-    <form id="update-search-results-form">
-      <div class="usa-search usa-search--big margin-bottom-2 grid-col-12">
-        <div role="search" class="flex-column">
-          <label for="dm-practice-search-field"></label>
-          <div id="search-bar-container" class="display-flex">
-            <input
-              class="usa-input"
-              id="dm-practice-search-field"
-              title="Type at least three characters to search."
-              autocomplete="off"
-              type="search"
-              name="search"
-              placeholder="Search innovations, tags, communities..."
-            >
-            <button id="dm-practice-search-button" class="usa-button" type="submit" name="search-button">
-              <span class="usa-search__submit-text text-bold">Search</span>
-            </button>
-          </div>
-        </div>
-      </div>
-      <div class="usa-accordion usa-accordion--bordered position-relative">
-        <button id="mobile_filters_button" class="usa-button width-full desktop:display-none" type="button">Filters</button>
-        <h2 class="usa-accordion__heading desktop-filters-accordion-heading display-none desktop:display-block">
-          <button class="usa-accordion__button search-filters-accordion-button"
-                  aria-expanded="false"
-                  aria-controls="search_filters_dropdown">
-            Filters
-          </button>
-        </h2>
-        <div id="search_filters_dropdown" class="usa-accordion__content position-fixed top-0 right-0 left-0 bottom-0 width-full z-400 padding-0 display-none">
-          <div class="mobile-modal-container">
-            <div class="grid-container grid-row height-10 display-flex flex-align-center desktop:display-none">
-              <div class="grid-col-3">
-                <button type="button" class="fas fa-times fa-2x display-block" id="close_filters_modal"></button>
-              </div>
-              <div class="grid-col-6">
-                <h2 class="margin-top-0 font-sans-xl line-height-37px text-center">Filters</h2>
-              </div>
-              <div class="grid-col-3">
-                <div class="text-right">
-                  <button type="button" class="dm-button--unstyled-primary width-auto" id="resetSearchFiltersButtonMobile">Reset</button>
-                </div>
-              </div>
-            </div>
-            <%= render partial: 'practices/search_partials/search_filters' %>
-          </div>
-        </div>
-      </div>
-    </form>
-
-    <%= render partial: 'shared/search_sort_select_section', locals: {
-      sort_options: [
-        ['Sort by most relevant', 'most_relevant', selected: true, class: 'usa-select'],
-        ['Sort by A to Z', 'a_to_z', class: 'usa-select'],
-        ['Sort by most adopted innovations', 'adoptions', class: 'usa-select'],
-        ['Sort by most recently added', 'added', class: 'usa-select']
-      ],
-      section_id: 'dm-search-practices',
-      section_classes: 'dm-search-practices display-none margin-top-2',
-      first_div_classes: 'grid-row margin-bottom-105 flex-align-center',
-      second_div_classes: 'grid-col-12 order-first margin-top-0 dm-sort-container margin-bottom-3 desktop:margin-top-1 desktop:margin-bottom-0 desktop:margin-top-0 desktop:order-last desktop:grid-col-4'
-    }
-    %>
-    <%= render partial: 'shared/loading_spinner', locals: { display: false, classes: "dm-loading-spinner display-none flex-justify-center flex-align-self-center margin-y-8 desktop:margin-y-10" } %>
-    <%= render partial: 'shared/search_no_results', locals: { display_no_query_msg: true } %>
-  </section>
-</div>

--- a/app/views/practices/search.html.erb
+++ b/app/views/practices/search.html.erb
@@ -62,7 +62,7 @@
                 aria-expanded="false"
                 aria-controls="mobileFiltersContainer"
               >
-                Filter Results
+                Refine Results
               </button>
             </h2>
             <div class="usa-accordion__content usa-prose" id="mobileFiltersContainer" >

--- a/app/views/practices/search.html.erb
+++ b/app/views/practices/search.html.erb
@@ -47,7 +47,7 @@
       <div class="grid-row grid-gap">
         <div class="grid-col-12">
           <div id="filtersContainer" class="display-none">
-              <%= render 'practices/search_partials/search_filters' %>
+            <%= render 'practices/search_partials/search_filters' %>
           </div>
 
           <div class="desktop:grid-col-4 mobile-hide tablet-hide" id="desktopFiltersContainer">

--- a/app/views/practices/search.html.erb
+++ b/app/views/practices/search.html.erb
@@ -45,7 +45,7 @@
       </div>
 
       <div class="grid-row grid-gap">
-        <div id="dynamicFilters" class="grid-col-12">
+        <div class="grid-col-12">
           <div id="filtersContainer" class="display-none">
               <%= render 'practices/search_partials/search_filters' %>
           </div>

--- a/app/views/practices/search.html.erb
+++ b/app/views/practices/search.html.erb
@@ -50,7 +50,7 @@
               <%= render 'practices/search_partials/search_filters' %>
           </div>
 
-          <div class="desktop:grid-col-4 mobile-hide tablet-hide" id="desktopFilters">
+          <div class="desktop:grid-col-4 mobile-hide tablet-hide" id="desktopFiltersContainer">
             <!-- Content will be injected here via js -->
           </div>
 
@@ -60,12 +60,12 @@
                 type="button"
                 class="usa-accordion__button"
                 aria-expanded="false"
-                aria-controls="filtersAccordion"
+                aria-controls="mobileFiltersContainer"
               >
                 Filter Results
               </button>
             </h2>
-            <div class="usa-accordion__content usa-prose" id="filtersAccordion" >
+            <div class="usa-accordion__content usa-prose" id="mobileFiltersContainer" >
               <!-- Content will be injected here via js -->
             </div>
           </div>

--- a/app/views/practices/search_partials/_category_filter_column.html.erb
+++ b/app/views/practices/search_partials/_category_filter_column.html.erb
@@ -1,7 +1,0 @@
-<div class="grid-col-12 desktop:grid-col-4">
-  <% categories.each do |category| %>
-    <% cache(category) do %>
-      <%= render partial: 'practices/search_partials/category_checkbox', locals: { category: category, parent_category: parent_category } %>
-    <% end %>
-  <% end %>
-</div>

--- a/app/views/practices/search_partials/_search_filters.html.erb
+++ b/app/views/practices/search_partials/_search_filters.html.erb
@@ -1,7 +1,6 @@
-
-<fieldset class="usa-fieldset padding-bottom-2">
-  <h3> Filters </h3>
-  <div class="sub-category-checkboxes filters-scrollbar maxh-mobile">
+<h3> Refine Results </h3>
+<fieldset class="usa-fieldset">
+  <div class="category-filters maxh-mobile">
     <h4> Tags </h4>
     <% @parent_categories.each do |parent_category, sub_categories| %>
       <% if sub_categories.any? %>
@@ -46,7 +45,7 @@
 
 <hr class="border border-base-lighter margin-x-neg-205">
 
-<fieldset class="usa-fieldset padding-top-1 padding-bottom-3">
+<fieldset class="usa-fieldset padding-top-2 padding-bottom-3">
   <div id="originating-facility-container">
     <p class="text-bold line-height-26 margin-bottom-1 grid-col-12 desktop:display-block">Originating Location</p>
     <%= render partial: 'practices/search_partials/visn_facility_combo_box', locals: {facility_type_selector: 'originating-facility-and-visn-select', visn_grouped_facilities: @visn_grouped_facilities} %>
@@ -56,14 +55,14 @@
 
 <hr class="border border-base-lighter margin-x-neg-205">
 
-<fieldset class="usa-fieldset padding-top-1 padding-bottom-5">
+<fieldset class="usa-fieldset padding-bottom-5">
   <div id="adopting-facility-container">
     <p class="text-bold line-height-26 margin-top-2 margin-bottom-1 grid-col-12 desktop:display-block">Adopting location</p>
     <%= render partial: 'practices/search_partials/visn_facility_combo_box', locals: {facility_type_selector: 'adopting-facility-and-visn-select', visn_grouped_facilities: @visn_grouped_facilities } %>
   </div>
 </fieldset>
 
-<div class="border-base-lightest padding-1" id="filter_button_container">
+<div class="border-base-lightest padding-top-1" id="filter_button_container">
   <button type="submit" id="update-search-results-button" class="usa-button filter-submit-button display-block line-height-19px" name="button">
     Apply filters
   </button>

--- a/app/views/practices/search_partials/_search_filters.html.erb
+++ b/app/views/practices/search_partials/_search_filters.html.erb
@@ -1,7 +1,7 @@
-<h3> Refine Results </h3>
+<h3 class="padding-bottom-2"> Refine Results </h3>
 <fieldset class="usa-fieldset">
+  <legend class="usa-legend usa-typography--h text-bold padding-bottom-2">Tags</legend>
   <div class="category-filters maxh-mobile">
-    <h4> Tags </h4>
     <% @parent_categories.each do |parent_category, sub_categories| %>
       <% if sub_categories.any? %>
         <% parent_cat_name = "#{parent_category.name.downcase.gsub(' ', '-')}" %>
@@ -47,7 +47,7 @@
 
 <fieldset class="usa-fieldset padding-top-2 padding-bottom-3">
   <div id="originating-facility-container">
-    <p class="text-bold line-height-26 margin-bottom-1 grid-col-12 desktop:display-block">Originating Location</p>
+    <legend class="text-bold line-height-26 margin-bottom-1 grid-col-12 desktop:display-block">Originating Location</legend>
     <%= render partial: 'practices/search_partials/visn_facility_combo_box', locals: {facility_type_selector: 'originating-facility-and-visn-select', visn_grouped_facilities: @visn_grouped_facilities} %>
     <%= render partial: 'shared/visn_info_modal', locals: { hide_modal_on_initial_load: false } %>
   </div>
@@ -57,7 +57,7 @@
 
 <fieldset class="usa-fieldset padding-bottom-5">
   <div id="adopting-facility-container">
-    <p class="text-bold line-height-26 margin-top-2 margin-bottom-1 grid-col-12 desktop:display-block">Adopting location</p>
+    <legend class="text-bold line-height-26 margin-top-2 margin-bottom-1 grid-col-12 desktop:display-block">Adopting location</legend>
     <%= render partial: 'practices/search_partials/visn_facility_combo_box', locals: {facility_type_selector: 'adopting-facility-and-visn-select', visn_grouped_facilities: @visn_grouped_facilities } %>
   </div>
 </fieldset>

--- a/app/views/practices/search_partials/_search_filters.html.erb
+++ b/app/views/practices/search_partials/_search_filters.html.erb
@@ -29,8 +29,8 @@
                 class="usa-checkbox__input <%= parent_cat_name %>-checkbox"
                 id=<%= category_checkbox_id %>
                 type="checkbox"
-                name=<%= category.name %>
-                value=<%= category.name %>
+                name="<%= category.name %>"
+                value="<%= category.name %>"
                 data-parent-category=<%= parent_cat_name %>
               />
               <label class="usa-checkbox__label <%= category_checkbox_id %>" for=<%= category_checkbox_id %>>
@@ -47,16 +47,20 @@
 <hr class="border border-base-lighter margin-x-neg-205">
 
 <fieldset class="usa-fieldset padding-top-1 padding-bottom-3">
-  <p class="text-bold line-height-26 margin-bottom-1 grid-col-12 desktop:display-block">Originating Location</p>
-  <%= render partial: 'practices/search_partials/visn_facility_combo_box', locals: {facility_type_selector: 'originating-facility-and-visn-select', visn_grouped_facilities: @visn_grouped_facilities} %>
-  <%= render partial: 'shared/visn_info_modal', locals: { hide_modal_on_initial_load: false } %>
+  <div id="originating-facility-container">
+    <p class="text-bold line-height-26 margin-bottom-1 grid-col-12 desktop:display-block">Originating Location</p>
+    <%= render partial: 'practices/search_partials/visn_facility_combo_box', locals: {facility_type_selector: 'originating-facility-and-visn-select', visn_grouped_facilities: @visn_grouped_facilities} %>
+    <%= render partial: 'shared/visn_info_modal', locals: { hide_modal_on_initial_load: false } %>
+  </div>
 </fieldset>
 
 <hr class="border border-base-lighter margin-x-neg-205">
 
 <fieldset class="usa-fieldset padding-top-1 padding-bottom-5">
-  <p class="text-bold line-height-26 margin-top-2 margin-bottom-1 grid-col-12 desktop:display-block">Adopting location</p>
-  <%= render partial: 'practices/search_partials/visn_facility_combo_box', locals: {facility_type_selector: 'adopting-facility-and-visn-select', visn_grouped_facilities: @visn_grouped_facilities } %>
+  <div id="adopting-facility-container">
+    <p class="text-bold line-height-26 margin-top-2 margin-bottom-1 grid-col-12 desktop:display-block">Adopting location</p>
+    <%= render partial: 'practices/search_partials/visn_facility_combo_box', locals: {facility_type_selector: 'adopting-facility-and-visn-select', visn_grouped_facilities: @visn_grouped_facilities } %>
+  </div>
 </fieldset>
 
 <div class="border-base-lightest padding-1" id="filter_button_container">

--- a/app/views/practices/search_partials/_search_filters.html.erb
+++ b/app/views/practices/search_partials/_search_filters.html.erb
@@ -23,6 +23,7 @@
         <div class="sub-category-checkboxes padding-bottom-3 margin-left-205">
           <% sub_categories.each do |category| %>
             <% category_checkbox_id = "cat-#{category.id}-input" %>
+            <% category_checkbox_label = "cat-#{category.id}-label" %>
             <div class="usa-checkbox">
               <input
                 class="usa-checkbox__input <%= parent_cat_name %>-checkbox"
@@ -32,7 +33,7 @@
                 value="<%= category.name %>"
                 data-parent-category=<%= parent_cat_name %>
               />
-              <label class="usa-checkbox__label <%= category_checkbox_id %>" for=<%= category_checkbox_id %>>
+              <label class="usa-checkbox__label <%= category_checkbox_label %>" for=<%= category_checkbox_id %>>
                 <%= category.name %>
               </label>
             </div>

--- a/app/views/practices/search_partials/_search_filters.html.erb
+++ b/app/views/practices/search_partials/_search_filters.html.erb
@@ -4,7 +4,8 @@
   <div class="sub-category-checkboxes filters-scrollbar maxh-mobile">
     <% @parent_categories.each do |parent_category, sub_categories| %>
       <% if sub_categories.any? %>
-        <% all_cats_checkbox_id = "cat-all-#{parent_category.name.downcase.gsub(' ', '-')}-input" %>
+        <% parent_cat_name = "#{parent_category.name.downcase.gsub(' ', '-')}" %>
+        <% all_cats_checkbox_id = "cat-all-#{parent_cat_name}-input" %>
         <% parent_cat_name = parent_category.name.split(' ').join('-').downcase %>
         <div class="usa-checkbox">
           <input
@@ -29,6 +30,7 @@
                 type="checkbox"
                 name=<%= category.name %>
                 value=<%= category.name %>
+                data-parent-category=<%= parent_cat_name %>
               />
               <label class="usa-checkbox__label <%= category_checkbox_id %>" for=<%= category_checkbox_id %>>
                 <%= category.name %>

--- a/app/views/practices/search_partials/_search_filters.html.erb
+++ b/app/views/practices/search_partials/_search_filters.html.erb
@@ -1,7 +1,8 @@
 
 <fieldset class="usa-fieldset padding-bottom-2">
-  <h4> Tags </h4>
+  <h3> Filters </h3>
   <div class="sub-category-checkboxes filters-scrollbar maxh-mobile">
+    <h4> Tags </h4>
     <% @parent_categories.each do |parent_category, sub_categories| %>
       <% if sub_categories.any? %>
         <% parent_cat_name = "#{parent_category.name.downcase.gsub(' ', '-')}" %>

--- a/app/views/practices/search_partials/_search_filters.html.erb
+++ b/app/views/practices/search_partials/_search_filters.html.erb
@@ -1,85 +1,63 @@
-<div class="grid-row padding-x-3 padding-bottom-0 desktop:padding-x-0">
-  <fieldset class="padding-0">
-    <legend class="usa-sr-only">Tag Filters</legend>
-    <div class="bg-gray-5 desktop:padding-bottom-2px search-category-filters">
-      <h2 class="usa-accordion__heading">
-        <button class="usa-accordion__button mobile-category-accordion desktop:display-none"
-                aria-expanded="false"
-                type="button">
-          Tags
-        </button>
-      </h2>
 
-      <div class="grid-row category-container display-none padding-top-2 desktop:padding-bottom-1 desktop:padding-top-0 desktop:display-flex desktop:padding-x-2">
-        <p class="text-bold line-height-26 margin-y-2 grid-col-12 display-none desktop:display-block margin-top-2">
-        <a href="#parent-category-modal" class="dotted parent-category-modal cursor-pointer margin-bottom-2" aria-controls="parent-category-modal" data-open-modal>
-          <span class="usa-sr-only">Open parent tag definitions modal</span>
-          Tags
-        </a>
-          <%= render partial: 'shared/parent_category_modal' %>
-        </p>
-        <% @parent_categories.each do |parent_category, sub_categories| %>
-          <%
-            if sub_categories.any?
-              categories = [{name: "All #{parent_category.name.downcase}", parent_category: parent_category, id: parent_category.name}] + sub_categories
-            else
-              categories = []
-            end
-            sliced_categories = split_data_into_three_columns(categories)
-          %>
-          <% if sub_categories.any? %>
-            <div class="grid-row grid-col-12 category-container display-none padding-top-2 desktop:padding-bottom-1 desktop:padding-top-0 desktop:display-flex padding-left-0 padding-right-0">
-              <p class="line-height-26 margin-y-2 grid-col-12 display-none desktop:display-block desktop:margin-top-1 desktop:margin-bottom-0"><%= parent_category.name %></p>
-              <% sliced_categories.each_with_index do |sc, i| %>
-                <%= render partial: 'practices/search_partials/category_filter_column', locals: { categories: sc, column: i, parent_category: parent_category } unless i === 3 %>
-              <% end %>
+<fieldset class="usa-fieldset padding-bottom-2">
+  <h4> Tags </h4>
+  <div class="sub-category-checkboxes filters-scrollbar maxh-mobile">
+    <% @parent_categories.each do |parent_category, sub_categories| %>
+      <% if sub_categories.any? %>
+        <% all_cats_checkbox_id = "cat-all-#{parent_category.name.downcase.gsub(' ', '-')}-input" %>
+        <% parent_cat_name = parent_category.name.split(' ').join('-').downcase %>
+        <div class="usa-checkbox">
+          <input
+            class="usa-checkbox__input all-<%= parent_cat_name %>-checkbox"
+            id=<%= all_cats_checkbox_id %>
+            type="checkbox"
+            name="All <%= parent_cat_name %>"
+            value="All <%= parent_cat_name %>"
+          />
+          <label class="usa-checkbox__label cat-all-<%= parent_cat_name %>-label" for=<%= all_cats_checkbox_id %>>
+            <%= "All #{parent_category.name}" %>
+          </label>
+        </div>
+
+        <div class="sub-category-checkboxes padding-bottom-3 margin-left-205">
+          <% sub_categories.each do |category| %>
+            <% category_checkbox_id = "cat-#{category.id}-input" %>
+            <div class="usa-checkbox">
+              <input
+                class="usa-checkbox__input <%= parent_cat_name %>-checkbox"
+                id=<%= category_checkbox_id %>
+                type="checkbox"
+                name=<%= category.name %>
+                value=<%= category.name %>
+              />
+              <label class="usa-checkbox__label <%= category_checkbox_id %>" for=<%= category_checkbox_id %>>
+                <%= category.name %>
+              </label>
             </div>
           <% end %>
-        <% end %>
-      </div>
-    </div>
-  </fieldset>
+        </div>
+      <% end %>
+    <% end %>
+  </div>
+</fieldset>
 
-  <fieldset class="padding-0">
-    <legend class="usa-sr-only">Originating Facility Filter</legend>
-    <div class="bg-gray-5 desktop:padding-bottom-2px search-originating-facility-filter">
-      <h2 class="usa-accordion__heading">
-        <button class="usa-accordion__button mobile-origin-accordion desktop:display-none"
-                aria-expanded="false"
-                type="button">
-          Originating facility
-        </button>
-      </h2>
+<hr class="border border-base-lighter margin-x-neg-205">
 
-      <div class="grid-row originating-facility-container display-none desktop:padding-bottom-3 desktop:display-block desktop:padding-x-2">
-        <p class="text-bold line-height-26 margin-top-2 margin-bottom-1 grid-col-12 display-none desktop:display-block">Originating location</p>
-        <%= render partial: 'practices/search_partials/visn_facility_combo_box', locals: {facility_type_selector: 'originating-facility-and-visn-select', visn_grouped_facilities: @visn_grouped_facilities} %>
-        <%= render partial: 'shared/visn_info_modal', locals: { hide_modal_on_initial_load: false } %>
-      </div>
-    </div>
-  </fieldset>
+<fieldset class="usa-fieldset padding-top-1 padding-bottom-3">
+  <p class="text-bold line-height-26 margin-bottom-1 grid-col-12 desktop:display-block">Originating Location</p>
+  <%= render partial: 'practices/search_partials/visn_facility_combo_box', locals: {facility_type_selector: 'originating-facility-and-visn-select', visn_grouped_facilities: @visn_grouped_facilities} %>
+  <%= render partial: 'shared/visn_info_modal', locals: { hide_modal_on_initial_load: false } %>
+</fieldset>
 
-  <fieldset class="padding-0">
-    <legend class="usa-sr-only">Adopting Facility Filter</legend>
-    <div class="bg-gray-5 desktop:padding-bottom-2px search-adopting-facility-filter">
-      <h2 class="usa-accordion__heading">
-        <button class="usa-accordion__button mobile-adopting-accordion desktop:display-none"
-                aria-expanded="false"
-                type="button">
-          Adopting facility
-        </button>
-      </h2>
+<hr class="border border-base-lighter margin-x-neg-205">
 
-      <div class="grid-row adopting-facility-container display-none desktop:padding-bottom-3 desktop:display-block desktop:padding-x-2">
-        <p class="text-bold line-height-26 margin-top-2 margin-bottom-1 grid-col-12 display-none desktop:display-block">Adopting location</p>
-        <%= render partial: 'practices/search_partials/visn_facility_combo_box', locals: {facility_type_selector: 'adopting-facility-and-visn-select', visn_grouped_facilities: @visn_grouped_facilities } %>
-      </div>
-    </div>
-  </fieldset>
-</div>
+<fieldset class="usa-fieldset padding-top-1 padding-bottom-5">
+  <p class="text-bold line-height-26 margin-top-2 margin-bottom-1 grid-col-12 desktop:display-block">Adopting location</p>
+  <%= render partial: 'practices/search_partials/visn_facility_combo_box', locals: {facility_type_selector: 'adopting-facility-and-visn-select', visn_grouped_facilities: @visn_grouped_facilities } %>
+</fieldset>
 
-<div class="padding-y-2 padding-x-3 border-top-2px border-base-lightest bg-white desktop:border-top-0 desktop:padding-2" id="filter_button_container">
-  <button type="submit" id="update-search-results-button" class="usa-button usa-button--primary display-block width-full desktop:margin-bottom-1 line-height-19px" name="button">
-    Update results
+<div class="border-base-lightest padding-1" id="filter_button_container">
+  <button type="submit" id="update-search-results-button" class="usa-button filter-submit-button display-block line-height-19px" name="button">
+    Apply filters
   </button>
 </div>

--- a/app/views/practices/search_partials/_search_filters.html.erb
+++ b/app/views/practices/search_partials/_search_filters.html.erb
@@ -1,5 +1,5 @@
 <h3 class="padding-bottom-2"> Refine Results </h3>
-<fieldset class="usa-fieldset">
+<fieldset class="usa-fieldset padding-bottom-2">
   <legend class="usa-legend usa-typography--h text-bold padding-bottom-2">Tags</legend>
   <div class="category-filters maxh-mobile">
     <% @parent_categories.each do |parent_category, sub_categories| %>

--- a/app/views/practices/search_partials/_visn_facility_combo_box.html.erb
+++ b/app/views/practices/search_partials/_visn_facility_combo_box.html.erb
@@ -1,4 +1,4 @@
-<div class="usa-combo-box margin-top-1 margin-bottom-2 desktop:margin-y-0 desktop:grid-col-5">
+<div class="usa-combo-box">
   <label for="<%= facility_type_selector %>" class="line-height-26">
     Search by
     <a href="#visn-info-modal" aria-controls="visn-info-modal" data-open-modal class="dotted cursor-pointer">

--- a/spec/features/about_spec.rb
+++ b/spec/features/about_spec.rb
@@ -26,7 +26,7 @@ describe 'About us page', type: :feature do
       all('.usa-accordion__heading')[2].click
       click_link('Emerging')
       expect(page).to have_content('Search')
-      expect(page).to have_content('2 results:')
+      expect(page).to have_content('2 Results:')
       expect(page).to have_content('Project HAPPEN')
       expect(page).to have_content('Best Practice Ever')
     end

--- a/spec/features/admin/admin_categories_spec.rb
+++ b/spec/features/admin/admin_categories_spec.rb
@@ -59,7 +59,6 @@ describe 'Admin Dashboard Categories Tab', type: :feature do
       click_button('Update Tag')
       expect(cache_keys).not_to include("categories")
       add_categories_to_cache
-      find('.search-filters-accordion-button').click
       expect(page).to have_content('Completely updated category')
     end
 
@@ -72,7 +71,6 @@ describe 'Admin Dashboard Categories Tab', type: :feature do
       click_button('Create Tag')
       expect(cache_keys).not_to include("categories")
       add_categories_to_cache
-      find('.search-filters-accordion-button').click
       expect(page).to have_content('Newest Category')
     end
   end

--- a/spec/features/homepage_spec.rb
+++ b/spec/features/homepage_spec.rb
@@ -169,12 +169,10 @@ describe 'Homepage', type: :feature do
 
       it 'provides a link that navs to the search page with the filters accordian engaged' do
         within '#search-dropdown' do
-          expect(page).to have_link('Browse all Tags', href: '/search?filters=open')
+          expect(page).to have_link('Browse all Tags', href: '/search')
           click_link 'Browse all Tags'
         end
-        expect(page).to have_current_path('/search?filters=open')
-        expect(page).to have_css('.usa-accordion__button.search-filters-accordion-button[aria-expanded="true"]')
-        expect(page).to have_css('#search_filters_dropdown:not([hidden])')
+        expect(page).to have_current_path('/search')
       end
 
       it 'provides a link that navs to the search page with all community tags engaged', js: true do
@@ -184,8 +182,6 @@ describe 'Homepage', type: :feature do
         end
 
         expect(page).to have_current_path('/search?all_communities=true')
-        filter_button = find('button.search-filters-accordion-button')
-        expect(filter_button).to have_text('Filters (1)')
         expect(page).to have_content("1 Result:")
         expect(page).to have_content(@practice_3.name)
       end

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -115,12 +115,8 @@ describe 'Search', type: :feature do
     find('#dm-practice-search-button').click
   end
 
-  def toggle_filters_accordion
-    find('.search-filters-accordion-button').click
-  end
-
   def update_results
-    click_button('Update results')
+    click_button('Apply filters')
   end
 
   def update_practice_introduction(practice)
@@ -156,7 +152,9 @@ describe 'Search', type: :feature do
   end
 
   def select_category(label_class)
-    find(label_class).click
+    within('#filtersContainer') do
+      find(label_class).click
+    end
   end
 
   def add_crh_adoptions_and_practice_origin_facilities
@@ -212,7 +210,6 @@ describe 'Search', type: :feature do
 
     it 'should display certain text if no matches are found' do
       visit_search_page
-      toggle_filters_accordion
       fill_in('dm-practice-search-field', with: 'test')
       set_combobox_val(0, 'James J. Howard Veterans\' Outpatient Clinic')
       select_category('.cat-2-label')
@@ -354,13 +351,11 @@ describe 'Search', type: :feature do
       it 'should collect practices that match ANY of the conditions if the user selects filters, but does not use the search input' do
         visit_search_page
 
-        toggle_filters_accordion
         set_combobox_val(0, 'Norwood VA Clinic')
         select_category('.cat-2-label')
         select_category('.cat-5-label')
         update_results
 
-        expect(page).to have_content('Filters (3)')
         expect(page).to have_content('6 Results')
         expect(page).to have_button('Clear filters')
         expect(page).to have_content(@practice.name)
@@ -375,7 +370,6 @@ describe 'Search', type: :feature do
         # reset the practice cache
         visit_search_page
 
-        toggle_filters_accordion
         set_combobox_val(0, 'VISN 8 Clinical Resource Hub (Remote)')
         update_results
 
@@ -383,7 +377,6 @@ describe 'Search', type: :feature do
         expect(page).to have_content(@practice13.name)
         expect(page).to have_content(@practice14.name)
 
-        toggle_filters_accordion
         click_button('Clear filters')
         set_combobox_val(1, 'VISN 8 Clinical Resource Hub (Remote)')
         update_results
@@ -395,7 +388,6 @@ describe 'Search', type: :feature do
 
       it 'should select all subcategories when selecting the parent category' do
         visit_search_page
-        toggle_filters_accordion
         select_category('.cat-all-strategic-label')
         expect(find("#cat-2-input", visible: false)).to be_checked
         expect(find("#cat-3-input", visible: false)).to be_checked
@@ -404,7 +396,6 @@ describe 'Search', type: :feature do
         expect(find("#cat-6-input", visible: false)).to be_checked
         update_results
         expect(page).to have_content('7 Results')
-        toggle_filters_accordion
         select_category('.cat-2-label')
         expect(find("#cat-all-strategic-input", visible: false)).to_not be_checked
         expect(find("#cat-2-input", visible: false)).to_not be_checked
@@ -421,54 +412,44 @@ describe 'Search', type: :feature do
         visit_search_page
 
         fill_in('dm-practice-search-field', with: 'practice')
-        toggle_filters_accordion
         set_combobox_val(0, 'Togus VA Medical Center')
         select_category('.cat-2-label')
         search
-        expect(page).to have_content('Filters (2)')
         expect(page).to have_content('2 Results')
         expect(page).to have_content(@practice3.name)
         expect(page).to have_content(@practice5.name)
 
         # Now add the remaining to eliminate one of the last two practices
-        toggle_filters_accordion
         set_combobox_val(1, 'Aberdeen VA Clinic')
         update_results
 
-        expect(page).to have_content('Filters (3)')
         expect(page).to have_content('1 Result')
         expect(page).to have_content(@practice3.name)
         expect(page).to_not have_content(@practice5.name)
 
         # Reset filters and select a VISN from the Originating Facility combo box
-        toggle_filters_accordion
         click_button('Clear filters')
         set_combobox_val(0, 'VISN-1')
         update_results
 
-        expect(page).to have_content('Filters (1)')
         expect(page).to have_content('4 Results')
         expect(page).to have_content(@practice3.name)
         expect(page).to have_content(@practice4.name)
         expect(page).to have_content(@practice5.name)
         expect(page).to have_content(@practice6.name)
 
-        toggle_filters_accordion
         select_category('.cat-4-label')
         update_results
 
-        expect(page).to have_content('Filters (2)')
         expect(page).to have_content('2 Results')
         expect(page).to have_content(@practice4.name)
         expect(page).to have_content(@practice5.name)
 
         # Reset filters and select a VISN from the Adopting Facility combo box
-        toggle_filters_accordion
         click_button('Clear filters')
         set_combobox_val(1, 'VISN-7')
         update_results
 
-        expect(page).to have_content('Filters (1)')
         expect(page).to have_content('1 Result')
         expect(page).to have_content(@practice6.name)
 
@@ -477,12 +458,10 @@ describe 'Search', type: :feature do
         visit_search_page
 
         fill_in('dm-practice-search-field', with: 'important')
-        toggle_filters_accordion
         set_combobox_val(0, 'VISN 8 Clinical Resource Hub (Remote)')
         set_combobox_val(1, 'VISN 8 Clinical Resource Hub (Remote)')
         update_results
 
-        expect(page).to have_content('Filters (2)')
         expect(page).to have_content('1 Result')
         expect(page).to have_content(@practice14.name)
       end
@@ -491,11 +470,9 @@ describe 'Search', type: :feature do
         it 'should, when the user selects a VISN, collect practices that either have that VISN as their initiating_facility OR have a practice_origin_facility that belongs to that VISN' do
           visit_search_page
 
-          toggle_filters_accordion
           set_combobox_val(0, 'VISN-1')
           update_results
 
-          expect(page).to have_content('Filters (1)')
           expect(page).to have_content('4 Results')
           expect(page).to have_content(@practice3.name)
           expect(page).to have_content(@practice3.name)
@@ -506,11 +483,9 @@ describe 'Search', type: :feature do
           add_crh_adoptions_and_practice_origin_facilities
           visit_search_page
 
-          toggle_filters_accordion
           set_combobox_val(0, 'VISN-8')
           update_results
 
-          expect(page).to have_content('Filters (1)')
           expect(page).to have_content('2 Results')
           expect(page).to have_content(@practice13.name)
           expect(page).to have_content(@practice14.name)
@@ -519,11 +494,9 @@ describe 'Search', type: :feature do
         it 'should, when the user selects a facility, only collect practices that have a practice_origin_facility that matches the selected facility' do
           visit_search_page
 
-          toggle_filters_accordion
           set_combobox_val(0, 'Vinita VA Clinic')
           update_results
 
-          expect(page).to have_content('1 Result')
           expect(page).to have_content(@practice12.name)
         end
       end
@@ -532,7 +505,6 @@ describe 'Search', type: :feature do
         it 'should, when the user selects a VISN, collect practices that have an adoption facility that belongs to that VISN' do
           visit_search_page
 
-          toggle_filters_accordion
           set_combobox_val(1, 'VISN-23')
           update_results
 
@@ -544,11 +516,9 @@ describe 'Search', type: :feature do
           add_crh_adoptions_and_practice_origin_facilities
           visit_search_page
 
-          toggle_filters_accordion
           set_combobox_val(1, 'VISN-8')
           update_results
 
-          expect(page).to have_content('Filters (1)')
           expect(page).to have_content('2 Results')
           expect(page).to have_content(@practice12.name)
           expect(page).to have_content(@practice14.name)
@@ -557,7 +527,6 @@ describe 'Search', type: :feature do
         it 'should, when the user selects a facility, only collect practices that have an adopting facility that matches the selected facility' do
           visit_search_page
 
-          toggle_filters_accordion
           set_combobox_val(0, 'Vinita VA Clinic')
           update_results
 
@@ -570,7 +539,6 @@ describe 'Search', type: :feature do
         before do
           visit_search_page
 
-          toggle_filters_accordion
           set_combobox_val(0, 'Norwood VA Clinic')
           set_combobox_val(1, 'Marietta VA Clinic')
           select_category('.cat-2-label')
@@ -591,6 +559,7 @@ describe 'Search', type: :feature do
           within('#searchResultsContainer') do
             all('button.applied-filter').first.click
           end
+
           # expect updated applied filters
           expect(page).not_to have_content('TAG: COVID')
           expect(page).to have_content('TAG: PULMONARY CARE')
@@ -605,8 +574,6 @@ describe 'Search', type: :feature do
           expect(page).to have_content(@practice7.name)
           expect(page).not_to have_content(@practice12.name)
           # expect updated filter checkboxes
-          expect(page).to have_content('Filters (3)')
-          toggle_filters_accordion
           label = find('.cat-2-label')
           parent_div = label.find(:xpath, './..')
           checkbox = parent_div.find('input[type="checkbox"]', visible: :all)
@@ -641,8 +608,6 @@ describe 'Search', type: :feature do
     describe 'Sorting' do
       it 'should sort the results based on the sort option chosen' do
         visit_search_page
-
-        toggle_filters_accordion
         set_combobox_val(0, 'VISN-1')
         select_category('.cat-2-label')
         update_results
@@ -650,8 +615,6 @@ describe 'Search', type: :feature do
         # results should be sorted my most relevant(closest match) by default
         expect(page).to have_content('6 Results')
         expect(first('span.dm-practice-title').text).to eq(@practice6.name)
-
-        toggle_filters_accordion
         select_category('.cat-3-label')
         select_category('.cat-4-label')
         update_results
@@ -705,8 +668,6 @@ describe 'Search', type: :feature do
     describe 'Querying' do
       it 'should not create a query if the user does not enter text into the search input' do
         visit_search_page
-
-        toggle_filters_accordion
         set_combobox_val(0, 'VISN-2')
         select_category('.cat-2-label')
         select_category('.cat-3-label')
@@ -727,8 +688,6 @@ describe 'Search', type: :feature do
 
       it 'should, if there is no query and the user clicks on a practice card, add a search page breadcrumb that does not include a query' do
         visit_search_page
-
-        toggle_filters_accordion
         select_category('.cat-2-label')
         update_results
         all('.dm-practice-link-aria-hidden').first.click
@@ -812,12 +771,12 @@ describe 'Search', type: :feature do
     it 'should function appropriately' do
       visit_search_page
 
-      click_button('Filters')
-      click_button('Originating facility')
+      click_button('Refine Results')
+      # click_button('Originating facility')
       set_combobox_val(0, 'Togus VA Medical Center')
-      click_button('Adopting facility')
+      # click_button('Adopting facility')
       set_combobox_val(1, 'VISN-2')
-      click_button('Tags')
+      # click_button('Tags')
       select_category('.cat-5-label')
       update_results
 


### PR DESCRIPTION
### JIRA issue link
https://agile6.atlassian.net/browse/DM-4912

## Description - what does this code do?
* updates search page drop down to appear in new section as defined in figma design
* mobile view has the filters section within an accordion drop-down, new js logic written to transfer filter section contents to and from the mobile accordion as per window resizing.

* Note: As per Nick, the info copy and modals for "Originating" and "Adopting Location" comboboxes were unintentionally left out of the mockups and should be included in the new layout.

* Note: The sort box was left out from this pr, going to add it separately for demo purposes since there is some discourse concerning how and where it should appear vs the proposed design

## Testing done - how did you test it/steps on how can another person can test it 
1. Locally, visit the search page and verify the filters section appears as per screenshot-1
2. Verify the filters filter innovation results as expected
3. Verify that when resizing the screen to less than mobile width the filters appear under an accordion, with all the selections previously applied in place, verify the reverse when enlarging to desktop view.

## Screenshots, Gifs, Videos from application (if applicable)
![Screenshot 2024-08-05 at 12 07 50 PM](https://github.com/user-attachments/assets/3a2dae0d-5231-4d8b-b490-c0c2f25d2d35)

![Screenshot 2024-08-05 at 12 08 38 PM](https://github.com/user-attachments/assets/d13cdc74-2c23-43d1-a052-ad4bd06a3338)

## Link to mock-ups/mock ups (image file if you have it) (if applicable)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Unit tests written (if applicable)
- [ ] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating JIRA issue
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs