### PR TITLE
dm-4992 remove gmap load scripts from facilities and visns js

### DIFF
--- a/app/assets/javascripts/va_facilities/map.es6
+++ b/app/assets/javascripts/va_facilities/map.es6
@@ -37,7 +37,3 @@ function initialize() {
     buildMapMarkers(mapData);
   });
 }
-
-$(document).on("turbolinks:load", function () {
-  google.maps.event.addDomListener(window, "load", initialize);
-});

--- a/app/assets/javascripts/visns/maps.es6
+++ b/app/assets/javascripts/visns/maps.es6
@@ -244,7 +244,3 @@ function initialize() {
   addVisnShowFilterListener();
   resetMarkerBounds();
 }
-
-$(document).on("turbolinks:load", function () {
-  google.maps.event.addDomListener(window, "load", initialize);
-});


### PR DESCRIPTION
### JIRA issue link
https://agile6.atlassian.net/browse/DM-4992

## Description - what does this code do?
As per bug ticket the navbar dropdown content was not loading on facilities and visns pages..

Turns out the issue was gmaps loading scripts left over from the previous implementation strategy that has since been updated as per https://github.com/department-of-veterans-affairs/diffusion-marketplace/commit/cb1742581d94a45eb6e8c31f7f15d8d81494f96a in which the loading has been updated to be async and centralized in the `application.html.erb` file.

## Testing done - how did you test it/steps on how can another person can test it 
Verify the navbar dropdown content and gmap loads as expected for facility and visn show pages (you may need to add valid communities via `active_admin`)

## Screenshots, Gifs, Videos from application (if applicable)


## Link to mock-ups/mock ups (image file if you have it) (if applicable)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Unit tests written (if applicable)
- [ ] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating JIRA issue
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs