### PR TITLE
DM-5904: Fix up screenreader accessibility on Originating / Adoption location comboboxes

### DIFF
--- a/app/views/practices/search_partials/_search_filters.html.erb
+++ b/app/views/practices/search_partials/_search_filters.html.erb
@@ -67,16 +67,14 @@
 
 <fieldset class="usa-fieldset margin-top-3 padding-top-1 padding-bottom-3 border-bottom-2px border-gray-10">
   <div id="originating-facility-container">
-    <legend class="text-bold line-height-26 margin-bottom-1 grid-col-12 desktop:display-block">Originating Location</legend>
-    <%= render partial: 'practices/search_partials/visn_facility_combo_box', locals: {facility_type_selector: 'originating-facility-and-visn-select', visn_grouped_facilities: @visn_grouped_facilities} %>
+    <%= render partial: 'practices/search_partials/visn_facility_combo_box', locals: { form_label: 'Originating location', facility_type_selector: 'originating-facility-and-visn-select', visn_grouped_facilities: @visn_grouped_facilities} %>
     <%= render partial: 'shared/visn_info_modal', locals: { hide_modal_on_initial_load: false } %>
   </div>
 </fieldset>
 
 <fieldset class="usa-fieldset margin-top-3 padding-top-1 padding-bottom-3">
   <div id="adopting-facility-container">
-    <legend class="text-bold line-height-26 margin-bottom-1 grid-col-12 desktop:display-block">Adopting location</legend>
-    <%= render partial: 'practices/search_partials/visn_facility_combo_box', locals: {facility_type_selector: 'adopting-facility-and-visn-select', visn_grouped_facilities: @visn_grouped_facilities } %>
+    <%= render partial: 'practices/search_partials/visn_facility_combo_box', locals: { form_label: 'Adopting location', facility_type_selector: 'adopting-facility-and-visn-select', visn_grouped_facilities: @visn_grouped_facilities } %>
   </div>
 </fieldset>
 

--- a/app/views/practices/search_partials/_visn_facility_combo_box.html.erb
+++ b/app/views/practices/search_partials/_visn_facility_combo_box.html.erb
@@ -1,11 +1,12 @@
+<label for="<%= facility_type_selector %>" class="text-bold line-height-26 margin-bottom-1 grid-col-12 desktop:display-block"><%= form_label %></label>
 <div class="usa-combo-box">
-  <label for="<%= facility_type_selector %>" class="line-height-26">
+  <span class="line-height-26">
     Search by
     <a href="#visn-info-modal" aria-controls="visn-info-modal" data-open-modal class="dotted cursor-pointer">
       <span class="usa-sr-only">Open visn info modal</span>
       VISN</a>
     <span>or facility</span>
-  </label>
+  </span>
   <select id="<%= facility_type_selector %>" class="usa-select" name="<%= facility_type_selector %>">
     <div>
       <%= visn_grouped_facilities %>


### PR DESCRIPTION
### JIRA issue link
[DM-5904](https://agile6.atlassian.net/browse/DM-5094)

## Description - what does this code do?
1. Updates the combobox partial so that the `<label>` accurately reflects what it's for
2. Remove the `Search by VISN or facility` span per Figma design, as well as the link to the VISN definition

## Testing done - how did you test it/steps on how can another person can test it 
1. Go to `/search` and open VoiceOver screenreader
4. Open the [VoiceOver form controls menu ](https://support.apple.com/guide/voiceover/general-commands-cpvokys01/mac)
5. Confirm that the combobox form labels now begin with differentiating info e.g. "Originating Location..."

## Screenshots, Gifs, Videos from application (if applicable)


## Link to mock-ups/mock ups (image file if you have it) (if applicable)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Unit tests written (if applicable)
- [ ] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating JIRA issue
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs