### PR TITLE
DM-5103: Clean up Practice model

### DIFF
--- a/app/controllers/practices_controller.rb
+++ b/app/controllers/practices_controller.rb
@@ -579,7 +579,7 @@ class PracticesController < ApplicationController # rubocop:disable Metrics/Clas
   def practice_params
     params.require(:practice).permit(:tagline, :process, :it_required, :description, :name, :initiating_facility, :summary, :origin_title, :origin_story, :date_initiated,
                                      :number_adopted, :number_departments, :number_failed,
-                                     :training_length, :required_training_summary, :private_contact_info, :support_network_email,
+                                     :training_length, :private_contact_info, :support_network_email,
                                      :initiating_facility_type, :initiating_department_office_id,
                                      :main_display_image, :main_display_image_alt_text, :crop_x, :crop_y, :crop_h, :crop_w,
                                      :tagline, :delete_main_display_image,

--- a/app/controllers/practices_controller.rb
+++ b/app/controllers/practices_controller.rb
@@ -579,7 +579,7 @@ class PracticesController < ApplicationController # rubocop:disable Metrics/Clas
   def practice_params
     params.require(:practice).permit(:tagline, :process, :it_required, :description, :name, :initiating_facility, :summary, :origin_title, :origin_story, :date_initiated,
                                      :number_adopted, :number_departments, :number_failed,
-                                     :training_provider, :training_length, :training_test, :training_provider_role, :required_training_summary, :private_contact_info, :support_network_email,
+                                     :training_length, :training_test, :required_training_summary, :private_contact_info, :support_network_email,
                                      :initiating_facility_type, :initiating_department_office_id,
                                      :main_display_image, :main_display_image_alt_text, :crop_x, :crop_y, :crop_h, :crop_w,
                                      :tagline, :delete_main_display_image,

--- a/app/controllers/practices_controller.rb
+++ b/app/controllers/practices_controller.rb
@@ -577,7 +577,7 @@ class PracticesController < ApplicationController # rubocop:disable Metrics/Clas
 
   # Never trust parameters from the scary internet, only allow the white list through.
   def practice_params
-    params.require(:practice).permit(:need_training, :tagline, :process, :it_required, :need_new_license, :description, :name, :initiating_facility, :summary, :origin_title, :origin_story, :date_initiated,
+    params.require(:practice).permit(:tagline, :process, :it_required, :need_new_license, :description, :name, :initiating_facility, :summary, :origin_title, :origin_story, :date_initiated,
                                      :number_adopted, :number_departments, :number_failed,
                                      :training_provider, :training_length, :training_test, :training_provider_role, :required_training_summary, :private_contact_info, :support_network_email,
                                      :initiating_facility_type, :initiating_department_office_id,

--- a/app/controllers/practices_controller.rb
+++ b/app/controllers/practices_controller.rb
@@ -577,7 +577,7 @@ class PracticesController < ApplicationController # rubocop:disable Metrics/Clas
 
   # Never trust parameters from the scary internet, only allow the white list through.
   def practice_params
-    params.require(:practice).permit(:tagline, :process, :it_required, :description, :name, :initiating_facility, :summary, :origin_title, :origin_story, :date_initiated,
+    params.require(:practice).permit(:tagline, :process, :description, :name, :initiating_facility, :summary, :origin_title, :origin_story, :date_initiated,
                                      :number_adopted, :number_departments, :number_failed,
                                      :private_contact_info, :support_network_email,
                                      :initiating_facility_type, :initiating_department_office_id,

--- a/app/controllers/practices_controller.rb
+++ b/app/controllers/practices_controller.rb
@@ -577,7 +577,7 @@ class PracticesController < ApplicationController # rubocop:disable Metrics/Clas
 
   # Never trust parameters from the scary internet, only allow the white list through.
   def practice_params
-    params.require(:practice).permit(:tagline, :process, :it_required, :need_new_license, :description, :name, :initiating_facility, :summary, :origin_title, :origin_story, :date_initiated,
+    params.require(:practice).permit(:tagline, :process, :it_required, :description, :name, :initiating_facility, :summary, :origin_title, :origin_story, :date_initiated,
                                      :number_adopted, :number_departments, :number_failed,
                                      :training_provider, :training_length, :training_test, :training_provider_role, :required_training_summary, :private_contact_info, :support_network_email,
                                      :initiating_facility_type, :initiating_department_office_id,

--- a/app/controllers/practices_controller.rb
+++ b/app/controllers/practices_controller.rb
@@ -579,7 +579,7 @@ class PracticesController < ApplicationController # rubocop:disable Metrics/Clas
   def practice_params
     params.require(:practice).permit(:tagline, :process, :it_required, :description, :name, :initiating_facility, :summary, :origin_title, :origin_story, :date_initiated,
                                      :number_adopted, :number_departments, :number_failed,
-                                     :training_length, :training_test, :required_training_summary, :private_contact_info, :support_network_email,
+                                     :training_length, :required_training_summary, :private_contact_info, :support_network_email,
                                      :initiating_facility_type, :initiating_department_office_id,
                                      :main_display_image, :main_display_image_alt_text, :crop_x, :crop_y, :crop_h, :crop_w,
                                      :tagline, :delete_main_display_image,

--- a/app/controllers/practices_controller.rb
+++ b/app/controllers/practices_controller.rb
@@ -579,7 +579,7 @@ class PracticesController < ApplicationController # rubocop:disable Metrics/Clas
   def practice_params
     params.require(:practice).permit(:tagline, :process, :it_required, :description, :name, :initiating_facility, :summary, :origin_title, :origin_story, :date_initiated,
                                      :number_adopted, :number_departments, :number_failed,
-                                     :training_length, :private_contact_info, :support_network_email,
+                                     :private_contact_info, :support_network_email,
                                      :initiating_facility_type, :initiating_department_office_id,
                                      :main_display_image, :main_display_image_alt_text, :crop_x, :crop_y, :crop_h, :crop_w,
                                      :tagline, :delete_main_display_image,

--- a/db/migrate/20240819002628_remove_more_fields_from_practices.rb
+++ b/db/migrate/20240819002628_remove_more_fields_from_practices.rb
@@ -1,0 +1,4 @@
+class RemoveMoreFieldsFromPractices < ActiveRecord::Migration[6.1]
+  def change
+  end
+end

--- a/db/migrate/20240819002628_remove_more_fields_from_practices.rb
+++ b/db/migrate/20240819002628_remove_more_fields_from_practices.rb
@@ -1,5 +1,6 @@
 class RemoveMoreFieldsFromPractices < ActiveRecord::Migration[6.1]
   def change
     remove_column :practices, :need_additional_staff, :boolean
+    remove_column :practices, :need_training, :boolean
   end
 end

--- a/db/migrate/20240819002628_remove_more_fields_from_practices.rb
+++ b/db/migrate/20240819002628_remove_more_fields_from_practices.rb
@@ -1,4 +1,5 @@
 class RemoveMoreFieldsFromPractices < ActiveRecord::Migration[6.1]
   def change
+    remove_column :practices, :need_additional_staff, :boolean
   end
 end

--- a/db/migrate/20240819002628_remove_more_fields_from_practices.rb
+++ b/db/migrate/20240819002628_remove_more_fields_from_practices.rb
@@ -4,5 +4,7 @@ class RemoveMoreFieldsFromPractices < ActiveRecord::Migration[6.1]
     remove_column :practices, :need_training, :boolean
     remove_column :practices, :need_policy_change, :boolean
     remove_column :practices, :need_new_license, :boolean
+    remove_column :practices, :training_provider, :string
+    remove_column :practices, :training_provider_role, :string
   end
 end

--- a/db/migrate/20240819002628_remove_more_fields_from_practices.rb
+++ b/db/migrate/20240819002628_remove_more_fields_from_practices.rb
@@ -8,5 +8,6 @@ class RemoveMoreFieldsFromPractices < ActiveRecord::Migration[6.1]
     remove_column :practices, :training_provider_role, :string
     remove_column :practices, :training_test, :boolean
     remove_column :practices, :training_test_details, :boolean
+    remove_column :practices, :required_training_summary, :text
   end
 end

--- a/db/migrate/20240819002628_remove_more_fields_from_practices.rb
+++ b/db/migrate/20240819002628_remove_more_fields_from_practices.rb
@@ -7,5 +7,6 @@ class RemoveMoreFieldsFromPractices < ActiveRecord::Migration[6.1]
     remove_column :practices, :training_provider, :string
     remove_column :practices, :training_provider_role, :string
     remove_column :practices, :training_test, :boolean
+    remove_column :practices, :training_test_details, :boolean
   end
 end

--- a/db/migrate/20240819002628_remove_more_fields_from_practices.rb
+++ b/db/migrate/20240819002628_remove_more_fields_from_practices.rb
@@ -9,5 +9,6 @@ class RemoveMoreFieldsFromPractices < ActiveRecord::Migration[6.1]
     remove_column :practices, :training_test, :boolean
     remove_column :practices, :training_test_details, :boolean
     remove_column :practices, :required_training_summary, :text
+    remove_column :practices, :training_length, :string
   end
 end

--- a/db/migrate/20240819002628_remove_more_fields_from_practices.rb
+++ b/db/migrate/20240819002628_remove_more_fields_from_practices.rb
@@ -2,5 +2,7 @@ class RemoveMoreFieldsFromPractices < ActiveRecord::Migration[6.1]
   def change
     remove_column :practices, :need_additional_staff, :boolean
     remove_column :practices, :need_training, :boolean
+    remove_column :practices, :need_policy_change, :boolean
+    remove_column :practices, :need_new_license, :boolean
   end
 end

--- a/db/migrate/20240819002628_remove_more_fields_from_practices.rb
+++ b/db/migrate/20240819002628_remove_more_fields_from_practices.rb
@@ -6,5 +6,6 @@ class RemoveMoreFieldsFromPractices < ActiveRecord::Migration[6.1]
     remove_column :practices, :need_new_license, :boolean
     remove_column :practices, :training_provider, :string
     remove_column :practices, :training_provider_role, :string
+    remove_column :practices, :training_test, :boolean
   end
 end

--- a/db/migrate/20240819002628_remove_more_fields_from_practices.rb
+++ b/db/migrate/20240819002628_remove_more_fields_from_practices.rb
@@ -10,5 +10,6 @@ class RemoveMoreFieldsFromPractices < ActiveRecord::Migration[6.1]
     remove_column :practices, :training_test_details, :boolean
     remove_column :practices, :required_training_summary, :text
     remove_column :practices, :training_length, :string
+    remove_column :practices, :it_required, :boolean
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_08_01_184827) do
+ActiveRecord::Schema.define(version: 2024_08_19_002628) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -1036,15 +1036,6 @@ ActiveRecord::Schema.define(version: 2024_08_01_184827) do
     t.string "summary"
     t.string "origin_title"
     t.string "origin_story"
-    t.boolean "need_additional_staff"
-    t.boolean "need_training"
-    t.boolean "need_policy_change"
-    t.boolean "need_new_license"
-    t.boolean "training_test"
-    t.boolean "training_test_details"
-    t.string "training_provider"
-    t.text "required_training_summary"
-    t.string "training_length"
     t.string "facility_complexity_level"
     t.integer "main_display_image_original_w"
     t.integer "main_display_image_original_h"
@@ -1059,7 +1050,6 @@ ActiveRecord::Schema.define(version: 2024_08_01_184827) do
     t.integer "origin_picture_crop_w"
     t.integer "origin_picture_crop_h"
     t.integer "number_departments", default: 0
-    t.boolean "it_required"
     t.string "process"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -1078,7 +1068,6 @@ ActiveRecord::Schema.define(version: 2024_08_01_184827) do
     t.boolean "highlight", default: false, null: false
     t.boolean "featured", default: false, null: false
     t.integer "ahoy_visit_id"
-    t.string "training_provider_role"
     t.boolean "enabled", default: true, null: false
     t.integer "initiating_facility_type", default: 0
     t.integer "initiating_department_office_id"

--- a/lib/tasks/importer.rake
+++ b/lib/tasks/importer.rake
@@ -127,7 +127,6 @@ namespace :importer do
       practice_permissions
       timelines
       training_details
-      license_required
       it_required
     end
     puts "*********** Completed Importing Practices! ***********".green
@@ -170,8 +169,6 @@ def basic_answers
       'Is this practice a New Clinical Approach or New Process? Or is this practice a process change of something already being done? (Choose one of the following.)': :process,
       'Please list who provides the training.': :training_provider,
       'Training details:': :required_training_summary,
-      # 'Will a policy change be required?': :need_policy_change,
-      # 'Will a new license or certification be required?': :need_new_license,
       'Please enter a 10-20 word title for the origin story of this Practice': :origin_title,
       'Please provide a 50 - 100 word paragraph sharing the story of the origin of this practice': :origin_story,
       'Number of facilities that have successfully implemented the Practice (Please enter a whole number):': :number_adopted,
@@ -935,22 +932,6 @@ def training_details
     @practice.training_test = training_test.downcase.include?('yes') ? true : false
   end
   @practice.save
-end
-
-def license_required
-  puts "==> Importing Practice: #{@name} License Details".light_blue
-  question_fields = {
-      'Will a new license or certification be required?': 1
-  }
-  question_fields.each do |key, value|
-    next if @answers[@questions.index(key.to_s)].blank?
-
-    answer = @answers[@questions.index(key.to_s)]
-
-    @practice.need_new_license = true if answer.downcase == 'yes'
-    @practice.need_new_license = false if answer.downcase == 'no'
-    @practice.save
-  end
 end
 
 def it_required

--- a/lib/tasks/importer.rake
+++ b/lib/tasks/importer.rake
@@ -167,7 +167,6 @@ def basic_answers
       'Please provide a 50-100 word descriptive paragraph for your Practice. ': :summary,
       'Is Information Technology (IT) required to implement the practice?': :it_required,
       'Is this practice a New Clinical Approach or New Process? Or is this practice a process change of something already being done? (Choose one of the following.)': :process,
-      'Please list who provides the training.': :training_provider,
       'Training details:': :required_training_summary,
       'Please enter a 10-20 word title for the origin story of this Practice': :origin_title,
       'Please provide a 50 - 100 word paragraph sharing the story of the origin of this practice': :origin_story,

--- a/lib/tasks/importer.rake
+++ b/lib/tasks/importer.rake
@@ -126,7 +126,6 @@ namespace :importer do
       domains
       practice_permissions
       timelines
-      training_details
       it_required
     end
     puts "*********** Completed Importing Practices! ***********".green
@@ -912,25 +911,6 @@ def practice_permissions
       PracticePermission.find_or_create_by!(description: @answers[i], practice: @practice)
     end
   end
-end
-
-def training_details
-  puts "==> Importing Practice: #{@name} Training Details".light_blue
-  question_fields = {
-      "Training details:": 3
-  }
-
-  question_fields.each do |key, value|
-    q_index = @questions.index(key.to_s)
-
-    @practice.training_length = @answers[q_index]
-    @practice.required_training_summary = @answers[q_index + 1]
-    @practice.training_test_details = @answers[q_index + 2]
-    training_test = @answers[q_index + 2]
-    next if training_test.blank?
-    @practice.training_test = training_test.downcase.include?('yes') ? true : false
-  end
-  @practice.save
 end
 
 def it_required

--- a/lib/tasks/importer.rake
+++ b/lib/tasks/importer.rake
@@ -166,7 +166,6 @@ def basic_answers
       'Please provide a 50-100 word descriptive paragraph for your Practice. ': :summary,
       'Is Information Technology (IT) required to implement the practice?': :it_required,
       'Is this practice a New Clinical Approach or New Process? Or is this practice a process change of something already being done? (Choose one of the following.)': :process,
-      'Training details:': :required_training_summary,
       'Please enter a 10-20 word title for the origin story of this Practice': :origin_title,
       'Please provide a 50 - 100 word paragraph sharing the story of the origin of this practice': :origin_story,
       'Number of facilities that have successfully implemented the Practice (Please enter a whole number):': :number_adopted,

--- a/lib/tasks/importer.rake
+++ b/lib/tasks/importer.rake
@@ -168,7 +168,6 @@ def basic_answers
       'Please provide a 50-100 word descriptive paragraph for your Practice. ': :summary,
       'Is Information Technology (IT) required to implement the practice?': :it_required,
       'Is this practice a New Clinical Approach or New Process? Or is this practice a process change of something already being done? (Choose one of the following.)': :process,
-      # 'Did your institution have to hire additional staff to implement this Practice?': :need_additional_staff,
       # 'Is there training required?': :need_training,
       'Please list who provides the training.': :training_provider,
       'Training details:': :required_training_summary,

--- a/lib/tasks/importer.rake
+++ b/lib/tasks/importer.rake
@@ -126,7 +126,6 @@ namespace :importer do
       domains
       practice_permissions
       timelines
-      it_required
     end
     puts "*********** Completed Importing Practices! ***********".green
   end
@@ -164,7 +163,6 @@ def basic_answers
       "On the Practice page, we often use a descriptive tagline as the functional title. For example: the FLOW3 Practice is not well described by the title, and we therefore use the tagline: \"Delivery of prosthetic limbs to Veterans in less than ½ the time\".Please provide a 5-10 word descriptive tagline for your Practice. This will be used as the functional title.": :tagline,
       "On the Practice page, under the tagline/functional title you just provided, we would like a longer descriptive tagline to further explain your practice. For example, for FLOW3: \"Enable 53% faster delivery of prosthetic limbs to Veterans. Automating the prosthetic limb procurement process to improve continuity of care for Veterans.\"Please provide a 1-2 line descriptive tagline for your Practice. This will be used below the functional title.": :description,
       'Please provide a 50-100 word descriptive paragraph for your Practice. ': :summary,
-      'Is Information Technology (IT) required to implement the practice?': :it_required,
       'Is this practice a New Clinical Approach or New Process? Or is this practice a process change of something already being done? (Choose one of the following.)': :process,
       'Please enter a 10-20 word title for the origin story of this Practice': :origin_title,
       'Please provide a 50 - 100 word paragraph sharing the story of the origin of this practice': :origin_story,
@@ -909,23 +907,6 @@ def practice_permissions
       next if @answers[i].blank?
       PracticePermission.find_or_create_by!(description: @answers[i], practice: @practice)
     end
-  end
-end
-
-def it_required
-  puts "==> Importing Practice: #{@name} IT Required".light_blue
-  question_fields = {
-      "Is Information Technology (IT) required to implement the practice?": 1
-  }
-
-  question_fields.each do |key, value|
-    next if @answers[@questions.index(key.to_s)].blank?
-
-    answer = @answers[@questions.index(key.to_s)]
-
-    @practice.it_required = true if answer.downcase == 'yes'
-    @practice.it_required = false if answer.downcase == 'no'
-    @practice.save
   end
 end
 

--- a/lib/tasks/importer.rake
+++ b/lib/tasks/importer.rake
@@ -168,7 +168,6 @@ def basic_answers
       'Please provide a 50-100 word descriptive paragraph for your Practice. ': :summary,
       'Is Information Technology (IT) required to implement the practice?': :it_required,
       'Is this practice a New Clinical Approach or New Process? Or is this practice a process change of something already being done? (Choose one of the following.)': :process,
-      # 'Is there training required?': :need_training,
       'Please list who provides the training.': :training_provider,
       'Training details:': :required_training_summary,
       # 'Will a policy change be required?': :need_policy_change,

--- a/spec/features/practice_spec.rb
+++ b/spec/features/practice_spec.rb
@@ -180,7 +180,7 @@ describe 'Practices', type: :feature do
 
     it 'should display the practice departments section' do
       login_as(@user, :scope => :user, :run_callbacks => false)
-      @user_practice.update(published: true, approved: true, number_departments: 3, it_required: true, process: 'New approach')
+      @user_practice.update(published: true, approved: true, number_departments: 3, process: 'New approach')
       visit practice_path(@user_practice)
 
       expect(page).to be_accessible.according_to :wcag2a, :section508

--- a/spec/features/practice_spec.rb
+++ b/spec/features/practice_spec.rb
@@ -180,7 +180,7 @@ describe 'Practices', type: :feature do
 
     it 'should display the practice departments section' do
       login_as(@user, :scope => :user, :run_callbacks => false)
-      @user_practice.update(published: true, approved: true, number_departments: 3, it_required: true, process: 'New approach', training_length: '1 month')
+      @user_practice.update(published: true, approved: true, number_departments: 3, it_required: true, process: 'New approach')
       visit practice_path(@user_practice)
 
       expect(page).to be_accessible.according_to :wcag2a, :section508

--- a/spec/features/practice_spec.rb
+++ b/spec/features/practice_spec.rb
@@ -180,7 +180,7 @@ describe 'Practices', type: :feature do
 
     it 'should display the practice departments section' do
       login_as(@user, :scope => :user, :run_callbacks => false)
-      @user_practice.update(published: true, approved: true, number_departments: 3, it_required: true, process: 'New approach', training_test: true, training_length: '1 month')
+      @user_practice.update(published: true, approved: true, number_departments: 3, it_required: true, process: 'New approach', training_length: '1 month')
       visit practice_path(@user_practice)
 
       expect(page).to be_accessible.according_to :wcag2a, :section508

--- a/spec/features/practice_spec.rb
+++ b/spec/features/practice_spec.rb
@@ -180,7 +180,7 @@ describe 'Practices', type: :feature do
 
     it 'should display the practice departments section' do
       login_as(@user, :scope => :user, :run_callbacks => false)
-      @user_practice.update(published: true, approved: true, number_departments: 3, it_required: true, process: 'New approach', training_provider: 'Practice champion', training_test: true, training_length: '1 month')
+      @user_practice.update(published: true, approved: true, number_departments: 3, it_required: true, process: 'New approach', training_test: true, training_length: '1 month')
       visit practice_path(@user_practice)
 
       expect(page).to be_accessible.according_to :wcag2a, :section508

--- a/spec/features/practice_spec.rb
+++ b/spec/features/practice_spec.rb
@@ -180,7 +180,7 @@ describe 'Practices', type: :feature do
 
     it 'should display the practice departments section' do
       login_as(@user, :scope => :user, :run_callbacks => false)
-      @user_practice.update(published: true, approved: true, number_departments: 3, it_required: true, process: 'New approach', training_provider: 'Practice champion', training_test: true, need_new_license: true, training_length: '1 month')
+      @user_practice.update(published: true, approved: true, number_departments: 3, it_required: true, process: 'New approach', training_provider: 'Practice champion', training_test: true, training_length: '1 month')
       visit practice_path(@user_practice)
 
       expect(page).to be_accessible.according_to :wcag2a, :section508

--- a/spec/tasks/importer_spec.rb
+++ b/spec/tasks/importer_spec.rb
@@ -25,7 +25,6 @@ describe 'Importer' do
       expect(flow3.origin_title).to eq('Innovating delivery processes')
       expect(flow3.origin_story).to include('Dr. Jeffrey Heckman, a physician in the VA Puget S')
       expect(flow3.training_length).to eq('126 minutes over 1 month initial training')
-      expect(flow3.required_training_summary).to include('At your own pace, one month per group')
       expect(flow3.it_required).to be(true)
 
       # Practice Partners

--- a/spec/tasks/importer_spec.rb
+++ b/spec/tasks/importer_spec.rb
@@ -24,7 +24,6 @@ describe 'Importer' do
       expect(flow3.summary).to include('FLOW3 is a system of three interrelated software')
       expect(flow3.origin_title).to eq('Innovating delivery processes')
       expect(flow3.origin_story).to include('Dr. Jeffrey Heckman, a physician in the VA Puget S')
-      expect(flow3.training_length).to eq('126 minutes over 1 month initial training')
       expect(flow3.it_required).to be(true)
 
       # Practice Partners

--- a/spec/tasks/importer_spec.rb
+++ b/spec/tasks/importer_spec.rb
@@ -24,7 +24,6 @@ describe 'Importer' do
       expect(flow3.summary).to include('FLOW3 is a system of three interrelated software')
       expect(flow3.origin_title).to eq('Innovating delivery processes')
       expect(flow3.origin_story).to include('Dr. Jeffrey Heckman, a physician in the VA Puget S')
-      expect(flow3.training_test).to be(true)
       expect(flow3.training_length).to eq('126 minutes over 1 month initial training')
       expect(flow3.required_training_summary).to include('At your own pace, one month per group')
       expect(flow3.it_required).to be(true)

--- a/spec/tasks/importer_spec.rb
+++ b/spec/tasks/importer_spec.rb
@@ -24,12 +24,10 @@ describe 'Importer' do
       expect(flow3.summary).to include('FLOW3 is a system of three interrelated software')
       expect(flow3.origin_title).to eq('Innovating delivery processes')
       expect(flow3.origin_story).to include('Dr. Jeffrey Heckman, a physician in the VA Puget S')
-      expect(flow3.need_new_license).to be(false)
       expect(flow3.training_test).to be(true)
       expect(flow3.training_length).to eq('126 minutes over 1 month initial training')
       expect(flow3.required_training_summary).to include('At your own pace, one month per group')
       expect(flow3.it_required).to be(true)
-      expect(flow3.need_new_license).to eq(false)
 
       # Practice Partners
       expect(flow3.practice_partners.count).to eq(1)

--- a/spec/tasks/importer_spec.rb
+++ b/spec/tasks/importer_spec.rb
@@ -24,7 +24,6 @@ describe 'Importer' do
       expect(flow3.summary).to include('FLOW3 is a system of three interrelated software')
       expect(flow3.origin_title).to eq('Innovating delivery processes')
       expect(flow3.origin_story).to include('Dr. Jeffrey Heckman, a physician in the VA Puget S')
-      expect(flow3.it_required).to be(true)
 
       # Practice Partners
       expect(flow3.practice_partners.count).to eq(1)


### PR DESCRIPTION
### JIRA issue link
[DM-5103](https://agile6.atlassian.net/browse/DM-5103)
More of DM-4056 / #968

## Description - what does this code do?
Drops more retired fields from the DB. 

## Testing done - how did you test it/steps on how can another person can test it 
1. Run the importer workflow (``dm:reset_up`) and confirm that it runs successfully. 
