### PR TITLE
dm-5904 fix innovation submission form reCAPTCHA tolerance

### DIFF
--- a/app/controllers/nominate_practices_controller.rb
+++ b/app/controllers/nominate_practices_controller.rb
@@ -49,7 +49,7 @@ class NominatePracticesController < ApplicationController
     end
   end
 
-  def log_recaptcha_failure(score, email)
+  def log_recaptcha_failure(recaptcha_reply, email)
     Rails.logger.info(
       "Nominate innovation form reCAPTCHA score below threshold: reply: #{recaptcha_reply}, submitted_email: #{email}"
     )

--- a/app/controllers/nominate_practices_controller.rb
+++ b/app/controllers/nominate_practices_controller.rb
@@ -4,25 +4,64 @@ class NominatePracticesController < ApplicationController
   end
 
   def email
-    recaptcha_result = verify_recaptcha(action: 'email', minimum_score: 0.5)
-
-    if recaptcha_result
-      if params["phone"].present?
-        log_spam_attempt "Nominate"
-        redirect_to root_path
-      else
-        NominateAPracticeMailer.send_contact_email(options = { email: params[:email], subject: params[:subject], message: params[:message], message_url: request.url }, 'Nominate', 'nominate_a_practice_mailer/nominate_a_practice_email').deliver_now
-        success = 'Message sent. The Diffusion Marketplace team will review your nomination.'
-        flash[:success] = success
-        respond_to do |format|
-          format.html { redirect_back fallback_location: root_path, notice: flash[:notice] }
-        end
-      end
+    if current_user.present?
+      handle_nomination
     else
-      respond_to do |format|
-        format.html { redirect_to root_path }
+      begin
+        recaptcha_result = verify_recaptcha(action: 'email', minimum_score: 0.3)
+
+        if recaptcha_result
+          handle_nomination
+        else
+          log_recaptcha_failure(recaptcha_reply, params[:email])
+          flash.clear
+          flash[:error] = 'reCAPTCHA verification failed, please try again.'
+          redirect_with_flash
+        end
+      rescue StandardError => e
+        log_recaptcha_error(e, params[:email])
+        flash.clear
+        flash[:error] = 'reCAPTCHA verification failed due to an error. Please try again.'
+        redirect_with_flash
       end
     end
   end
-end
 
+  private
+
+  def handle_nomination
+    if params["phone"].present?
+      log_spam_attempt "Nominate"
+      redirect_to root_path
+    else
+      NominateAPracticeMailer.send_contact_email(
+        options = {
+          email: params[:email],
+          subject: params[:subject],
+          message: params[:message],
+          message_url: request.url
+        },
+        'Nominate', 'nominate_a_practice_mailer/nominate_a_practice_email'
+      ).deliver_now
+
+      flash[:success] = 'Message sent. The Diffusion Marketplace team will review your nomination.'
+      redirect_with_flash
+    end
+  end
+
+  def log_recaptcha_failure(score, email)
+    Rails.logger.info(
+      "Nominate innovation form reCAPTCHA score below threshold: reply: #{recaptcha_reply}, submitted_email: #{email}"
+    )
+  end
+
+  def log_recaptcha_error(error, email)
+    Rails.logger.error("reCAPTCHA verification failed in NominatePracticesController#email for email: #{email} - Error: #{error.message}")
+  end
+
+  def redirect_with_flash
+    respond_to do |format|
+      format.html { redirect_back fallback_location: root_path}
+    end
+  end
+end

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -122,7 +122,7 @@
         <p class="usa-prose-body margin-bottom-2">
           Are you working on an innovation that’s making a difference at VA? Submit a nomination for the innovation to be included on the Diffusion Marketplace.
         </p>
-        <a class="usa-link display-inline-block margin-bottom-0 desktop:margin-bottom-0" href="<%= nominate_an_innovation_path %>">Nominate</a>
+        <a class="usa-link display-inline-block margin-bottom-0 desktop:margin-bottom-0" href="<%= nominate_an_innovation_path %>" data-turbolinks="false">Nominate</a>
       </div>
     </div>
   </section>

--- a/app/views/shared/_email_form.html.erb
+++ b/app/views/shared/_email_form.html.erb
@@ -19,5 +19,5 @@
     <input type="submit" value="Send message" class="usa-button margin-right-0">
   </div>
 
-  <%= recaptcha_v3(action: 'email', site_key: ENV['RECAPTCHA_SITE_KEY_V3']) if ENV['RECAPTCHA_SITE_KEY_V3'] %>
+  <%= recaptcha_v3(action: 'email', turbo: 'true', site_key: ENV['RECAPTCHA_SITE_KEY_V3']) if ENV['RECAPTCHA_SITE_KEY_V3'] %>
 <% end %>


### PR DESCRIPTION
### JIRA issue link
https://agile6.atlassian.net/browse/DM-5102

## Description - what does this code do?
changes `NominatePracticesController#email` endpoint to check reCAPTCHA score only if `current_user` is not present, meaning guest users will be subjected to reCAPTCHA evaluation

lowers reCAPTCHA tolerance at `NominatePracticesController#email` endpoint to 0.3 and adds logging for submissions coming in below threshold for the score

Note: I chose 0.3 as the three because I was seeing that as the typical score when testing submissions on DEV from gfe

## Testing done - how did you test it/steps on how can another person can test it 
Locally, submit the form at `/nominate-an-innovation` and verify it succeeds as expected, repeat on DEV

## Screenshots, Gifs, Videos from application (if applicable)


## Link to mock-ups/mock ups (image file if you have it) (if applicable)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Unit tests written (if applicable)
- [ ] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating JIRA issue
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs