### PR TITLE
Remove legacy custom Google Analytics events

### DIFF
--- a/app/assets/javascripts/va_facilities/facility_adopted_practice_search.es6
+++ b/app/assets/javascripts/va_facilities/facility_adopted_practice_search.es6
@@ -10,14 +10,6 @@ const ap = {
 function trackSearch(term) {
   if (term !== '') {
     ahoy.track("Facility practice search", { search_term: term });
-    if (typeof ga === "function") {
-      ga("send", {
-        hitType: "event",
-        eventCategory: "Facility search",
-        eventAction: "Facility search",
-        location: `/facilities/${facilitySlug}`
-      });
-    }
   }
 }
 

--- a/app/assets/javascripts/va_facilities/facility_created_practice_search.es6
+++ b/app/assets/javascripts/va_facilities/facility_created_practice_search.es6
@@ -47,14 +47,6 @@ function filterCategoriesEventListener() {
 function trackSearch(term) {
   if (term !== '') {
     ahoy.track("Facility practice search", { search_term: term });
-    if (typeof ga === "function") {
-      ga("send", {
-        hitType: "event",
-        eventCategory: "Facility search",
-        eventAction: "Facility search",
-        location: `/facilities/${facilitySlug}`
-      });
-    }
   }
 }
 

--- a/app/views/clinical_resource_hubs/_crh_show.js.erb
+++ b/app/views/clinical_resource_hubs/_crh_show.js.erb
@@ -363,14 +363,6 @@ function trackCrhSearchField(searchTerm) {
     if (searchTerm !== '') {
         if ($('fieldset').attr('data-search-filter') === 'false') {
             ahoy.track('CRH practice search', {search_term: searchTerm});
-            if (typeof ga === 'function') {
-                ga('send', {
-                    hitType: 'event',
-                    eventCategory: 'CRH search',
-                    eventAction: 'VCRHISN search',
-                    location: '/crh/' + visn["number"] + '/?query=' + searchTerm
-                });
-            }
         }
     }
     setFieldsetAttr('false');

--- a/app/views/practices/_search.js.erb
+++ b/app/views/practices/_search.js.erb
@@ -1007,28 +1007,12 @@ function searchPracticesPage() {
 function trackSearchField(searchTerm) {
     if (searchTerm) {
         ahoy.track('Practice search', {search_term: searchTerm});
-        if (typeof ga === 'function') {
-            ga('send', {
-                hitType: 'event',
-                eventCategory: 'search',
-                eventAction: 'search',
-                location: '/search?query=' + searchTerm
-            });
-        }
     }
 }
 
 function trackSearchByFilter(filterTerm) {
     var decodedFilterTerm = decodeURI(filterTerm);
     ahoy.track('Practice search by filter', {filter_term: decodedFilterTerm});
-    if (typeof ga === 'function') {
-        ga('send', {
-            hitType: 'event',
-            eventCategory: 'search filter',
-            eventAction: 'search filter',
-            location: '/search?filter_by=' + decodedFilterTerm
-        });
-    }
 }
 
 function preventFiltersAccordionContentFlickerOnPageLoad() {

--- a/app/views/visns/_show.js.erb
+++ b/app/views/visns/_show.js.erb
@@ -354,14 +354,6 @@ function trackVisnSearchField(searchTerm) {
     if (searchTerm !== '') {
         if ($('fieldset').attr('data-search-filter') === 'false') {
             ahoy.track('VISN practice search', {search_term: searchTerm});
-            if (typeof ga === 'function') {
-                ga('send', {
-                    hitType: 'event',
-                    eventCategory: 'VISN search',
-                    eventAction: 'VISN search',
-                    location: '/visns/' + visn["number"] + '/?query=' + searchTerm
-                });
-            }
         }
     }
     setFieldsetAttr('false');


### PR DESCRIPTION
### JIRA issue link
N/A

## Description - what does this code do?
- Removes legacy custom events that were created when VADM had its own Google Analytics events. 
  - DAP does not allow us to register custom events
  - this syntax is from a previous version of GA that is not forward compatible
  - GA4 automatically collects data on search terms that appear in the URL via query params ([Read more: view_search_results](https://support.google.com/analytics/answer/9234069))

## Testing done - how did you test it/steps on how can another person can test it 
1. Log in to DAP Google Analytics
2. Go to `Reports > Life Cycle > Engagement > Events` and confirm that the list of events collected does not match the name of any of the events removed in this PR.
