### PR TITLE
update search js to add applied filter pill for just CRH hubs when se…

### DIFF
--- a/app/views/practices/_search.js.erb
+++ b/app/views/practices/_search.js.erb
@@ -326,9 +326,11 @@ function searchPracticesPage(skipSearchTracking=false) {
                 } else {
                     originFacilityArray.push({'origin_facilities': "=\"" + vf.official_station_name + "\""});
                 }
-
-                addAppliedFilter('ORIGIN', vf.official_station_name)
             });
+
+            // Add applied filter pill for just the Clinical Resource Hub
+            addAppliedFilter('ORIGIN', visnFacilities[visnFacilities.length - 1].official_station_name)
+
         } else if (originatingFacility && !originatingFacility.includes('VISN-')){
             // Collect the practices that have an origin facility matching the selected facility
             var foundOriginatingFacility = facilities.find(function(f) {
@@ -372,8 +374,10 @@ function searchPracticesPage(skipSearchTracking=false) {
                     } else {
                         stationNumbers.push(ff.official_station_name);
                     }
-                    addAppliedFilter('ADOPTION', ff.official_station_name)
                 });
+
+                // Add applied filter pill for just the Clinical Resource Hub
+                addAppliedFilter('ADOPTION', filteredFacilities[filteredFacilities.length - 1].official_station_name)
 
                 getAdoptionFacilities(stationNumbers, adoptionFacilityArray);
             } else {


### PR DESCRIPTION
### JIRA issue link
https://agile6.atlassian.net/browse/DM-5105

## Description - what does this code do?
updates search js to add applied filter pill for just CRH hubs when selected as locations

## Testing done - how did you test it/steps on how can another person can test it 
1. Locally on the search page add a clinical resource hub (CRH) as the Originating and Adopting locations from the comboboxes ("VISN-1" is the first, the facilities indented and below these belong to the given CRH) - see screenshot 1
2. Submit the search and verify the only applied filter pills that appear are for the CRH's you selected, no other location filter pills should be visible.
3. Verify that Innovations with an Originating or Adopting location that belong to the selected CRH's appear in the search results (you may need to go in and update a few innovations in order to see them in the search results for the CRH's you select) - see screenshot 3
4. Verify that the applied filter pills for the Locations are clicked the results update, and the window changes focus to the relevant combobox for the filter that was removed which should now be empty.

## Screenshots, Gifs, Videos from application (if applicable)

Selecting a CRH as Adopting and Originating Locations:
![Screenshot 2024-08-20 at 1 44 17 PM](https://github.com/user-attachments/assets/d91bb079-abaf-4c79-9dec-837a86ef3ca6)

Before
![Screenshot 2024-08-20 at 1 45 20 PM](https://github.com/user-attachments/assets/a07da780-2e25-47b9-b6ec-e953ea3ca439)

After
![Screenshot 2024-08-20 at 1 44 46 PM](https://github.com/user-attachments/assets/1065bb89-2727-456f-8969-668e2bf56aa0)


## Link to mock-ups/mock ups (image file if you have it) (if applicable)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Unit tests written (if applicable)
- [ ] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating JIRA issue
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs