### PR TITLE
Restore alt text to Practice main display image

### DIFF
--- a/app/models/practice.rb
+++ b/app/models/practice.rb
@@ -28,7 +28,7 @@ class Practice < ApplicationRecord
   attr_accessor :delete_main_display_image
   attr_accessor :crop_x, :crop_y, :crop_w, :crop_h
   attr_accessor :practice_partner, :department, :practice_award, :category
-  attr_accessor :main_display_image_alt_text, :highlight_attachment_content_type
+  attr_accessor :highlight_attachment_content_type
 
   def self.cached_json_practices(is_guest_user)
     if is_guest_user
@@ -433,8 +433,7 @@ class Practice < ApplicationRecord
   def trim_whitespace
     strip_attributes(
       [
-        self.name,
-        self.main_display_image_alt_text
+        self.name
       ]
     )
   end


### PR DESCRIPTION
### JIRA issue link
Follow-up to #987

## Description - what does this code do?
- Restores the ability to supply alt text for a Practice's main display image
- Removes the other call to `#main_display_image_alt_text` that was interfering with the importer workflow

## Testing done - how did you test it/steps on how can another person can test it 
1. Go to a practice
2. Add an large image as a practice's main display image. 
3. Add alt text to the image and save. 
4. Confirm that the text was saved and edit it a few times. 
