### PR TITLE
dm-5113 update VaFacility#get_locations to remove nils from return

### DIFF
--- a/app/models/va_facility.rb
+++ b/app/models/va_facility.rb
@@ -13,7 +13,7 @@ class VaFacility < ApplicationRecord
   scope :get_classification_counts, -> (facility_type) { where(classification: facility_type, hidden: false).size }
   scope :get_classifications, -> { pluck(:classification).uniq }
   scope :get_ids, -> { pluck(:id) }
-  scope :get_locations, -> { order(:street_address_state).pluck(:street_address_state).uniq }
+  scope :get_locations, -> { order(:street_address_state).pluck(:street_address_state).uniq.compact }
   scope :get_complexity, -> { order(:fy17_parent_station_complexity_level).pluck(:fy17_parent_station_complexity_level).uniq }
   scope :get_relevant_attributes, -> {
       select(:street_address_state, :official_station_name, :id, :visn_id, :common_name, :station_number, :latitude,
@@ -43,4 +43,3 @@ class VaFacility < ApplicationRecord
     (practices + practices_through_diffusion).uniq.each(&:clear_searchable_cache)
   end
 end
-


### PR DESCRIPTION
### JIRA issue link
https://agile6.atlassian.net/browse/DM-5113

## Description - what does this code do?
As of the recent facilities update that occurred on 7/19, some facilities have nils for address values which now causes a breakage in a [helper method utilized in the visn show view](https://github.com/department-of-veterans-affairs/diffusion-marketplace/blob/8a834834d42812e86fdd7f594e0a74833978ca97/app/helpers/application_helper.rb#L183)

Simple fix is to update `VaFacility#get_locations` to remove nils from return value.

## Testing done - how did you test it/steps on how can another person can test it 
Locally, go to `/visns/23` and verify the page loads

## Screenshots, Gifs, Videos from application (if applicable)


## Link to mock-ups/mock ups (image file if you have it) (if applicable)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Unit tests written (if applicable)
- [ ] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating JIRA issue
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs