### PR TITLE
dm-5116 disable top sort on empty search

### DIFF
--- a/app/views/practices/_search.js.erb
+++ b/app/views/practices/_search.js.erb
@@ -717,14 +717,20 @@ function searchPracticesPage(skipSearchTracking=false) {
         }
 
         // Get the results and then filter them
+        const sortRadioInputs = document.querySelectorAll(SORT_EL);
         if (!query && !categories && !originatingFacility && !adoptingFacility) {
             // on an empty search or filtered search, sort by most adoptions and disable the score sorting option, since the score for each result is the same
             buildSearchResults(results, sortByAdoptionCounts);
-            $(SORT_EL).prop('selectedIndex', 2);
+            if (sortRadioInputs) {
+                sortRadioInputs[0].disabled = true;
+                sortRadioInputs[2].checked = true;
+            }
         } else {
             buildSearchResults(results, sortByScore);
-            // re-enable the score sorting option
-            $(SORT_EL).prop('selectedIndex', 0);
+            if (sortRadioInputs) {
+                sortRadioInputs[0].disabled = false;
+                sortRadioInputs[0].checked = true;
+            }
         }
 
         // Print the number of results for the query


### PR DESCRIPTION
### JIRA issue link
https://agile6.atlassian.net/browse/DM-5116

## Description - what does this code do?
updates search js to disable / enable and check / uncheck "most relevant" sort option depending on presence of search params

## Testing done - how did you test it/steps on how can another person can test it 
1. Locally on the search page with no search query and no filters submitted, verify that the "most relevant" sort option is disabled and the "most adoptions" sort option is selected.
2. Submit a search with a query and verify the "most relevant" option is enabled and checked, repeat with any filter and verify the same.
3. From the homepage search dropdown, verify that selecting a category or entering a search takes you to the search page with the "most relevant" option enabled and selected.

## Screenshots, Gifs, Videos from application (if applicable)
![Screenshot 2024-08-21 at 5 08 31 PM](https://github.com/user-attachments/assets/c4d14282-bce3-4aca-8625-d6ac45a9ff2d)

## Link to mock-ups/mock ups (image file if you have it) (if applicable)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Unit tests written (if applicable)
- [ ] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating JIRA issue
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs