### PR TITLE
dm-5118 search refresh copy changes

### DIFF
--- a/app/assets/stylesheets/dm/pages/_search.scss
+++ b/app/assets/stylesheets/dm/pages/_search.scss
@@ -7,6 +7,15 @@
     @include at-media(tablet) {
       display: inline-block;
     }
+
+    svg {
+      vertical-align: text-bottom;
+      margin-left: 4px;
+      width: 16px;
+      height: 16px;
+      fill: currentColor;
+      line-height: 1;
+    }
   }
 
   .applied-filter-1 {
@@ -258,13 +267,4 @@
     bottom: 0;
     width: 100%;
   }
-}
-
-.applied-filter svg {
-  vertical-align: text-bottom;
-  margin-left: 4px;
-  width: 16px;
-  height: 16px;
-  fill: currentColor;
-  line-height: 1;
 }

--- a/app/assets/stylesheets/dm/pages/_search.scss
+++ b/app/assets/stylesheets/dm/pages/_search.scss
@@ -259,3 +259,12 @@
     width: 100%;
   }
 }
+
+.applied-filter svg {
+  vertical-align: text-bottom;
+  margin-left: 4px;
+  width: 16px;
+  height: 16px;
+  fill: currentColor;
+  line-height: 1;
+}

--- a/app/views/practices/_search.js.erb
+++ b/app/views/practices/_search.js.erb
@@ -762,12 +762,28 @@ function searchPracticesPage(skipSearchTracking=false) {
 
         appliedFilterButton.className = `usa-button applied-filter applied-filter-${filterClassIndex}`;
         appliedFilterButton.id = `${filterName}`;
-        appliedFilterButton.textContent = appliedFilterString + ' X';
+        appliedFilterButton.textContent = appliedFilterString;
         appliedFilterButton.style.cursor = 'pointer';
         appliedFilterButton.setAttribute(
             'aria-label',
             `Remove ${filterType} filter for ${filterName} and update search results`
         );
+
+        const svgNamespace = "http://www.w3.org/2000/svg";
+        const svgIcon = document.createElementNS(svgNamespace, "svg");
+        svgIcon.setAttribute("xmlns", svgNamespace);
+        svgIcon.setAttribute("viewBox", "0 0 352 512");
+
+        const path = document.createElementNS(svgNamespace, "path");
+        path.setAttribute("d",
+            "M242.72 256L349.35 149.37a16 16 0 0 0 0-22.63L325.25 102a16 16 0 0 0-22.63 0L176 228.72 " +
+            "49.37 102.05a16 16 0 0 0-22.63 0L2.7 126.74a16 16 0 0 0 0 22.63L109.33 256 2.7 362.63a16 " +
+            "16 0 0 0 0 22.63l24.07 24.07a16 16 0 0 0 22.63 0L176 283.28l126.63 126.62a16 16 0 0 0 " +
+            "22.63 0l24.07-24.07a16 16 0 0 0 0-22.63z"
+        );
+
+        svgIcon.appendChild(path);
+        appliedFilterButton.appendChild(svgIcon);
 
         appliedFilterButton.addEventListener('click', function(event) {
             uncheckFilter(filterType, filterName);

--- a/app/views/practices/_search.js.erb
+++ b/app/views/practices/_search.js.erb
@@ -773,6 +773,7 @@ function searchPracticesPage(skipSearchTracking=false) {
         const svgIcon = document.createElementNS(svgNamespace, "svg");
         svgIcon.setAttribute("xmlns", svgNamespace);
         svgIcon.setAttribute("viewBox", "0 0 352 512");
+        svgIcon.setAttribute("aria-hidden", "true");
 
         const path = document.createElementNS(svgNamespace, "path");
         path.setAttribute("d",

--- a/app/views/practices/search.html.erb
+++ b/app/views/practices/search.html.erb
@@ -14,7 +14,7 @@
 <% end %>
 
 <div id="search-page">
-  <section class="grid-container margin-bottom-neg-3 margin-top-5" id="searchResultsContainer">
+  <section class="grid-container margin-bottom-neg-3 margin-top-5" id="search-results-container">
     <%= render partial: "shared/messages", locals: {small_text: false} %>
       <div class="grid-row margin-bottom-2">
         <div class="grid-col-12">

--- a/app/views/practices/search.html.erb
+++ b/app/views/practices/search.html.erb
@@ -40,7 +40,7 @@
               </div>
             </div>
             <span id="results-summary" class="display-block desktop:display-inline margin-right-2">Results:</span>
-            <button type="button" class="usa-button usa-button--unstyled display-none" id="reset-search-filters-button">Clear filters</button>
+            <button type="button" class="usa-button usa-button--unstyled display-none" id="reset-search-filters-button">Clear Filters</button>
           </form>
         </div>
       </div>

--- a/app/views/practices/search_partials/_search_filters.html.erb
+++ b/app/views/practices/search_partials/_search_filters.html.erb
@@ -3,10 +3,10 @@
 <div id="search-sort-options-container" class="padding-bottom-3 border-bottom-2px border-gray-10" aria-label="Sort options">
   <%
     sort_options = [
-      ['Sort by most relevant', 'most_relevant'],
-      ['Sort by A to Z', 'a_to_z'],
-      ['Sort by most adopted innovations', 'adoptions'],
-      ['Sort by most recently added', 'added']
+      ['Most Relevant', 'most_relevant'],
+      ['A to Z', 'a_to_z'],
+      ['Most Adopted', 'adoptions'],
+      ['Most Recently Added', 'added']
     ]
   %>
   <h4 class="text-bold">Sort By</h3>
@@ -80,6 +80,6 @@
 
 <div class="border-base-lightest padding-top-2" id="filter_button_container">
   <button type="submit" id="update-search-results-button" class="usa-button filter-submit-button display-block line-height-19px" name="button" form="update-search-results-form">
-    Apply filters
+    Apply Filters
   </button>
 </div>

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -117,7 +117,7 @@ describe 'Search', type: :feature do
   end
 
   def update_results
-    click_button('Apply filters')
+    click_button('Apply Filters')
   end
 
   def update_practice_introduction(practice)
@@ -358,7 +358,7 @@ describe 'Search', type: :feature do
         update_results
 
         expect(page).to have_content('6 Results')
-        expect(page).to have_button('Clear filters')
+        expect(page).to have_button('Clear Filters')
         expect(page).to have_content(@practice.name)
         expect(page).to have_content(@practice3.name)
         expect(page).to have_content(@practice5.name)
@@ -378,7 +378,7 @@ describe 'Search', type: :feature do
         expect(page).to have_content(@practice13.name)
         expect(page).to have_content(@practice14.name)
 
-        click_button('Clear filters')
+        click_button('Clear Filters')
         set_combobox_val(1, 'VISN 8 Clinical Resource Hub (Remote)')
         update_results
 
@@ -429,7 +429,7 @@ describe 'Search', type: :feature do
         expect(page).to_not have_content(@practice5.name)
 
         # Reset filters and select a VISN from the Originating Facility combo box
-        click_button('Clear filters')
+        click_button('Clear Filters')
         set_combobox_val(0, 'VISN-1')
         update_results
 
@@ -447,7 +447,7 @@ describe 'Search', type: :feature do
         expect(page).to have_content(@practice5.name)
 
         # Reset filters and select a VISN from the Adopting Facility combo box
-        click_button('Clear filters')
+        click_button('Clear Filters')
         set_combobox_val(1, 'VISN-7')
         update_results
 
@@ -547,12 +547,12 @@ describe 'Search', type: :feature do
           update_results
         end
 
-        it "should display applied filters with 'Clear filters' button" do
+        it "should display applied filters with 'Clear Filters' button" do
           expect(page).to have_content('TAG: COVID')
           expect(page).to have_content('TAG: PULMONARY CARE')
           expect(page).to have_content('ORIGIN: NORWOOD VA CLINIC')
           expect(page).to have_content('ADOPTION: MARIETTA VA CLINIC')
-          expect(page).to have_button('Clear filters')
+          expect(page).to have_button('Clear Filters')
         end
 
         it 'should allow filters to be individually removed to update results' do
@@ -566,7 +566,7 @@ describe 'Search', type: :feature do
           expect(page).to have_content('TAG: PULMONARY CARE')
           expect(page).to have_content('ORIGIN: NORWOOD VA CLINIC')
           expect(page).to have_content('ADOPTION: MARIETTA VA CLINIC')
-          expect(page).to have_button('Clear filters')
+          expect(page).to have_button('Clear Filters')
           # expect updated results
           expect(page).to have_content('1 Result')
           expect(page).not_to have_content(@practice.name)
@@ -585,23 +585,23 @@ describe 'Search', type: :feature do
           expect(checkbox).to be_checked
         end
 
-        it "should remove the 'Clear filters' button when all applied filters are removed" do
+        it "should remove the 'Clear Filters' button when all applied filters are removed" do
           find_button('COVID').click
           find_button('Pulmonary Care').click
           find_button('Norwood VA Clinic').click
           find_button('Marietta VA Clinic').click
 
-          expect(page).not_to have_button('Clear filters')
+          expect(page).not_to have_button('Clear Filters')
         end
 
         it 'should clear all filters' do
-          click_button('Clear filters')
+          click_button('Clear Filters')
 
           expect(page).not_to have_content('TAG: COVID')
           expect(page).not_to have_content('TAG: PULMONARY CARE')
           expect(page).not_to have_content('ORIGIN: NORWOOD VA CLINIC')
           expect(page).not_to have_content('ADOPTION: MARIETTA VA CLINIC')
-          expect(page).not_to have_button('Clear filters')
+          expect(page).not_to have_button('Clear Filters')
         end
       end
     end
@@ -625,7 +625,7 @@ describe 'Search', type: :feature do
         expect(first('a.dm-link-title').text).to eq(@practice4.name)
 
         # choose 'A to Z' option
-        find('label', text: 'Sort by A to Z').click
+        find('label', text: 'A to Z').click
         expect(all('a.dm-link-title').first.text).to eq(@practice4.name)
         expect(all('a.dm-link-title')[1].text).to eq(@practice6.name)
         expect(all('a.dm-link-title')[2].text).to eq(@practice5.name)
@@ -634,13 +634,13 @@ describe 'Search', type: :feature do
         expect(all('a.dm-link-title')[5].text).to eq(@practice12.name)
 
         # choose 'most adoptions' option
-        find('label', text: 'Sort by most adopted innovations').click
+        find('label', text: 'Most Adopted').click
         expect(all('a.dm-link-title').first.text).to eq(@practice.name)
         expect(all('a.dm-link-title')[1].text).to eq(@practice3.name)
         expect(all('a.dm-link-title')[2].text).to eq(@practice6.name)
 
         # choose 'most recently added' option
-        find('label', text: 'Sort by most recently added').click
+        find('label', text: 'Most Recently Added').click
         expect(all('a.dm-link-title').first.text).to eq(@practice12.name)
         expect(all('a.dm-link-title')[1].text).to eq(@practice6.name)
         expect(all('a.dm-link-title')[2].text).to eq(@practice5.name)

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -557,7 +557,7 @@ describe 'Search', type: :feature do
 
         it 'should allow filters to be individually removed to update results' do
           expect(page).to have_content('6 Results')
-          within('#searchResultsContainer') do
+          within('#search-results-container') do
             all('button.applied-filter').first.click
           end
 


### PR DESCRIPTION
### JIRA issue link
https://agile6.atlassian.net/browse/DM-5118

## Description - what does this code do?

update search filters copy: changed header, sort options, submit button, clear filters button, applied filter copy (to use fa "x" icon)

## Testing done - how did you test it/steps on how can another person can test it 
1. Locally, verify expected keyboard accessibility for the applied filter icons - should be a single focusable element that is removed when triggered with the space or enter key.

## Screenshots, Gifs, Videos from application (if applicable)


## Link to mock-ups/mock ups (image file if you have it) (if applicable)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Unit tests written (if applicable)
- [ ] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating JIRA issue
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs