### PR TITLE
DM-5129: Homepage preview

### DIFF
--- a/app/admin/homepage.rb
+++ b/app/admin/homepage.rb
@@ -27,9 +27,12 @@ ActiveAdmin.register Homepage do
   config.sort_order = 'published_desc'
 
   # Customizing the action items (buttons) on the show page
-  action_item :publish, priority: 0, only: :show do
+  action_item :publish, priority: 1, only: :show do
     publish_action_str = resource.published? ? 'Unpublish' : 'Publish'
     link_to publish_action_str, publish_admin_homepage_path(resource), method: :post
+  end
+  action_item :preview, priority: 0, only: :show do
+    link_to "Preview", preview_admin_homepage_path(resource), method: :get
   end
 
   member_action :publish, priority: 0, method: :post do
@@ -64,7 +67,7 @@ ActiveAdmin.register Homepage do
     actions do |homepage|
       publish_action_str = homepage.published ? "Unpublish" : "Publish"
       item publish_action_str, publish_admin_homepage_path(homepage), method: :post
-      item "Preview", preview_admin_homepage_path(homepage.id), method: :get
+      item "Preview", preview_admin_homepage_path(homepage), method: :get
     end
   end
 

--- a/app/admin/homepage.rb
+++ b/app/admin/homepage.rb
@@ -51,6 +51,11 @@ ActiveAdmin.register Homepage do
     redirect_back fallback_location: root_path, notice: message
   end
 
+  member_action :preview, method: :get do
+    homepage_id = resource.id
+    redirect_to "/homepages/#{homepage_id}/preview"
+  end
+
   index do
     id_column
     column :internal_title
@@ -59,6 +64,7 @@ ActiveAdmin.register Homepage do
     actions do |homepage|
       publish_action_str = homepage.published ? "Unpublish" : "Publish"
       item publish_action_str, publish_admin_homepage_path(homepage), method: :post
+      item "Preview", preview_admin_homepage_path(homepage.id), method: :get
     end
   end
 

--- a/app/admin/homepage.rb
+++ b/app/admin/homepage.rb
@@ -36,16 +36,16 @@ ActiveAdmin.register Homepage do
   end
 
   member_action :publish, priority: 0, method: :post do
-    title = resource.internal_title.present? ? resource.internal_title : "Homepage #{resource.id}"
+    title = resource.internal_title? ? resource.internal_title : "Homepage #{resource.id}"
     if resource.published
-      message = "\"#{title.to_s}\" unpublished"
+      message = "\"#{title}\" unpublished"
       resource.published = false
     else
       message = "\"#{title}\" published"
       already_published = Homepage.where(published: true)
       if already_published.present?
         already_published_titles = []
-        already_published&.each {|h| already_published_titles << (h.internal_title.present? ? h.internal_title : "Homepage #{h.id}") }
+        already_published&.each {|h| already_published_titles << (h.internal_title? ? h.internal_title : "Homepage #{h.id}") }
         message += ", \"#{already_published_titles.join(',')}\" unpublished"
       end
       resource.published = true

--- a/app/admin/homepage.rb
+++ b/app/admin/homepage.rb
@@ -32,7 +32,7 @@ ActiveAdmin.register Homepage do
     link_to publish_action_str, publish_admin_homepage_path(resource), method: :post
   end
   action_item :preview, priority: 0, only: :show do
-    link_to "Preview", preview_admin_homepage_path(resource), method: :get
+    link_to "Preview", preview_admin_homepage_path(resource), method: :get unless resource.published?
   end
 
   member_action :publish, priority: 0, method: :post do
@@ -67,7 +67,7 @@ ActiveAdmin.register Homepage do
     actions do |homepage|
       publish_action_str = homepage.published ? "Unpublish" : "Publish"
       item publish_action_str, publish_admin_homepage_path(homepage), method: :post
-      item "Preview", preview_admin_homepage_path(homepage), method: :get
+      item "Preview", preview_admin_homepage_path(homepage), method: :get unless homepage.published?
     end
   end
 

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -18,15 +18,17 @@ class HomeController < ApplicationController
 
   def preview
     if current_user&.has_role?(:admin)
-      @@dropdown_categories = nil
-      @dropdown_communities = nil
-      @homepage = nil
+      @dropdown_categories, @dropdown_communities, @homepage = nil
       begin
         @homepage = Homepage.find(params[:id])
       rescue ActiveRecord::RecordNotFound
         warning = "That homepage does not exist"
         flash[:warning] = warning
         redirect_to admin_homepages_path, warning: warning
+        return
+      end
+      if @homepage.published?
+        redirect_to root_path
         return
       end
       current_features = @homepage&.homepage_features

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -29,8 +29,9 @@ class HomeController < ApplicationController
         @section_two_features = current_features&.where(section_id: 2)&.first(3)
         @section_three_features = current_features&.where(section_id: 3)&.first(3)
       end
-      # maybe add some warning banner that this is not published for clarity?
-      render 'index'
+      warning = 'This is a preview of unpublished content'
+      flash[:warning] = warning
+      render 'index', warning: warning
     else
       redirect_to root_path
     end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -10,9 +10,29 @@ class HomeController < ApplicationController
     @homepage = Homepage.where(published: true)&.first
     if @homepage
       current_features = @homepage&.homepage_features
-      @section_one_features = current_features&.where(section_id: 1).first(3)
-      @section_two_features = current_features&.where(section_id: 2).first(3)
-      @section_three_features = current_features&.where(section_id: 3).first(3)
+      @section_one_features = current_features&.where(section_id: 1)&.first(3)
+      @section_two_features = current_features&.where(section_id: 2)&.first(3)
+      @section_three_features = current_features&.where(section_id: 3)&.first(3)
+    end
+  end
+
+  def preview
+    if current_user&.has_role?(:admin)
+      @@dropdown_categories = nil
+      @dropdown_communities = nil
+      @homepage = nil
+      @homepage = Homepage.find(params[:id]) # <-- param is set by a member action in admin/homepages/ controller
+        # TODO: set a nicer error message & redirect for Homepages that don't exist
+      current_features = @homepage&.homepage_features
+      if current_features
+        @section_one_features = current_features&.where(section_id: 1)&.first(3)
+        @section_two_features = current_features&.where(section_id: 2)&.first(3)
+        @section_three_features = current_features&.where(section_id: 3)&.first(3)
+      end
+      # maybe add some warning banner that this is not published for clarity?
+      render 'index'
+    else
+      redirect_to root_path
     end
   end
 

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -29,9 +29,8 @@ class HomeController < ApplicationController
         @section_two_features = current_features&.where(section_id: 2)&.first(3)
         @section_three_features = current_features&.where(section_id: 3)&.first(3)
       end
-      warning = 'This is a preview of unpublished content'
-      flash[:warning] = warning
-      render 'index', warning: warning
+      flash.now[:notice] = "This is a preview of unpublished content"
+      render 'index'
     else
       redirect_to root_path
     end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -21,8 +21,14 @@ class HomeController < ApplicationController
       @@dropdown_categories = nil
       @dropdown_communities = nil
       @homepage = nil
-      @homepage = Homepage.find(params[:id]) # <-- param is set by a member action in admin/homepages/ controller
-        # TODO: set a nicer error message & redirect for Homepages that don't exist
+      begin
+        @homepage = Homepage.find(params[:id])
+      rescue ActiveRecord::RecordNotFound
+        warning = "That homepage does not exist"
+        flash[:warning] = warning
+        redirect_to admin_homepages_path, warning: warning
+        return
+      end
       current_features = @homepage&.homepage_features
       if current_features
         @section_one_features = current_features&.where(section_id: 1)&.first(3)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -217,6 +217,7 @@ module ApplicationHelper
     params["controller"] == "admin" || # all admin pages
     (params["controller"] == "page" && !@page&.published?) || # unpublished PageBuilder pages
     (params["controller"] == "practices" && !["show", "index", "search"].include?(params["action"])) || # practice editor pages
-    (params["controller"] == "practices" && params["action"] == "show" && !@practice.is_public) # internal or unpublished practices
+    (params["controller"] == "practices" && params["action"] == "show" && !@practice.is_public) || # internal or unpublished practices
+    params["controller"] == "home" && params["action"] == "preview" # homepage previews
   end
 end

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -44,6 +44,7 @@
             style="display: none;"
           >
 
+          <% if @dropdown_practices.present? && @dropdown_categories.present? && @dropdown_communities.present? %>
           <div class="dropdown-content margin-4">
             <div class="result-section" data-type="innovation">
               <h3 class="search-header usa-prose-h3 margin-bottom-0">Innovations</h3>
@@ -81,6 +82,7 @@
               <a class="browse-all-link text-bold" href="<%= search_path %>?all_communities=true">Browse all Community Innovations</a>
             </div>
           </div>
+          <% end %>
         </div>
         <button id="dm-homepage-search-button" class="usa-button height-5 margin-right-0" type="submit">
           <span class="usa-search__submit-text">Search</span>
@@ -90,7 +92,7 @@
   </section>
   <div class="grid-container">
     <section id="homepage-section-1" class="homepage-section">
-        <% if @homepage.blank? %>
+        <% if @homepage.blank? && (controller.action_name != 'preview') %>
           <h2 class="section-title">Featured Innovations</h2>
           <div class="grid-row grid-gap">
             <div id="section-1-feature-1" class="homepage-feature three-column-layout">

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -91,8 +91,9 @@
     </form>
   </section>
   <div class="grid-container">
+    <% fallback_content? = @homepage.blank? && (controller.action_name != 'preview') %>
     <section id="homepage-section-1" class="homepage-section">
-        <% if @homepage.blank? && (controller.action_name != 'preview') %>
+        <% if fallback_content? %>
           <h2 class="section-title">Featured Innovations</h2>
           <div class="grid-row grid-gap">
             <div id="section-1-feature-1" class="homepage-feature three-column-layout">
@@ -136,7 +137,7 @@
         <% end %>
     </section>
     <section id="homepage-section-2" class="homepage-section">
-        <% if @homepage.blank? %>
+        <% if fallback_content? %>
           <h2 class="section-title">Trending Tags</h2>
           <div class="grid-row grid-gap">
             <div id="section-2-feature-1" class="homepage-feature three-column-layout">
@@ -180,7 +181,7 @@
         <% end %>
     </section>
     <section id="homepage-section-3" class="homepage-section">
-        <% if @homepage.blank? %>
+        <% if fallback_content? %>
         <h2 class="section-title">Innovation Communities</h2>
         <div class="grid-row grid-gap">
           <div id="section-3-feature-1" class="homepage-feature two-column-layout">

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -91,9 +91,9 @@
     </form>
   </section>
   <div class="grid-container">
-    <% fallback_content? = @homepage.blank? && (controller.action_name != 'preview') %>
+    <% fallback_content = @homepage.blank? && (controller.action_name != 'preview') %>
     <section id="homepage-section-1" class="homepage-section">
-        <% if fallback_content? %>
+        <% if fallback_content %>
           <h2 class="section-title">Featured Innovations</h2>
           <div class="grid-row grid-gap">
             <div id="section-1-feature-1" class="homepage-feature three-column-layout">
@@ -137,7 +137,7 @@
         <% end %>
     </section>
     <section id="homepage-section-2" class="homepage-section">
-        <% if fallback_content? %>
+        <% if fallback_content %>
           <h2 class="section-title">Trending Tags</h2>
           <div class="grid-row grid-gap">
             <div id="section-2-feature-1" class="homepage-feature three-column-layout">
@@ -181,7 +181,7 @@
         <% end %>
     </section>
     <section id="homepage-section-3" class="homepage-section">
-        <% if fallback_content? %>
+        <% if fallback_content %>
         <h2 class="section-title">Innovation Communities</h2>
         <div class="grid-row grid-gap">
           <div id="section-3-feature-1" class="homepage-feature two-column-layout">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -79,6 +79,7 @@ Rails.application.routes.draw do
   end
 
   root 'home#index'
+  get '/homepages/:id/preview', controller: 'home', action: 'preview'
   resources :clinical_resource_hubs, path: :crh, param: :number
   get '/practices' => 'practices#index'
   get '/partners' => 'practice_partners#index'

--- a/spec/features/admin/admin_homepage_spec.rb
+++ b/spec/features/admin/admin_homepage_spec.rb
@@ -149,12 +149,17 @@ describe 'Homepage editor', type: :feature do
   end
 
   describe 'Preview' do
-    it 'lets admins preview homepage' do
+    it 'lets admins preview homepage' do      
       Homepage.create(internal_title: 'current', published: true, section_title_one: 'Old homepage')
       Homepage.create(internal_title: 'next month', published: false, section_title_one: 'Next month homepage')
       visit root_path
       expect(page).to have_content('Old homepage')
-      visit '/homepages/2/preview'
+      visit admin_homepages_path
+      within('#homepage_2') do
+        expect(page).to have_content('Publish')
+        click_link('Preview')
+      end
+      expect(page).to have_current_path('/homepages/2/preview')
       expect(page).to have_content('Next month homepage')
     end
 

--- a/spec/features/admin/admin_homepage_spec.rb
+++ b/spec/features/admin/admin_homepage_spec.rb
@@ -148,6 +148,26 @@ describe 'Homepage editor', type: :feature do
     end
   end
 
+  describe 'Preview' do
+    it 'lets admins preview homepage' do
+      Homepage.create(internal_title: 'current', published: true, section_title_one: 'Old homepage')
+      Homepage.create(internal_title: 'next month', published: false, section_title_one: 'Next month homepage')
+      visit root_path
+      expect(page).to have_content('Old homepage')
+      visit '/homepages/2/preview'
+      expect(page).to have_content('Next month homepage')
+    end
+
+    it 'hides previews from non-admins' do
+      @non_admin = create(:user, email: 'spongebob@va.gov')
+      login_as(@non_admin, scope: :user, run_callbacks: false)
+      Homepage.create(internal_title: 'next month', published: false, section_title_one: 'Next month homepage')
+      visit '/homepages/1/preview'
+      expect(page).to have_current_path(root_path)
+    end
+
+  end
+
   def save_page
     find('input[type="submit"]', match: :first).click
   end

--- a/spec/features/admin/admin_homepage_spec.rb
+++ b/spec/features/admin/admin_homepage_spec.rb
@@ -39,6 +39,8 @@ describe 'Homepage editor', type: :feature do
       within('#homepage_2') { click_link('Publish') }
       within('#homepage_1') { expect(page).to have_link('Publish') }
       within('#homepage_2') { expect(page).to have_link('Unpublish') }
+      expect(page).to have_content('"september" published')
+      expect(page).to have_content('"august" unpublished')
   	end
   end
 
@@ -104,9 +106,7 @@ describe 'Homepage editor', type: :feature do
       visit admin_homepages_path
       click_link 'Edit'
       feature_form = find('.has_many_fields', match: :first)
-      within(feature_form) do
-        check 'Delete image?'
-      end
+      within(feature_form) {  check 'Delete image?' }
       save_page
       click_link 'Edit Homepage'
       within(feature_form) do
@@ -175,9 +175,7 @@ describe 'Homepage editor', type: :feature do
     it 'published pages do not have a preview' do
       Homepage.create(internal_title: 'current', published: true, section_title_one: 'Old homepage')
       visit admin_homepages_path
-      within("#homepage_1") do
-        expect(page).not_to have_content('Preview')
-      end
+      within("#homepage_1") { expect(page).not_to have_content('Preview') }
       visit '/homepages/1/preview'
       expect(page).to have_current_path(root_path)
       expect(page).not_to have_content_warning

--- a/spec/features/admin/admin_homepage_spec.rb
+++ b/spec/features/admin/admin_homepage_spec.rb
@@ -149,7 +149,7 @@ describe 'Homepage editor', type: :feature do
   end
 
   describe 'Preview' do
-    it 'lets admins preview homepage' do      
+    it 'lets admins preview homepage' do
       Homepage.create(internal_title: 'current', published: true, section_title_one: 'Old homepage')
       Homepage.create(internal_title: 'next month', published: false, section_title_one: 'Next month homepage')
       visit root_path
@@ -160,7 +160,7 @@ describe 'Homepage editor', type: :feature do
         click_link('Preview')
       end
       expect(page).to have_current_path('/homepages/2/preview')
-      expect(page).to have_content('This is a preview of unpublished content')
+      expect(page).to have_content_warning
       expect(page).to have_content('Next month homepage')
     end
 
@@ -172,9 +172,24 @@ describe 'Homepage editor', type: :feature do
       expect(page).to have_current_path(root_path)
     end
 
+    it 'published pages do not have a preview' do
+      Homepage.create(internal_title: 'current', published: true, section_title_one: 'Old homepage')
+      visit admin_homepages_path
+      within("#homepage_1") do
+        expect(page).not_to have_content('Preview')
+      end
+      visit '/homepages/1/preview'
+      expect(page).to have_current_path(root_path)
+      expect(page).not_to have_content_warning
+    end
+
   end
 
   def save_page
     find('input[type="submit"]', match: :first).click
+  end
+
+  def have_content_warning
+    have_content('This is a preview of unpublished content')
   end
 end

--- a/spec/features/admin/admin_homepage_spec.rb
+++ b/spec/features/admin/admin_homepage_spec.rb
@@ -160,6 +160,7 @@ describe 'Homepage editor', type: :feature do
         click_link('Preview')
       end
       expect(page).to have_current_path('/homepages/2/preview')
+      expect(page).to have_content('This is a preview of unpublished content')
       expect(page).to have_content('Next month homepage')
     end
 


### PR DESCRIPTION
### JIRA issue link
[DM-5129](https://agile6.atlassian.net/browse/DM-5129)

## Description - what does this code do?
- Adds a "Preview" link to homepages admin index and show pages. This preview largely reuses the `home#index` action but sets DB pulls related to activerecord to nil. 

## Testing done - how did you test it/steps on how can another person can test it 
1. Go to `/admin/homepages` 
2. create a new homepage and save with empty content. 
3. Click `Preview` and confirm the hardcoded content is gone. 
4. go back and edit your homepage and add some content. 
5. Click `Preview` and confirm your content is rendered.
