### PR TITLE
Homepage CMS: Move publishing workflow to model; add URL validation

### DIFF
--- a/app/admin/homepage.rb
+++ b/app/admin/homepage.rb
@@ -44,7 +44,6 @@ ActiveAdmin.register Homepage do
         already_published_titles = []
         already_published&.each {|h| already_published_titles << (h.internal_title.present? ? h.internal_title : "Homepage #{h.id}") }
         message += ", \"#{already_published_titles.join(',')}\" unpublished"
-        already_published.update_all(published: false)
       end
       resource.published = true
     end

--- a/app/models/homepage.rb
+++ b/app/models/homepage.rb
@@ -2,6 +2,13 @@ class Homepage < ApplicationRecord
   has_many :homepage_features, dependent: :destroy
   accepts_nested_attributes_for :homepage_features, allow_destroy: true
 
+  before_save :unpublish_other_homepages, if: :published?
+
+  def unpublish_other_homepages
+    # Unpublish all other homepages with published: true
+    Homepage.where(published: true).where.not(id: self.id).update_all(published: false)
+  end
+
   def self.ransackable_associations(auth_object = nil)
     []
   end

--- a/app/models/homepage_feature.rb
+++ b/app/models/homepage_feature.rb
@@ -2,6 +2,12 @@ class HomepageFeature < ApplicationRecord
   belongs_to :homepage
   has_attached_file :featured_image
   validates_attachment_content_type :featured_image, content_type: /\Aimage\/.*\z/, if: -> { featured_image.present? }
+  validates_with InternalUrlValidator,
+                 on: [:create, :update],
+                 if: Proc.new { |feature| feature.url.present? && feature.url.chars.first === '/' }
+  validates_with ExternalUrlValidator,
+                 on: [:create, :update],
+                 if: Proc.new { |feature| feature.url.present? && feature.url.chars.first != '/' }
 
   attr_accessor :delete_image
   before_save :check_image_deletion


### PR DESCRIPTION
### JIRA issue link
N/A. Follow up to #1002 

## Description - what does this code do?
- When a homepage is published via the ActiveAdmin UI, any other unpublished homepages are unpublished. This PR moves this logic out of the ActiveAdmin action definition and into a callback on the `Homepage` model. This should result in more predictable behavior when we publish next month's homepage via automation. 
- Adds URL validation to homepage features

## Testing done - how did you test it/steps on how can another person can test it 
### Publishing
1. Create several homepages in `/admin/homepages`
2. Publish a homepage
3. Update an unpublished homepage via the rails console, e.g. `Homepage.find(2).update(published: true)`. 
4. Confirm that the previous homepage is now unpublished in both the UI and the DB. 

### URL validation
1. Edit a homepage
2. Add 2 new features
3. Provide an invalid URL for one feature, e.g. `asd;lkfjaw;fijawe;ofiv`
4. Provide a relative link to a non-existent page, e.g. `/not-a-page`
5. Update the homepage. 
6. Review the errors provided for each invalid URL