### PR TITLE
DM-5117: Remove dark background from 'unstyled' buttons

### DIFF
--- a/app/assets/stylesheets/dm/components/_buttons.scss
+++ b/app/assets/stylesheets/dm/components/_buttons.scss
@@ -168,12 +168,11 @@
 }
 
 .dm-button--unstyled-primary {
-  @extend .usa-button;
   @extend .usa-button--unstyled;
+  cursor: pointer;
 }
 
 .dm-button--unstyled-warning {
-  @extend .usa-button;
   @extend .usa-button--unstyled;
   @include u-text("error", !important);
   font-weight: normal;


### PR DESCRIPTION
### JIRA issue link
Part of [DM-5117](https://agile6.atlassian.net/browse/DM-5117)

## Description - what does this code do?
- Updates several "unstyled" button styles so they're more link-ish. Remove dark background that they received via inheritance from `.usa-button`.

## Testing done - how did you test it/steps on how can another person can test it 
1. Go to `/innovations/vha-rapid-naloxone/edit/implementation`
2. In the `Risks and Mitigations` section, hover over `Add Another` link. Confirm that no background color is applied
3. Hover over the `Delete entry` link. Confirm that no background color is applied
4. On the same practice editor page, hover over the `Return to Top` link in the footer. Confirm that no background color is applied

## Screenshots, Gifs, Videos from application (if applicable)
![Screenshot 2024-09-16 at 3 43 55 PM](https://github.com/user-attachments/assets/2d903ede-c367-49b5-b428-5d066f128a71)
