### PR TITLE
dm-5077 product editor description

### DIFF
--- a/app/admin/products.rb
+++ b/app/admin/products.rb
@@ -52,7 +52,7 @@ ActiveAdmin.register Product do
     attributes_table  do
       row :id
       row(:name, label: 'Product name') # { |product| link_to(product.name, product_path(product)) } - uncomment when product show page is created
-      # row('Edit URL') { |product| link_to(product_overview_path(product), product_overview_path(product)) } - uncomment when product editor is created
+      row('Edit URL') { |product| link_to(product_description_path(product), product_description_path(product)) }
       row(:user) {|product| link_to(product.user&.email, admin_user_path(product.user)) if product.user.present?}
       row(:published, label: 'Published')
       row(:date_published, label: 'Date Published')

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -1,0 +1,4 @@
+class ProductsController < ApplicationController
+  def description
+  end
+end

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -1,5 +1,56 @@
 class ProductsController < ApplicationController
+  before_action :authenticate_user!, except: [:show, :search, :index]
+  before_action :set_product, only: [:description, :update]
+  before_action :check_product_permissions, only: [:update, :description]
+
   def description
     render 'products/form/description'
+  end
+
+  def update
+    submitted_product_data = product_params
+    submitted_page = submitted_product_data.delete(:submitted_page)
+    @product.assign_attributes(submitted_product_data)
+
+    if @product.changed?
+      unless @product.save
+        flash[:error] = @product.errors.map {|error| error.options[:message]}.join(', ')
+        redirect_to send("product_#{submitted_page}_path", @product) || admin_product_path(@product)
+        return
+      end
+    end
+
+    # once subsequent editor pages exist render the next page using submitted_page upon successful update
+    flash[:success] = 'Product was successfully updated.'
+    redirect_to send("product_#{submitted_page}_path", @product) || admin_product_path(@product)
+  rescue => e
+    logger.error "Product update failed: #{e.message}"
+    flash[:error] = "An unexpected error occurred: #{e.message}"
+    redirect_to send("product_#{submitted_page}_path", @product) || admin_product_path(@product)
+  end
+
+  private
+
+  def set_product
+    product_id = params[:id] || params[:product_id]
+    @product = Product.find(product_id)
+  end
+
+  def product_params
+    params.require(:product).permit(
+      :name,
+      :description,
+      :item_number,
+      :vendor,
+      :duns,
+      :shipping_timeline_estimate,
+      :submitted_page
+      )
+  end
+
+  def check_product_permissions
+    unless current_user.has_role?(:admin) || @practice&.user_id == current_user.id
+      unauthorized_response
+    end
   end
 end

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -1,4 +1,5 @@
 class ProductsController < ApplicationController
   def description
+    render 'products/form/description'
   end
 end

--- a/app/views/products/form/description.html.erb
+++ b/app/views/products/form/description.html.erb
@@ -1,0 +1,1 @@
+hello world

--- a/app/views/products/form/description.html.erb
+++ b/app/views/products/form/description.html.erb
@@ -1,1 +1,97 @@
-hello world
+<div class="grid-container">
+  <div class="grid-row grid-gap">
+    <div id="description" class="grid-col-12 margin-top-4">
+      <%= render partial: "shared/messages", locals: {small_text: false} %>
+      <section class="usa-section padding-y-0 introduction">
+        <h1 class="margin-top-0">Description</h1>
+        <%= nested_form_for(@product, html: {multipart: true, style: 'max-width: 100%', class: 'usa-form', id: 'form'}) do |f| %>
+          <fieldset class="usa-fieldset grid-col-10">
+            <legend class="usa-sr-only">Product Description</legend>
+            <div class="margin-bottom-5 margin-top-3">
+              <div>
+                <%= f.label :name, class: 'usa-label text-bold display-block margin-top-0 margin-bottom-2' do %>
+                  Innovation Title*
+                <% end %>
+                <span>Type the official name of your product.</span>&nbsp;
+              </div>
+              <%= f.text_field :name, class: "usa-input #{ @product.errors[:name].any? ? 'usa-input--error' : '' } display-block practice-editor-name-input dm-required-field", required: true %>
+
+              <p class="usa-error-message <%= @product.errors[:name].any? ? 'fas fa-exclamation-circle fon' : 'display-none' %>">&nbsp;<span class="font-family-sans"><%= show_errors(@product, :name) %></span>
+              </p>
+            </div>
+            <div class="margin-bottom-5 margin-top-3">
+              <div>
+                <%= f.label :description, class: 'usa-label text-bold display-block margin-top-0 margin-bottom-2' do %>
+                  Executive Summary*
+                <% end %>
+                <span>Type the description of your product.</span>&nbsp;
+              </div>
+              <%= f.text_area :description, class: "usa-textarea #{ @product.errors[:description].any? ? 'usa-input--error' : '' } display-block practice-editor-overview-statement-input dm-required-field", required: true %>
+
+              <p class="usa-error-message <%= @product.errors[:description].any? ? 'fas fa-exclamation-circle fon' : 'display-none' %>">&nbsp;
+                <span class="font-family-sans"><%= show_errors(@product, :description) %></span>
+              </p>
+            </div>
+            <div class="margin-bottom-5 margin-top-3">
+              <div>
+                <%= f.label :item_number, class: 'usa-label text-bold display-block margin-top-0 margin-bottom-2' do %>
+                  Item Number*
+                <% end %>
+                <span>Et harum quidem rerum facilis est et expedita distinctio.</span>&nbsp;
+              </div>
+              <%= f.text_field :item_number, class: "usa-input #{ @product.errors[:item_number].any? ? 'usa-input--error' : '' } display-block practice-editor-name-input dm-required-field", required: true %>
+
+              <p class="usa-error-message <%= @product.errors[:item_number].any? ? 'fas fa-exclamation-circle fon' : 'display-none' %>">&nbsp;
+                <span class="font-family-sans"><%= show_errors(@product, :item_number) %></span>
+              </p>
+            </div>
+            <div class="margin-bottom-5 margin-top-3">
+              <div>
+                <%= f.label :vendor, class: 'usa-label text-bold display-block margin-top-0 margin-bottom-2' do %>
+                  Vendor*
+                <% end %>
+                <span>Et harum quidem rerum facilis est et expedita distinctio.</span>&nbsp;
+              </div>
+              <%= f.text_field :vendor, class: "usa-input #{ @product.errors[:vendor].any? ? 'usa-input--error' : '' } display-block practice-editor-name-input dm-required-field", required: true %>
+
+              <p class="usa-error-message <%= @product.errors[:vendor].any? ? 'fas fa-exclamation-circle fon' : 'display-none' %>">&nbsp;
+                <span class="font-family-sans"><%= show_errors(@product, :vendor) %></span>
+              </p>
+            </div>
+            <div class="margin-bottom-5 margin-top-3">
+              <div>
+                <%= f.label :duns, class: 'usa-label text-bold display-block margin-top-0 margin-bottom-2' do %>
+                  DUNS
+                <% end %>
+                <span>Et harum quidem rerum facilis est et expedita distinctio.</span>&nbsp;
+              </div>
+              <%= f.text_field :duns, class: "usa-input #{ @product.errors[:duns].any? ? 'usa-input--error' : '' } display-block practice-editor-name-input" %>
+
+              <p class="usa-error-message <%= @product.errors[:duns].any? ? 'fas fa-exclamation-circle fon' : 'display-none' %>">&nbsp;
+                <span class="font-family-sans"><%= show_errors(@product, :duns) %></span>
+              </p>
+            </div>
+            <div class="margin-bottom-5 margin-top-3">
+              <div>
+                <%= f.label :shipping_timeline_estimate, class: 'usa-label text-bold display-block margin-top-0 margin-bottom-2' do %>
+                  Shipping Timeline Estimate
+                <% end %>
+                <span>Et harum quidem rerum facilis est et expedita distinctio.</span>&nbsp;
+              </div>
+              <%= f.text_field :shipping_timeline_estimate, class: "usa-input #{ @product.errors[:duns].any? ? 'usa-input--error' : '' } display-block practice-editor-name-input" %>
+
+              <p class="usa-error-message <%= @product.errors[:shipping_timeline_estimate].any? ? 'fas fa-exclamation-circle fon' : 'display-none' %>">&nbsp;
+                <span class="font-family-sans"><%= show_errors(@product, :shipping_timeline_estimate) %></span>
+              </p>
+            </div>
+            <%= f.hidden_field :submitted_page, value: request.original_url.split('/').last %>
+            <!-- Remove once footer with submit button is implemented -->
+            <div class="margin-top-4">
+              <%= f.submit 'Submit', class: 'usa-button usa-button--primary' %>
+            </div>
+          </fieldset>
+        <% end %>
+      </section>
+    </div>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -57,6 +57,10 @@ Rails.application.routes.draw do
     end
   end
 
+  resources :products, except: :index do
+    get '/edit/description', action: 'description', as: 'description'
+  end
+
   # old practice routes redirects
   get '/practices/:id', to: redirect('/innovations/%{id}', status: 302)
   get '/practices/:id/edit/metrics', to: redirect('/innovations/%{id}/edit/metrics', status: 302)

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1102,7 +1102,7 @@ ActiveRecord::Schema.define(version: 2024_09_12_210801) do
     t.text "main_display_image_alt_text"
     t.string "support_network_email"
     t.boolean "private_contact_info"
-    t.boolean "published", default: false
+    t.boolean "published"
     t.bigint "user_id"
     t.integer "crop_x"
     t.integer "crop_y"
@@ -1116,9 +1116,6 @@ ActiveRecord::Schema.define(version: 2024_09_12_210801) do
     t.datetime "main_display_image_updated_at"
     t.string "usage"
     t.string "price"
-    t.datetime "date_published"
-    t.boolean "retired", default: false, null: false
-    t.index ["name"], name: "index_products_on_name", unique: true
     t.index ["user_id"], name: "index_products_on_user_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1102,7 +1102,7 @@ ActiveRecord::Schema.define(version: 2024_09_12_210801) do
     t.text "main_display_image_alt_text"
     t.string "support_network_email"
     t.boolean "private_contact_info"
-    t.boolean "published"
+    t.boolean "published", default: false
     t.bigint "user_id"
     t.integer "crop_x"
     t.integer "crop_y"
@@ -1116,6 +1116,9 @@ ActiveRecord::Schema.define(version: 2024_09_12_210801) do
     t.datetime "main_display_image_updated_at"
     t.string "usage"
     t.string "price"
+    t.datetime "date_published"
+    t.boolean "retired", default: false, null: false
+    t.index ["name"], name: "index_products_on_name", unique: true
     t.index ["user_id"], name: "index_products_on_user_id"
   end
 

--- a/spec/features/product_editor/description_spec.rb
+++ b/spec/features/product_editor/description_spec.rb
@@ -1,0 +1,74 @@
+require 'rails_helper'
+
+describe 'Product editor - introduction', type: :feature do
+  let!(:product) { create(:product)}
+  let!(:user) { create(:user) }
+  let!(:admin) { create(:user, :admin)}
+
+  before do
+    login_as(current_user, :scope => :user, :run_callbacks => false)
+  end
+
+  describe 'when logged in as a regular user' do
+    let(:current_user) { user }
+
+    context 'with no permissions' do
+      it 'redirects to the root path with a warning' do
+        visit product_description_path(product)
+        expect(page).to have_current_path('/')
+        expect(page).to have_content('You are not authorized to view this content.')
+      end
+    end
+  end
+
+  describe 'when logged in as an admin' do
+    let(:current_user) { admin }
+
+    it 'allows access and displays the product description form' do
+      visit product_description_path(product)
+      expect(page).to have_content('Description')
+      expect(page).to have_field('product_name', with: product.name)
+    end
+
+    it 'allows access to the description page and updates the product successfully' do
+      visit product_description_path(product)
+      expect(page).to have_content('Description')
+
+      fill_in 'product_name', with: 'Updated Product Name'
+      click_button 'Submit'
+
+      expect(page).to have_content('Product was successfully updated.')
+      expect(product.reload.name).to eq('Updated Product Name')
+    end
+
+    it 'shows validation errors for missing required fields' do
+      visit product_description_path(product)
+
+      fill_in 'product_name', with: ''
+      click_button 'Submit'
+      expect(page).to have_current_path(product_description_path(product))
+      expect(page).to have_selector("input:invalid")
+    end
+
+    it 'shows model validation errors' do
+      new_product = create(:product, name: 'more different name')
+      visit product_description_path(new_product)
+
+      fill_in 'product_name', with: product.name
+      click_button 'Submit'
+      expect(page).to have_current_path(product_description_path(new_product))
+      expect(page).to have_content('Product name already exists')
+    end
+  end
+
+  describe 'when not logged in' do
+    let(:current_user) { nil }
+
+    context 'without login' do
+      it 'redirects to the login page' do
+        visit product_description_path(product)
+        expect(page).to have_current_path(new_user_session_path)
+      end
+    end
+  end
+end


### PR DESCRIPTION
### JIRA issue link
https://agile6.atlassian.net/browse/DM-5077

## Description - what does this code do?
adds first page & endpoint for `Product` editor

## Testing done - how did you test it/steps on how can another person can test it 
1. locally with products loaded via `:full_import` task go to `/admin/products/12` and click the "Edit Url" link
2. verify you can update the various fields and you see a success flash upon clicking the submit button, note: the "Submit" button will be replaced with a "Save and Continue" button in a footer that is being built and that the page will redirect to the next editor page once built, for now it just re-renders the "Description" form)
3. Verify that required fields will prevent form submission when left blank with an indicator under the field
4. Verify that when submitting with a "Innovation Title*" that duplicates another "product"'s name the change does not persist and the page re-renders with a flash indicating error.

## Screenshots, Gifs, Videos from application (if applicable)
<img width="803" alt="Screenshot 2024-09-17 at 3 40 20 PM" src="https://github.com/user-attachments/assets/68c0f624-e4c0-4168-9af1-1776467d9560">

## Link to mock-ups/mock ups (image file if you have it) (if applicable)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Unit tests written (if applicable)
- [ ] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating JIRA issue
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs