### PR TITLE
DM-5069: Add FriendlyID slugs to products for pretty URLs

### DIFF
--- a/app/admin/products.rb
+++ b/app/admin/products.rb
@@ -66,6 +66,10 @@ ActiveAdmin.register Product do
       super.left_joins(:user)
     end
 
+    def find_resource
+      scoped_collection.friendly.find(params[:id])
+    end
+
     def create
       ActiveRecord::Base.transaction do
         product = Product.new(product_params)
@@ -78,7 +82,7 @@ ActiveAdmin.register Product do
 
     def update
       ActiveRecord::Base.transaction do
-        @product = Product.find(params[:id])
+        @product = Product.friendly.find(params[:id])
         @product.assign_attributes(product_params)
         handle_user_email(@product)
 

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -33,7 +33,7 @@ class ProductsController < ApplicationController
 
   def set_product
     product_id = params[:id] || params[:product_id]
-    @product = Product.find(product_id)
+    @product = Product.friendly.find(product_id)
   end
 
   def product_params

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -8,6 +8,9 @@ class Product < Innovation
 
   after_update :update_date_published
 
+  extend FriendlyId
+  friendly_id :name, use: :slugged
+
   def user_email
     user&.email
   end

--- a/db/migrate/20240918010354_add_slug_to_products.rb
+++ b/db/migrate/20240918010354_add_slug_to_products.rb
@@ -1,0 +1,6 @@
+class AddSlugToProducts < ActiveRecord::Migration[6.1]
+  def change
+    add_column :products, :slug, :string
+    add_index :products, :slug, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_09_12_210801) do
+ActiveRecord::Schema.define(version: 2024_09_18_010354) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -1118,7 +1118,9 @@ ActiveRecord::Schema.define(version: 2024_09_12_210801) do
     t.string "price"
     t.datetime "date_published"
     t.boolean "retired", default: false, null: false
+    t.string "slug"
     t.index ["name"], name: "index_products_on_name", unique: true
+    t.index ["slug"], name: "index_products_on_slug", unique: true
     t.index ["user_id"], name: "index_products_on_user_id"
   end
 


### PR DESCRIPTION
### JIRA issue link
[DM-5069](https://agile6.atlassian.net/browse/DM-5069)

## Description - what does this code do?
- Adds FriendlyID to Products so that they have nice URLs

## Testing done - how did you test it/steps on how can another person can test it 
1. On a previous commit, look at a Product in the rails console and confirm it has no `slug` property. 
2. Check out this branch and run the migrations. 
3. Run `Product.find_each(&:save)`.
4. Confirm that all products now have a slug based off their `name`. e.g. `thermal-fuse-cover`
