### PR TITLE
DM-5069: Add PracticeMultimedia to Products factory

### DIFF
--- a/spec/factories/products.rb
+++ b/spec/factories/products.rb
@@ -28,7 +28,6 @@ FactoryBot.define do
         )
         # Image
         PracticeMultimedium.create(
-          link_url: "https://www.youtube.com/watch?v=-oazAtTm-lk",
           name: "Dr. Jeffrey Heckman speaks about the collaborative origins of FLOW3 and how it 
           uses three custom-designed features to address issues with artificial limb authorizations.)",
           resource_type: "image",

--- a/spec/factories/products.rb
+++ b/spec/factories/products.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :product do
-    name { "Sample Product" }
+    sequence(:name) { |n| "Sample Product #{n}" }
     tagline { "This is a sample tagline for a product." }
     item_number { "ITEM12345" }
     vendor { "Sample Vendor" }
@@ -14,6 +14,47 @@ FactoryBot.define do
     trait :with_image do
       main_display_image { Rack::Test::UploadedFile.new(Rails.root.join('app/assets/images/about-page-image.png'), 'image/jpg') }
       main_display_image_alt_text { "sample image" }
+    end
+
+    trait :with_multimedia do
+      after(:create) do |product|
+        # Video
+        PracticeMultimedium.create(
+          link_url: "https://www.youtube.com/watch?v=-oazAtTm-lk",
+          name: "Dr. Jeffrey Heckman speaks about the collaborative origins of FLOW3 and how it
+          uses three custom-designed features to address issues with artificial limb authorizations.)",
+          resource_type: "video",
+          innovable: product
+        )
+        # Image
+        PracticeMultimedium.create(
+          link_url: "https://www.youtube.com/watch?v=-oazAtTm-lk",
+          name: "Dr. Jeffrey Heckman speaks about the collaborative origins of FLOW3 and how it 
+          uses three custom-designed features to address issues with artificial limb authorizations.)",
+          resource_type: "image",
+          innovable: product,
+          attachment_file_name: "acceptable_img.jpg",
+          image_alt_text: "a prescription bottle and pills",
+          attachment: File.new(Rails.root.join('spec', 'assets', 'acceptable_img.jpg'))
+        )
+        # File - TODO: Fix up file partial to work with polymorphic relationship
+        PracticeMultimedium.create(
+          name: "Implementation guide",
+          description: "Tips on about implementing this practice at your facility",
+          resource_type: "file",
+          innovable: product,
+          attachment_file_name: "dummy.pdf",
+          attachment: File.new(Rails.root.join('spec', 'assets', 'dummy.pdf'))
+        )
+        # Link
+        PracticeMultimedium.create(
+          link_url: "https://va.gov",
+          name: "VA Strategic Initiatives",
+          description: "Learn more about the VHA Priorities",
+          resource_type: "link",
+          innovable: product
+        )
+      end
     end
   end
 end


### PR DESCRIPTION
### JIRA issue link
DM-5069

## Description - what does this code do?
- Add PracticeMultimedia to Products factory to verify behavior 

## Testing done - how did you test it/steps on how can another person can test it 
1. Open the rails console and run `FactoryBot.create(:product, :with_multimedia)`
2. Confirm that `Product.last.practice_multimedia` returns a video, a file, a link, and an image.