### PR TITLE
DM-5198: Set up routing and basic templates for Product pages

### DIFF
--- a/app/admin/products.rb
+++ b/app/admin/products.rb
@@ -51,7 +51,7 @@ ActiveAdmin.register Product do
   show do
     attributes_table  do
       row :id
-      row(:name, label: 'Product name') # { |product| link_to(product.name, product_path(product)) } - uncomment when product show page is created
+      row(:name, label: 'Product name') { |product| link_to(product.name, product_path(product)) }
       row('Edit URL') { |product| link_to(product_description_path(product), product_description_path(product)) }
       row(:user) {|product| link_to(product.user&.email, admin_user_path(product.user)) if product.user.present?}
       row(:published, label: 'Published')

--- a/app/assets/stylesheets/dm/pages/_products.scss
+++ b/app/assets/stylesheets/dm/pages/_products.scss
@@ -1,0 +1,5 @@
+.products.show-main {
+	p {
+		@extend .line-height-26;
+	}
+}

--- a/app/assets/stylesheets/dm/pages/_products.scss
+++ b/app/assets/stylesheets/dm/pages/_products.scss
@@ -1,4 +1,10 @@
 .products.show-main {
+	#practice-show-intrapreneur {
+		.origin-story p {
+			margin-bottom: 0.5rem;
+		}
+
+	}
 	p {
 		@extend .line-height-26;
 	}

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -44,21 +44,6 @@ class ProductsController < ApplicationController
     @product = Product.friendly.find(product_id)
   end
 
-  def can_view_product
-    # if practice is not published
-    unless @product.published
-      unauthorized_response if current_user.blank?
-      prevent_product_permissions if current_user.present?
-    end
-  end
-
-  def prevent_product_permissions
-    # if the user is the product owner or the user is an admin or TODO: product editor
-    unless current_user.has_role?(:admin) || @product.user_id == current_user.id #|| is_user_an_editor_for_practice(@practice, current_user)
-      unauthorized_response
-    end
-  end
-
   def product_params
     params.require(:product).permit(
       :name,

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -60,7 +60,7 @@ class ProductsController < ApplicationController
   end
 
   def check_product_permissions
-    unless current_user.has_role?(:admin) || @product&.user_id == current_user.id
+    unless current_user&.has_role?(:admin) || @product&.user_id == current_user&.id
       unauthorized_response
     end
   end

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -1,7 +1,7 @@
 class ProductsController < ApplicationController
   before_action :authenticate_user!, except: [:show, :search, :index]
-  before_action :set_product, only: [:update, :description, :intrapreneur]
-  before_action :check_product_permissions, only: [:update, :description, :intrapreneur]
+  before_action :set_product, only: [:show, :update, :description, :intrapreneur]
+  before_action :check_product_permissions, only: [:show, :update, :description, :intrapreneur]
 
   def description
     render 'products/form/description'
@@ -9,6 +9,10 @@ class ProductsController < ApplicationController
 
   def intrapreneur
     render 'products/form/intrapreneur'
+  end
+
+  def show
+    render 'products/show'
   end
 
   def update

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -44,6 +44,21 @@ class ProductsController < ApplicationController
     @product = Product.friendly.find(product_id)
   end
 
+  def can_view_product
+    # if practice is not published
+    unless @product.published
+      unauthorized_response if current_user.blank?
+      prevent_product_permissions if current_user.present?
+    end
+  end
+
+  def prevent_product_permissions
+    # if the user is the product owner or the user is an admin or TODO: product editor
+    unless current_user.has_role?(:admin) || @product.user_id == current_user.id #|| is_user_an_editor_for_practice(@practice, current_user)
+      unauthorized_response
+    end
+  end
+
   def product_params
     params.require(:product).permit(
       :name,

--- a/app/helpers/navigation_helper.rb
+++ b/app/helpers/navigation_helper.rb
@@ -156,6 +156,13 @@ module NavigationHelper
       end
     end
 
+    ### PRODUCTS
+    if controller == 'products'
+      if action == 'show'
+        empty_breadcrumbs # TODO: add home breadcrumbs after DM-5001
+      end
+    end
+
     ### VAMC breadcrumbs
     def add_facility_index_breadcrumb
       session[:breadcrumbs] << { 'display': 'Healthcare facility index', 'path': va_facilities_path }

--- a/app/views/products/_product_status_banner.html.erb
+++ b/app/views/products/_product_status_banner.html.erb
@@ -1,0 +1,26 @@
+<%
+  published = product.published
+  retired = product.retired
+%>
+<% unless published %>
+  <div class="usa-alert usa-alert--warning">
+    <div class="usa-alert__body">
+      <h3 class="usa-alert__heading">This innovation will not be shown in the marketplace because it is:</h3>
+      <% unless published %>
+        <div>
+         Unpublished
+        </div>
+      <% end %>
+    </div>
+  </div>
+<% end %>
+<% if retired %>
+  <div class="usa-alert usa-alert--info margin-bottom-3 margin-top-1">
+    <div class="usa-alert__body">
+      <h4 class="usa-alert__heading">Retired innovation</h4>
+      <div class="usa-alert__text">
+        This innovation is no longer being updated.
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -58,18 +58,14 @@
       <div class="desktop:grid-col-9 grid-col-12">
       	<h2>Multimedia</h2><span>TO DO: fix partial to fix different heading levels</span>
         <div class="multimedia-section practice-section">
-          <%= render partial: 'practices/show/overview/overview_sections', locals: {resources: @product.practice_multimedia, statement: '', title: 'Multimedia', s_area: 'multimedia'} %>
+        	<% # temporarily skip files while troubleshooting %>
+        	<% multimedia = @product.practice_multimedia.where.not(resource_type: "file") %>
+          <%= render partial: 'practices/show/overview/overview_sections', locals: {resources: multimedia, statement: '', title: 'Multimedia', s_area: 'multimedia'} %>
         </div>
       </div>
     </div>
   </section>
 <% end %>
-
-<% # @product.practice_multimedia %>
-<% # video %>
-<% # image %>
-<% # file %>
-	<% # link %>
 <section id="practice-show-order-instructions" class="grid-container">
 	<h2>Order Product</h2>
 	<ol class="usa-process-list">

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -1,0 +1,87 @@
+<section class="usa-section padding-y-0 margin-bottom-1 margin-top-0">
+  <div class="grid-container position-relative">
+    <div class="grid-row grid-gap">
+      <div id="practice_show" class="grid-col-12 overview-section practice-section">
+        <%= render partial: "shared/messages", locals: {small_text: false} %>
+        <% #render partial: "practices/show/practice_status_banner", locals: { practice: @practice } %>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section id="pr-view-introduction" class="grid-container margin-bottom-3">
+	<div class="grid-row grid-gap-2">
+		<div class="desktop:grid-col-8 grid-col-12">
+		      <h1 class="margin-top-0 margin-bottom-1 dm-word-break-break-word dm-hyphens-auto">
+		        <p><%= @product.name %></p>
+		      </h1>
+		      <%# innovation last update timestamp %>
+		      <p class="grid-col-12 font-sans-3xs text-base line-height-sans-4 margin-bottom-2">
+		        Last updated <%# timeago(updated_at) %>
+		      </p>
+
+		    <div class="practice-partners-section"><h5 class="text-uppercase display-inline margin-y-0">Partners:</h5>
+		    	<p class="display-inline line-height-26"><%= @product.practice_partners.pluck(:name).join(', ') %></p>
+			</div>
+		</div>
+	</div>
+</section>
+
+<section id="practice-show-product-description" class="usa-section grid-container">
+	<h2>Product Description</h2>
+	<% product_description_fields = {
+	tagline: "Executive Summary",
+	item_number: "Item Number",
+	vendor: "Vendor",
+	duns: "DUNS",
+	shipping_timeline_estimate: "Shipping Timeline Estimate",
+	origin_story: "From the Innovator",
+	description: "Description"
+	} %>
+	<% product_description_fields.each do |field_name, field_label| %>
+	<h3><%= field_label %></h3>
+	<p><%= @product.send(field_name.to_sym) %></p>
+	<% end %>
+</section>
+<section id="practice-show-intrapreneur" class="usa-section grid-container">
+	<h2>Intrapreneur</h2>
+	<h3><%= 'Innovator'.pluralize(@product.va_employee_practices.count) %></h3>
+	<% @product.va_employee_practices.each do |innovator| %>
+		<p><%= innovator.va_employee&.name %></p>
+		<p class="text-italic"><%= innovator.va_employee&.role %></p>
+	<% end %>
+	<h3>From the Innovator</h3>
+	<p><%= @product.origin_story %></p>
+</section>
+<section id="practice-show-multimedia" class="usa-section grid-container">
+	<h2>Multimedia</h2>
+	<% # @product.practice_multimedia %>
+	<% # video %>
+	<% # image %>
+	<% # file %>
+	<% # link %>
+
+</section>
+<section id="practice-show-order-instructions" class="usa-section grid-container">
+	<h2>Order Product</h2>
+	<ol class="usa-process-list">
+	  <li class="usa-process-list__item">
+	    <h4 class="usa-process-list__heading">Order from the Marketplace</h4>
+	    <p class="margin-top-05">
+	      VA employees wishing to order a product should copy and paste the details under the "Order" tab and send it to their usual service-line purchasing agent. If the order is above the purchase card threshold, contact <a class="usa-link" href="mailto:VAIMPSupport@va.gov">VAIMPSupport@va.gov</a>for information on contracting with the vendor. VA employees cannot order directly from the manufacturer unless they are authorized to do so.
+	    </p>
+	  </li>
+	  <li class="usa-process-list__item">
+	    <h4 class="usa-process-list__heading">Obtain a Completed VA Form 1091</h4>
+	    <p>
+	      For first-time purchases from a vendor, contact <a class="usa-link" href="mailto:VAIPMVendorizationRequest@va.gov">VAIPMVendorizationRequest@va.gov</a> to obtain a copy of the completed VA Form 10091 (FSC Vendor File Request Form).
+	    </p>
+	  </li>
+	  <li class="usa-process-list__item">
+	    <h4 class="usa-process-list__heading">Request a Local Vendor Number</h4>
+	    <p>
+	      Follow your local vendorization process to request the assignment of a local vendor number.
+	    </p>
+	  </li>
+	</ol>
+</section>

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -38,7 +38,7 @@
 	description: "Description"
 	} %>
 	<% product_description_fields.each do |field_name, field_label| %>
-	<h3><%= field_label %></h3>
+	<h3 class="font-sans-lg line-height-25px margin-top-2 margin-bottom-1"><%= field_label %></h3>
 	<p><%= @product.send(field_name.to_sym) %></p>
 	<% end %>
 </section>

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -46,11 +46,13 @@
 	<h2>Intrapreneur</h2>
 	<h3><%= 'Innovator'.pluralize(@product.va_employee_practices.count) %></h3>
 	<% @product.va_employee_practices.each do |innovator| %>
+		<div class="innovators margin-bottom-1">
 		<p><%= innovator.va_employee&.name %></p>
 		<p class="text-italic"><%= innovator.va_employee&.role %></p>
+		</div>
 	<% end %>
 	<h3>From the Innovator</h3>
-	<p><%= @product.origin_story %></p>
+	<div class="origin-story"><%= simple_format(@product.origin_story, wrapper_tag: "p") %></div>
 </section>
 <% if @product.practice_multimedia.any? %>
   <section id="practice-show-multimedia" class="margin-bottom-5 grid-container">

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -30,12 +30,11 @@
 <section id="practice-show-product-description" class="grid-container">
 	<h2>Product Description</h2>
 	<% product_description_fields = {
-	tagline: "Executive Summary",
+	description: "Executive Summary",
 	item_number: "Item Number",
 	vendor: "Vendor",
 	duns: "DUNS",
 	shipping_timeline_estimate: "Shipping Timeline Estimate",
-	description: "Description"
 	} %>
 	<% product_description_fields.each do |field_name, field_label| %>
 	<h3 class="font-sans-lg line-height-25px margin-top-2 margin-bottom-1"><%= field_label %></h3>

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -1,4 +1,4 @@
-<section class="usa-section padding-y-0 margin-bottom-1 margin-top-0">
+<section class="padding-y-0 margin-bottom-1 margin-top-0">
   <div class="grid-container position-relative">
     <div class="grid-row grid-gap">
       <div id="practice_show" class="grid-col-12 overview-section practice-section margin-y-3">
@@ -27,7 +27,7 @@
 	</div>
 </section>
 
-<section id="practice-show-product-description" class="usa-section grid-container">
+<section id="practice-show-product-description" class="grid-container">
 	<h2>Product Description</h2>
 	<% product_description_fields = {
 	tagline: "Executive Summary",
@@ -43,7 +43,7 @@
 	<p><%= @product.send(field_name.to_sym) %></p>
 	<% end %>
 </section>
-<section id="practice-show-intrapreneur" class="usa-section grid-container">
+<section id="practice-show-intrapreneur" class="grid-container">
 	<h2>Intrapreneur</h2>
 	<h3><%= 'Innovator'.pluralize(@product.va_employee_practices.count) %></h3>
 	<% @product.va_employee_practices.each do |innovator| %>
@@ -71,7 +71,7 @@
 <% # image %>
 <% # file %>
 	<% # link %>
-<section id="practice-show-order-instructions" class="usa-section grid-container">
+<section id="practice-show-order-instructions" class="grid-container">
 	<h2>Order Product</h2>
 	<ol class="usa-process-list">
 	  <li class="usa-process-list__item">

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -53,15 +53,24 @@
 	<h3>From the Innovator</h3>
 	<p><%= @product.origin_story %></p>
 </section>
-<section id="practice-show-multimedia" class="usa-section grid-container">
-	<h2>Multimedia</h2>
-	<% # @product.practice_multimedia %>
-	<% # video %>
-	<% # image %>
-	<% # file %>
-	<% # link %>
+<% if @product.practice_multimedia.any? %>
+  <section id="practice-show-multimedia" class="margin-bottom-5 grid-container">
+    <div class="grid-row grid-gap-2">
+      <div class="desktop:grid-col-9 grid-col-12">
+      	<h2>Multimedia</h2><span>TO DO: fix partial to fix different heading levels</span>
+        <div class="multimedia-section practice-section">
+          <%= render partial: 'practices/show/overview/overview_sections', locals: {resources: @product.practice_multimedia, statement: '', title: 'Multimedia', s_area: 'multimedia'} %>
+        </div>
+      </div>
+    </div>
+  </section>
+<% end %>
 
-</section>
+<% # @product.practice_multimedia %>
+<% # video %>
+<% # image %>
+<% # file %>
+	<% # link %>
 <section id="practice-show-order-instructions" class="usa-section grid-container">
 	<h2>Order Product</h2>
 	<ol class="usa-process-list">

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -38,6 +38,7 @@
 				field_label = arr[1]
 				options = arr[2]
 		%>
+		<% next if @product.send(field_name.to_sym).blank? %>
 		<h3 class="font-sans-lg line-height-25px margin-top-2 margin-bottom-1"><%= field_label %></h3>
 		<% if options.present? %>
 			<p><%= options %></p>

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -13,7 +13,7 @@
 	<div class="grid-row grid-gap-2">
 		<div class="desktop:grid-col-8 grid-col-12">
 		      <h1 class="margin-top-0 margin-bottom-1 dm-word-break-break-word dm-hyphens-auto">
-		        <p><%= @product.name %></p>
+		      	<%= @product.name %>
 		      </h1>
 		      <%# innovation last update timestamp %>
 		      <p class="grid-col-12 font-sans-3xs text-base line-height-sans-4 margin-bottom-2">

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -1,9 +1,9 @@
 <section class="usa-section padding-y-0 margin-bottom-1 margin-top-0">
   <div class="grid-container position-relative">
     <div class="grid-row grid-gap">
-      <div id="practice_show" class="grid-col-12 overview-section practice-section">
+      <div id="practice_show" class="grid-col-12 overview-section practice-section margin-y-3">
         <%= render partial: "shared/messages", locals: {small_text: false} %>
-        <% #render partial: "practices/show/practice_status_banner", locals: { practice: @practice } %>
+        <%= render partial: "products/product_status_banner", locals: { product: @product} %>
       </div>
     </div>
   </div>

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -35,7 +35,6 @@
 	vendor: "Vendor",
 	duns: "DUNS",
 	shipping_timeline_estimate: "Shipping Timeline Estimate",
-	origin_story: "From the Innovator",
 	description: "Description"
 	} %>
 	<% product_description_fields.each do |field_name, field_label| %>

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -19,26 +19,31 @@
 		      <p class="grid-col-12 font-sans-3xs text-base line-height-sans-4 margin-bottom-2">
 		        Last updated <%# timeago(updated_at) %>
 		      </p>
-
-		    <div class="practice-partners-section"><h5 class="text-uppercase display-inline margin-y-0">Partners:</h5>
-		    	<p class="display-inline line-height-26"><%= @product.practice_partners.pluck(:name).join(', ') %></p>
-			</div>
 		</div>
 	</div>
 </section>
 
 <section id="practice-show-product-description" class="grid-container">
 	<h2>Product Description</h2>
-	<% product_description_fields = {
-	description: "Executive Summary",
-	item_number: "Item Number",
-	vendor: "Vendor",
-	duns: "DUNS",
-	shipping_timeline_estimate: "Shipping Timeline Estimate",
-	} %>
-	<% product_description_fields.each do |field_name, field_label| %>
-	<h3 class="font-sans-lg line-height-25px margin-top-2 margin-bottom-1"><%= field_label %></h3>
-	<p><%= @product.send(field_name.to_sym) %></p>
+	<% product_description_fields = [
+	[:description, "Executive Summary"],
+	[:item_number, "Item Number"],
+	[:vendor, "Vendor"],
+	[:duns, "DUNS"],
+	[:practice_partners, "Partners", @product&.practice_partners.pluck(:name).join(', ')],
+	[:shipping_timeline_estimate, "Shipping Timeline Estimate"]
+	] %>
+	<% product_description_fields.each do |arr| %>
+		<%	field_name = arr[0]
+				field_label = arr[1]
+				options = arr[2]
+		%>
+		<h3 class="font-sans-lg line-height-25px margin-top-2 margin-bottom-1"><%= field_label %></h3>
+		<% if options.present? %>
+			<p><%= options %></p>
+		<% else %>
+			<p><%= @product.send(field_name.to_sym) %></p>
+		<% end %>
 	<% end %>
 </section>
 <section id="practice-show-intrapreneur" class="grid-container">

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -17,7 +17,7 @@
 		      </h1>
 		      <%# innovation last update timestamp %>
 		      <p class="grid-col-12 font-sans-3xs text-base line-height-sans-4 margin-bottom-2">
-		        Last updated <%# timeago(updated_at) %>
+		        Last updated <%= timeago(@product&.updated_at) %>
 		      </p>
 		</div>
 	</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -60,6 +60,7 @@ Rails.application.routes.draw do
   resources :products, except: :index do
     get '/edit/description', action: 'description', as: 'description'
     get '/edit/intrapreneur', action: 'intrapreneur', as: 'intrapreneur'
+    get '/products/:id', action: 'show'
   end
 
   # old practice routes redirects

--- a/spec/features/product_viewer_spec.rb
+++ b/spec/features/product_viewer_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+describe 'Product show page', type: :feature do
+  let!(:product) { create(:product)}
+  let!(:user) { create(:user) }
+  let!(:admin) { create(:user, :admin)}
+
+  it 'hides unpublished pages' do
+    visit product_path(product)
+    expect(page).not_to have_content product.name
+    expect(page).to have_current_path(root_path)
+    login_as(admin, :scope => :user, :run_callbacks => false)
+    visit product_path(product)
+    expect(page).to have_content('Unpublished')
+    expect(page).to have_content product.name
+    expect(page).to have_current_path(product_path(product))
+  end
+
+  it 'has human-readable URLs' do
+    product.update(published: true)
+    visit "/products/#{product.name.parameterize}"
+    expect(page).to have_current_path(product_path(product))
+  end
+end


### PR DESCRIPTION
### JIRA issue link
[DM-5198](https://agile6.atlassian.net/browse/DM-5198)

## Description - what does this code do?
- Set up routes for product show page
- Do simple authorization checks for whether the page is published
- Render provided text-based data
- Render provided videos, images, and links (Files TBD)

## Testing done - how did you test it/steps on how can another person can test it 
1. As an admin go to `/admin/products` and create a new product
2. Go to the admin show page and confirm that the URL is using a sluggified version of the product name e.g. `/products/thermal-fuse-cover`.
3. Visit the product's show page at `/products/thermal-fuse-cover`. 
4. Confirm that provided data is rendered. 
5. Confirm that fields with missing data do not have a heading rendered
6. Log out. 
7. Access `/products/thermal-fuse-cover` as a public user. 
8. Confirm that you are redirected to the home page.

## Screenshots, Gifs, Videos from application (if applicable)
![Screenshot 2024-09-19 at 11 51 55 AM](https://github.com/user-attachments/assets/a0161aaa-d1ad-40d7-b92d-e12177e5d732)