### PR TITLE
Drop retired models: RequiredStaffTrainings, Costs, Difficulties

### DIFF
--- a/app/assets/stylesheets/dm/pages/_practice.scss
+++ b/app/assets/stylesheets/dm/pages/_practice.scss
@@ -379,10 +379,6 @@
   right: 2rem !important;
 }
 
-.cost-to-implement-container {
-  width: 11.5%;
-}
-
 .dm-icon-link {
   @extend .usa-link;
   @include u-text('no-underline', !important);

--- a/app/assets/stylesheets/dm/pages/_practice.scss
+++ b/app/assets/stylesheets/dm/pages/_practice.scss
@@ -204,19 +204,11 @@
   }
 }
 
-.add-required-staff-link {
-  margin-top: 24px !important;
-}
-
-.add-additional-staff-link, .add-required-staff-link, .add-practice-resources-link,
+.add-additional-staff-link, .add-practice-resources-link,
 .add-impact-photo-link, .add-practice-creator-link, .add-additional-document-link, .add-publication-link,
 .add-video-file-link, .add-permission-link, .add-resource-link {
   margin-top: 24px !important;
   margin-bottom: 44px;
-}
-
-#required-training-container {
-  display: none;
 }
 
 .milestone-textarea, .risk-description, .mitigation-description,
@@ -289,7 +281,7 @@
   left: 8px !important;
 }
 
-.origin-errors-ul, .complexity-errors-ul, .complexity-errors-ul, .resources-errors-ul,
+.origin-errors-ul, .resources-errors-ul,
 .impact-errors-ul {
   padding-left: 20px;
   margin-top: 5px;

--- a/app/controllers/practices_controller.rb
+++ b/app/controllers/practices_controller.rb
@@ -566,7 +566,6 @@ class PracticesController < ApplicationController # rubocop:disable Metrics/Clas
                                                                 :attachment_crop_w, :attachment_crop_h, :_destroy],
                                      video_files_attributes: [:id, :title, :description, :url, :position, :attachment, :attachment_original_w, :attachment_original_h, :attachment_crop_x, :attachment_crop_y,
                                                               :attachment_crop_w, :attachment_crop_h, :_destroy],
-                                     difficulties_attributes: [:id, :description, :_destroy],
                                      risk_mitigations_attributes: [:id, :_destroy, :position, risks_attributes: [:id, :description, :_destroy], mitigations_attributes: [:id, :description, :_destroy]],
                                      timelines_attributes: [:id, :description, :milestone, :timeline, :_destroy, :position],
                                      va_employees_attributes: [:id, :name, :role, :_destroy],

--- a/app/controllers/practices_controller.rb
+++ b/app/controllers/practices_controller.rb
@@ -572,7 +572,6 @@ class PracticesController < ApplicationController # rubocop:disable Metrics/Clas
                                      va_employees_attributes: [:id, :name, :role, :_destroy],
                                      additional_staffs_attributes: [:id, :_destroy, :title, :hours_per_week, :duration_in_weeks, :permanent],
                                      additional_resources_attributes: [:id, :_destroy, :name, :position, :description],
-                                     required_staff_trainings_attributes: [:id, :_destroy, :title, :description],
                                      practice_creators_attributes: [:id, :_destroy, :name, :role, :avatar, :position, :delete_avatar, :crop_x, :crop_y, :crop_w, :crop_h],
                                      publications_attributes: [:id, :_destroy, :title, :link, :position],
                                      additional_documents_attributes: [:id, :_destroy, :attachment, :title, :position],

--- a/app/models/cost.rb
+++ b/app/models/cost.rb
@@ -1,4 +1,0 @@
-class Cost < ApplicationRecord
-  acts_as_list scope: :practice
-  belongs_to :practice
-end

--- a/app/models/difficulty.rb
+++ b/app/models/difficulty.rb
@@ -1,4 +1,0 @@
-class Difficulty < ApplicationRecord
-  acts_as_list scope: :practice
-  belongs_to :practice
-end

--- a/app/models/practice.rb
+++ b/app/models/practice.rb
@@ -253,7 +253,6 @@ class Practice < ApplicationRecord
   has_many :practice_partners, through: :practice_partner_practices
   has_many :practice_permissions, -> { order(position: :asc) }, dependent: :destroy
   has_many :publications, -> { order(position: :asc) }, dependent: :destroy
-  has_many :required_staff_trainings, dependent: :destroy
   has_many :risk_mitigations, -> { order(position: :asc) }, dependent: :destroy
   has_many :survey_result_files, dependent: :destroy
   has_many :timelines, -> { order(position: :asc) }, dependent: :destroy
@@ -307,7 +306,6 @@ class Practice < ApplicationRecord
   accepts_nested_attributes_for :va_employees, allow_destroy: true, reject_if: proc { |attributes| attributes['name'].blank? || attributes['role'].blank? }
   accepts_nested_attributes_for :additional_staffs, allow_destroy: true, reject_if: proc { |attributes| attributes['title'].blank? || attributes['hours_per_week'].blank? || attributes['duration_in_weeks'].blank? }
   accepts_nested_attributes_for :additional_resources, allow_destroy: true, reject_if: proc { |attributes| attributes['name'].blank? }
-  accepts_nested_attributes_for :required_staff_trainings, allow_destroy: true, reject_if: proc { |attributes| attributes['title'].blank? || attributes['description'].blank? }
   accepts_nested_attributes_for :practice_creators, allow_destroy: true, reject_if: proc { |attributes| attributes['name'].blank? || attributes['role'].blank? }
   accepts_nested_attributes_for :practice_permissions, allow_destroy: true, reject_if: proc { |attributes| attributes['name'].blank? }
   accepts_nested_attributes_for :additional_documents, allow_destroy: true, reject_if: proc { |attributes|

--- a/app/models/practice.rb
+++ b/app/models/practice.rb
@@ -231,13 +231,11 @@ class Practice < ApplicationRecord
   has_many :clinical_condition_practices, dependent: :destroy
   has_many :clinical_conditions, through: :clinical_condition_practices
   has_many :clinical_location_practices, dependent: :destroy
-  has_many :clinical_locations, through: :clinical_location_practices
-  has_many :costs, dependent: :destroy
+  has_many :clinical_locations, through: :clinical_location_practices 
   has_many :department_practices, dependent: :destroy
   has_many :departments, through: :department_practices
   has_many :developing_facility_type_practices, dependent: :destroy
   has_many :developing_facility_types, through: :developing_facility_type_practices
-  has_many :difficulties, dependent: :destroy
   has_many :diffusion_histories, dependent: :destroy
   has_many :domain_practices, dependent: :destroy
   has_many :domains, through: :domain_practices
@@ -300,7 +298,6 @@ class Practice < ApplicationRecord
   accepts_nested_attributes_for :department_practices, allow_destroy: true, reject_if: proc { |attributes| attributes['value'].blank? }
 
   accepts_nested_attributes_for :video_files, allow_destroy: true, reject_if: proc { |attributes| attributes['url'].blank? || attributes['description'].blank? }
-  accepts_nested_attributes_for :difficulties, allow_destroy: true
   accepts_nested_attributes_for :risk_mitigations, allow_destroy: true
   accepts_nested_attributes_for :timelines, allow_destroy: true, reject_if: proc{ |attributes| attributes['milestone'].blank? || attributes['timeline'].blank?}
   accepts_nested_attributes_for :va_employees, allow_destroy: true, reject_if: proc { |attributes| attributes['name'].blank? || attributes['role'].blank? }
@@ -317,12 +314,6 @@ class Practice < ApplicationRecord
   accepts_nested_attributes_for :publications, allow_destroy: true, reject_if: proc { |attributes| attributes['title'].blank? || attributes['link'].blank? }
   accepts_nested_attributes_for :practice_emails, allow_destroy: true, reject_if: proc { |attributes| attributes['address'].blank? }
   accepts_nested_attributes_for :practice_editors, allow_destroy: true, reject_if: proc { |attributes| attributes['email'].blank? }
-  SATISFACTION_LABELS = ['Little or no impact', 'Some impact', 'Significant impact', 'High or large impact'].freeze
-  COST_LABELS = ['0-$10,000', '$10,000-$50,000', '$50,000-$250,000', 'More than $250,000'].freeze
-  # also known as "Difficulty"
-  COMPLEXITY_LABELS = ['Little or no complexity', 'Some complexity', 'Significant complexity', 'High or large complexity'].freeze
-  TIME_ESTIMATE_OPTIONS = ['1 week', '1 month', '3 months', '6 months', '1 year', 'longer than 1 year', 'Other (Please specify)']
-  NUMBER_DEPARTMENTS_OPTIONS = ['1. Single department', '2. Two departments', '3. Three departments', '4. Four or more departments']
 
   def committed_user_count
     user_practices.where(committed: true).count

--- a/app/models/required_staff_training.rb
+++ b/app/models/required_staff_training.rb
@@ -1,4 +1,0 @@
-class RequiredStaffTraining < ApplicationRecord
-  acts_as_list scope: :practice
-  belongs_to :practice
-end

--- a/db/migrate/20240920234630_drop_retired_importer_models.rb
+++ b/db/migrate/20240920234630_drop_retired_importer_models.rb
@@ -1,5 +1,7 @@
 class DropRetiredImporterModels < ActiveRecord::Migration[6.1]
   def change
     drop_table :required_staff_trainings
+    drop_table :costs
+    drop_table :difficulties
   end
 end

--- a/db/migrate/20240920234630_drop_retired_importer_models.rb
+++ b/db/migrate/20240920234630_drop_retired_importer_models.rb
@@ -1,0 +1,5 @@
+class DropRetiredImporterModels < ActiveRecord::Migration[6.1]
+  def change
+    drop_table :required_staff_trainings
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_08_19_013959) do
+ActiveRecord::Schema.define(version: 2024_09_20_234630) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -234,15 +234,6 @@ ActiveRecord::Schema.define(version: 2024_08_19_013959) do
     t.index ["commontable_type", "commontable_id"], name: "index_commontator_threads_on_c_id_and_c_type", unique: true
   end
 
-  create_table "costs", force: :cascade do |t|
-    t.string "description"
-    t.integer "position"
-    t.bigint "practice_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["practice_id"], name: "index_costs_on_practice_id"
-  end
-
   create_table "department_practices", force: :cascade do |t|
     t.bigint "practice_id"
     t.bigint "department_id"
@@ -278,15 +269,6 @@ ActiveRecord::Schema.define(version: 2024_08_19_013959) do
     t.string "description"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-  end
-
-  create_table "difficulties", force: :cascade do |t|
-    t.string "description"
-    t.integer "position"
-    t.bigint "practice_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["practice_id"], name: "index_difficulties_on_practice_id"
   end
 
   create_table "diffusion_histories", force: :cascade do |t|
@@ -1098,16 +1080,6 @@ ActiveRecord::Schema.define(version: 2024_08_19_013959) do
     t.index ["practice_id"], name: "index_publications_on_practice_id"
   end
 
-  create_table "required_staff_trainings", force: :cascade do |t|
-    t.string "title"
-    t.text "description"
-    t.integer "position"
-    t.bigint "practice_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["practice_id"], name: "index_required_staff_trainings_on_practice_id"
-  end
-
   create_table "risk_mitigations", force: :cascade do |t|
     t.integer "position"
     t.bigint "practice_id"
@@ -1407,12 +1379,10 @@ ActiveRecord::Schema.define(version: 2024_08_19_013959) do
   add_foreign_key "commontator_comments", "commontator_comments", column: "parent_id", on_update: :restrict, on_delete: :cascade
   add_foreign_key "commontator_comments", "commontator_threads", column: "thread_id", on_update: :cascade, on_delete: :cascade
   add_foreign_key "commontator_subscriptions", "commontator_threads", column: "thread_id", on_update: :cascade, on_delete: :cascade
-  add_foreign_key "costs", "practices"
   add_foreign_key "department_practices", "departments"
   add_foreign_key "department_practices", "practices"
   add_foreign_key "developing_facility_type_practices", "developing_facility_types"
   add_foreign_key "developing_facility_type_practices", "practices"
-  add_foreign_key "difficulties", "practices"
   add_foreign_key "diffusion_histories", "clinical_resource_hubs"
   add_foreign_key "diffusion_histories", "practices"
   add_foreign_key "diffusion_histories", "va_facilities"
@@ -1474,7 +1444,6 @@ ActiveRecord::Schema.define(version: 2024_08_19_013959) do
   add_foreign_key "practice_testimonials", "practices"
   add_foreign_key "practices", "users"
   add_foreign_key "publications", "practices"
-  add_foreign_key "required_staff_trainings", "practices"
   add_foreign_key "risk_mitigations", "practices"
   add_foreign_key "risks", "risk_mitigations"
   add_foreign_key "survey_result_files", "practices"

--- a/lib/tasks/importer.rake
+++ b/lib/tasks/importer.rake
@@ -116,7 +116,6 @@ namespace :importer do
       risk_mitigations
       additional_staff
       additional_resources
-      costs_difficulties
       impact_photos
       domains
       practice_permissions
@@ -686,34 +685,6 @@ def additional_resources
     next if answer.blank?
 
     AdditionalResource.create(practice: @practice, description: answer) unless AdditionalResource.where(description: answer, practice: @practice).any?
-  end
-end
-
-def costs_difficulties
-  puts "==> Importing Practice: #{@name} Costs and Difficulties".light_blue
-  @practice.costs.each(&:destroy)
-  @practice.difficulties.each(&:destroy)
-  question_fields = {
-      'List other Costs of Implementation that are unique to your Practice.': 6
-  }
-  question_fields.each do |key, value|
-    q_index = @questions.index(key.to_s)
-    end_index = q_index + 2
-
-    (q_index..end_index).each do |i|
-      next if @answers[i].blank?
-
-      if i == end_index && @given_answers[i] == 'Other (please specify) If more than one answer, please separate with a backslash ("\")'
-        split_answer = answer.split(/\\/)
-        split_answer.each do |ans|
-          Cost.create practice: @practice, description: @answers[i] unless Cost.where(description: @answers[i], practice: @practice).any?
-          Difficulty.create practice: @practice, description: @answers[i + 3] unless Difficulty.where(description: @answers[i + 3], practice: @practice).any?
-        end
-      else
-        Cost.create practice: @practice, description: @answers[i] unless Cost.where(description: @answers[i], practice: @practice).any?
-        Difficulty.create practice: @practice, description: @answers[i + 3] unless Difficulty.where(description: @answers[i + 3], practice: @practice).any?
-      end
-    end
   end
 end
 

--- a/lib/tasks/importer.rake
+++ b/lib/tasks/importer.rake
@@ -116,7 +116,6 @@ namespace :importer do
       risk_mitigations
       additional_staff
       additional_resources
-      required_training_staff
       costs_difficulties
       impact_photos
       domains
@@ -687,23 +686,6 @@ def additional_resources
     next if answer.blank?
 
     AdditionalResource.create(practice: @practice, description: answer) unless AdditionalResource.where(description: answer, practice: @practice).any?
-  end
-end
-
-def required_training_staff
-  puts "==> Importing Practice: #{@name} Required Training Staff".light_blue
-  @practice.required_staff_trainings.each(&:destroy)
-  question_fields = {
-      'Who is required to take the training?': 5
-  }
-
-  question_fields.each do |key, value|
-    q_index = @questions.index(key.to_s)
-
-    answer = @answers[q_index]
-    next if answer.blank?
-
-    RequiredStaffTraining.create(practice: @practice, title: answer) unless RequiredStaffTraining.where(title: answer, practice: @practice).any?
   end
 end
 

--- a/spec/models/cost_spec.rb
+++ b/spec/models/cost_spec.rb
@@ -1,7 +1,0 @@
-require 'rails_helper'
-
-RSpec.describe Cost, type: :model do
-  describe 'associations' do
-    it { should belong_to(:practice) }
-  end
-end

--- a/spec/models/difficulty_spec.rb
+++ b/spec/models/difficulty_spec.rb
@@ -1,7 +1,0 @@
-require 'rails_helper'
-
-RSpec.describe Difficulty, type: :model do
-  describe 'associations' do
-    it { should belong_to(:practice) }
-  end
-end

--- a/spec/models/practice_spec.rb
+++ b/spec/models/practice_spec.rb
@@ -29,7 +29,6 @@ RSpec.describe Practice, type: :model do
     it { should have_many(:practice_management_practices) }
     it { should have_many(:practice_managements) }
     it { should have_many(:publications) }
-    it { should have_many(:required_staff_trainings) }
     it { should have_many(:risk_mitigations) }
     it { should have_many(:practice_partner_practices) }
     it { should have_many(:practice_partners) }

--- a/spec/models/practice_spec.rb
+++ b/spec/models/practice_spec.rb
@@ -13,12 +13,10 @@ RSpec.describe Practice, type: :model do
     it { should have_many(:clinical_conditions) }
     it { should have_many(:clinical_location_practices) }
     it { should have_many(:clinical_locations) }
-    it { should have_many(:costs) }
     it { should have_many(:department_practices) }
     it { should have_many(:departments) }
     it { should have_many(:developing_facility_type_practices) }
     it { should have_many(:developing_facility_types) }
-    it { should have_many(:difficulties) }
     it { should have_many(:domain_practices) }
     it { should have_many(:domains) }
     it { should have_many(:financial_files) }

--- a/spec/models/required_staff_training_spec.rb
+++ b/spec/models/required_staff_training_spec.rb
@@ -1,7 +1,0 @@
-require 'rails_helper'
-
-RSpec.describe RequiredStaffTraining, type: :model do
-  describe 'associations' do
-    it { should belong_to(:practice) }
-  end
-end

--- a/spec/tasks/importer_spec.rb
+++ b/spec/tasks/importer_spec.rb
@@ -79,15 +79,6 @@ describe 'Importer' do
       expect(flow3.additional_resources.count).to be(1)
       expect(flow3.additional_resources.first.description).to eq('VISN-Wide Corporate Data Warehouse (CDW) Access')
 
-      # Costs
-      expect(flow3.costs.count).to be(2)
-      expect(flow3.costs.first.description).to eq('Minimal FTE')
-      expect(flow3.costs.last.description).to eq('Minimal sustainment cost')
-
-      # Difficulties?
-      # expect(flow3.difficulties.count).to be(1)
-      # expect(flow3.difficulties.first.description).to be(nil)
-
       # Domains
       expect(flow3.domains.count).to be(2)
       expect(flow3.domains.first.name).to eq('Veteran')

--- a/spec/tasks/importer_spec.rb
+++ b/spec/tasks/importer_spec.rb
@@ -79,10 +79,6 @@ describe 'Importer' do
       expect(flow3.additional_resources.count).to be(1)
       expect(flow3.additional_resources.first.description).to eq('VISN-Wide Corporate Data Warehouse (CDW) Access')
 
-      # Required Staff Training
-      expect(flow3.required_staff_trainings.count).to be(1)
-      expect(flow3.required_staff_trainings.first.title).to eq('Clinical Staff')
-
       # Costs
       expect(flow3.costs.count).to be(2)
       expect(flow3.costs.first.description).to eq('Minimal FTE')


### PR DESCRIPTION
### JIRA issue link
N/A

## Description - what does this code do?
- Drops more dead models associated with `Practices`: `RequiredStaffTrainings`, `Costs`, `Difficulties`
- Removes specs, importer workflows, associations, styles

## Testing done - how did you test it/steps on how can another person can test it 
- Review view and editor files; confirm these fields are no longer used
- Run the importer workflow and confirm it runs without error