### PR TITLE
dm-5200 product editor footer

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -113,20 +113,4 @@ class ProductsController < ApplicationController
     end
     params
   end
-
-  def update_category_practices
-    category_params = product_params[:category]
-
-    category_keys = category_params ? category_params.keys.map { |key| key.gsub("_resource", "") } : []
-    current_category_ids = @product.categories.pluck(:id)
-    product_category_practices = @product.category_practices
-
-    # Add new category practices if not present
-    (category_keys.map(&:to_i) - current_category_ids).each do |category_id|
-      product_category_practices.find_or_create_by(category_id: category_id)
-    end
-
-    # Remove category practices that are not in the submitted category keys
-    product_category_practices.joins(:category).where.not(categories: { id: category_keys }).destroy_all
-  end
 end

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -94,19 +94,6 @@ class ProductsController < ApplicationController
       @product.practice_multimedia.length != @product.practice_multimedia.reject(&:marked_for_destruction?).length
   end
 
-  def handle_multimedia_updates
-    multimedia_resources = multimedia_params["practice_multimedia_attributes"]
-    if multimedia_resources
-      multimedia_resources.each do |r|
-        if is_cropping?(r[1]) && r[1][:_destroy] == 'false' && r[1][:id].present?
-          r_id = r[1][:id].to_i
-          record = @product.practice_multimedia.find(r_id)
-          reprocess_attachment(record, r[1])
-        end
-      end
-    end
-  end
-
   def process_multimedia_params(params)
     PracticeMultimedium.resource_types.each do |rt|
       params['practice_multimedia_attributes']&.delete('RANDOM_NUMBER_OR_SOMETHING_' + rt[0])

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -94,6 +94,19 @@ class ProductsController < ApplicationController
       @product.practice_multimedia.length != @product.practice_multimedia.reject(&:marked_for_destruction?).length
   end
 
+  def handle_multimedia_updates
+    multimedia_resources = multimedia_params["practice_multimedia_attributes"]
+    if multimedia_resources
+      multimedia_resources.each do |r|
+        if is_cropping?(r[1]) && r[1][:_destroy] == 'false' && r[1][:id].present?
+          r_id = r[1][:id].to_i
+          record = @product.practice_multimedia.find(r_id)
+          reprocess_attachment(record, r[1])
+        end
+      end
+    end
+  end
+
   def process_multimedia_params(params)
     PracticeMultimedium.resource_types.each do |rt|
       params['practice_multimedia_attributes']&.delete('RANDOM_NUMBER_OR_SOMETHING_' + rt[0])

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -113,4 +113,20 @@ class ProductsController < ApplicationController
     end
     params
   end
+
+  def update_category_practices
+    category_params = product_params[:category]
+
+    category_keys = category_params ? category_params.keys.map { |key| key.gsub("_resource", "") } : []
+    current_category_ids = @product.categories.pluck(:id)
+    product_category_practices = @product.category_practices
+
+    # Add new category practices if not present
+    (category_keys.map(&:to_i) - current_category_ids).each do |category_id|
+      product_category_practices.find_or_create_by(category_id: category_id)
+    end
+
+    # Remove category practices that are not in the submitted category keys
+    product_category_practices.joins(:category).where.not(categories: { id: category_keys }).destroy_all
+  end
 end

--- a/app/helpers/navigation_helper.rb
+++ b/app/helpers/navigation_helper.rb
@@ -1,6 +1,16 @@
 module NavigationHelper
   RETURN_TO_TOP_PAGES = ['show', 'metrics', 'introduction', 'overview', 'implementation']
-  PRACTICE_EDITOR_PAGES = ['introduction', 'editors', 'overview', 'implementation', 'adoptions', 'about']
+  INNOVATION_EDITOR_PAGES = [
+    'introduction',
+    'editors',
+    'overview',
+    'implementation',
+    'adoptions',
+    'about',
+    'description',
+    'intrapreneur',
+    'multimedia'
+  ]
 
   def setup_breadcrumb_navigation
     session[:breadcrumbs] = session[:breadcrumbs] || []

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -9,6 +9,12 @@ class Product < Innovation
 
   after_update :update_date_published
 
+  PRODUCT_EDITOR_SLUGS =
+      {
+          'description': 'intrapreneur',
+          'intrapreneur': 'multimedia',
+      }
+
   extend FriendlyId
   friendly_id :name, use: :slugged
 

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -23,20 +23,34 @@ class Product < Innovation
   end
 
   def update_category_practices(category_params)
+    changed = false
+
     category_keys = category_params ? category_params.keys.map { |key| key.gsub("_resource", "") } : []
     current_category_ids = categories.pluck(:id)
     product_category_practices = category_practices
 
     # Add new category practices if not present
-    (category_keys.map(&:to_i) - current_category_ids).each do |category_id|
-      product_category_practices.find_or_create_by(category_id: category_id)
+    missing_category_ids = category_keys.map(&:to_i) - current_category_ids
+    missing_category_ids.delete(0) if missing_category_ids.count
+    if missing_category_ids.any?
+      missing_category_ids.each do |category_id|
+        product_category_practices.create!(category_id: category_id)
+      end
+      changed = true
     end
 
     # Remove category practices that are not in the submitted category keys
-    product_category_practices.joins(:category).where.not(categories: { id: category_keys }).destroy_all
+    practices_to_remove = product_category_practices.joins(:category).where.not(categories: { id: category_keys })
+    if practices_to_remove.any?
+      practices_to_remove.destroy_all
+      changed = true
+    end
+
+    changed
   end
 
   def update_multimedia(multimedia_params)
+    changed = false
     multimedia_resources = multimedia_params["practice_multimedia_attributes"]
     if multimedia_resources
       multimedia_resources.each do |r|
@@ -44,9 +58,11 @@ class Product < Innovation
           r_id = r[1][:id].to_i
           record = practice_multimedia.find(r_id)
           reprocess_attachment(record, r[1])
+          changed = true
         end
       end
     end
+    changed
   end
 
   private

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -43,7 +43,8 @@
   <body <% if content_for?(:body_attributes) %>
           <%= yield(:body_attributes) %>
         <% end %> class="<%= yield(:body_classes) %>">
-    <% is_practice_editor = params[:controller] === 'practices' && (NavigationHelper::PRACTICE_EDITOR_PAGES.include?(params[:action]) || params[:action] === 'metrics') %>
+    <% is_practice_editor = params[:controller] === 'practices' && (NavigationHelper::INNOVATION_EDITOR_PAGES.include?(params[:action]) || params[:action] === 'metrics') %>
+    <% is_product_editor = params[:controller] === 'products' && NavigationHelper::INNOVATION_EDITOR_PAGES.include?(params[:action]) %>
     <%= render 'shared/header' unless is_practice_editor %>
     <%= render 'practices/shared/practice_editor_header' if is_practice_editor %>
     <main
@@ -55,8 +56,8 @@
       <% end %>
       <%= yield %>
     </main>
-    <%= render 'shared/footer' unless is_practice_editor %>
-    <%= render 'practices/shared/practice_editor_footer' if is_practice_editor %>
+    <%= render 'shared/footer' unless (is_practice_editor || is_product_editor) %>
+    <%= render 'practices/shared/practice_editor_footer' if (is_practice_editor || is_product_editor) %>
 
     <% if current_user.present? %>
       <%= render partial: 'shared/terms_and_conditions_modal' %>

--- a/app/views/practices/shared/_practice_editor_footer.html.erb
+++ b/app/views/practices/shared/_practice_editor_footer.html.erb
@@ -1,30 +1,47 @@
 <%
-  path_options = {
-    editors: {
-      back: nil,
-      continue: practice_introduction_path(@practice)
-    },
-    introduction: {
-      back: practice_editors_path(@practice),
-      continue: practice_adoptions_path(@practice)
-    },
-    adoptions: {
-      back: practice_introduction_path(@practice),
-      continue: practice_overview_path(@practice)
-    },
-    overview: {
-      back: practice_adoptions_path(@practice),
-      continue: practice_implementation_path(@practice)
-    },
-    implementation: {
-      back: practice_overview_path(@practice),
-      continue: practice_about_path(@practice)
-    },
-    about: {
-      back: practice_implementation_path(@practice),
-      continue: nil
+  if @practice
+    path_options = {
+      editors: {
+        back: nil,
+        continue: practice_introduction_path(@practice)
+      },
+      introduction: {
+        back: practice_editors_path(@practice),
+        continue: practice_adoptions_path(@practice)
+      },
+      adoptions: {
+        back: practice_introduction_path(@practice),
+        continue: practice_overview_path(@practice)
+      },
+      overview: {
+        back: practice_adoptions_path(@practice),
+        continue: practice_implementation_path(@practice)
+      },
+      implementation: {
+        back: practice_overview_path(@practice),
+        continue: practice_about_path(@practice)
+      },
+      about: {
+        back: practice_implementation_path(@practice),
+        continue: nil
+      }
     }
-  }
+  else
+    path_options = {
+      description: {
+        back: nil,
+        continue: product_intrapreneur_path(@product)
+      },
+      intrapreneur: {
+        back: product_description_path(@product),
+        continue: product_multimedia_path(@product)
+      },
+      multimedia: {
+        back: product_intrapreneur_path(@product),
+        continue: nil
+      }
+    }
+  end
 %>
 
 <footer class="practice-editor-footer <%= yield(:footer_classes) %>">

--- a/app/views/practices/shared/_practice_editor_header.html.erb
+++ b/app/views/practices/shared/_practice_editor_header.html.erb
@@ -42,7 +42,7 @@
       <div class="grid-col-6">
         <ul class="usa-nav__primary usa-accordion">
           <li class="usa-nav__primary-item">
-            <%= link_to 'Edit your innovation', practice_editors_path(@practice), class: "margin-right-3 margin-y-2px desktop-lg:margin-y-0 usa-nav__link #{'usa-current' if NavigationHelper::PRACTICE_EDITOR_PAGES.include?(params[:action]) }" %>
+            <%= link_to 'Edit your innovation', practice_editors_path(@practice), class: "margin-right-3 margin-y-2px desktop-lg:margin-y-0 usa-nav__link #{'usa-current' if NavigationHelper::INNOVATION_EDITOR_PAGES.include?(params[:action]) }" %>
           </li>
           <li class="usa-nav__primary-item">
             <a href="#dm-editing-guide-modal" class="margin-right-3 margin-y-2px desktop-lg:margin-y-0 usa-nav__link" aria-controls="dm-editing-guide-modal" data-open-modal>Editing guide</a>

--- a/app/views/products/form/description.html.erb
+++ b/app/views/products/form/description.html.erb
@@ -128,10 +128,6 @@
             </div>
 
             <%= f.hidden_field :submitted_page, value: request.original_url.split('/').last %>
-            <!-- Remove once footer with submit button is implemented -->
-            <div class="margin-top-4">
-              <%= f.submit 'Submit', class: 'usa-button usa-button--primary' %>
-            </div>
           </fieldset>
         <% end %>
       </section>

--- a/app/views/products/form/intrapreneur.html.erb
+++ b/app/views/products/form/intrapreneur.html.erb
@@ -92,10 +92,6 @@
               </div>
 
             <%= f.hidden_field :submitted_page, value: request.original_url.split('/').last %>
-
-            <div class="margin-top-4">
-              <%= f.submit 'Submit', class: 'usa-button usa-button--primary' %>
-            </div>
           </fieldset>
         <% end %>
       </section>

--- a/spec/factories/products.rb
+++ b/spec/factories/products.rb
@@ -58,10 +58,10 @@ FactoryBot.define do
 
     trait :with_va_employees do
       after(:create) do |product|
-        create_list(:va_employee, 3).each do |va_employee|
+        create_list(:va_employee, 3).each do |va_e|
           VaEmployeePractice.create(
             innovable: product,
-            va_employee: va_employee
+            va_employee: va_e
           )
         end
       end

--- a/spec/features/product_editor/description_spec.rb
+++ b/spec/features/product_editor/description_spec.rb
@@ -35,7 +35,7 @@ describe 'Product editor - description', type: :feature do
       expect(page).to have_content('Description')
 
       fill_in 'product_name', with: 'Updated Product Name'
-      click_button 'Submit'
+      click_link 'Save and continue'
 
       expect(page).to have_content('Product was successfully updated.')
       expect(product.reload.name).to eq('Updated Product Name')
@@ -45,7 +45,7 @@ describe 'Product editor - description', type: :feature do
       visit product_description_path(product)
 
       fill_in 'product_name', with: ''
-      click_button 'Submit'
+      click_link 'Save and continue'
       expect(page).to have_current_path(product_description_path(product))
       expect(page).to have_selector("input:invalid")
     end
@@ -55,7 +55,7 @@ describe 'Product editor - description', type: :feature do
       visit product_description_path(new_product)
 
       fill_in 'product_name', with: product.name
-      click_button 'Submit'
+      click_link 'Save and continue'
       expect(page).to have_current_path(product_description_path(new_product))
       expect(page).to have_content('Product name already exists')
     end
@@ -74,7 +74,8 @@ describe 'Product editor - description', type: :feature do
         find('.usa-checkbox__label[title="Test Category 2"]').click
         expect(find("#cat-all-clinical-input", visible: false)).to be_checked
       end
-      click_button 'Submit'
+
+      click_link 'Save and continue'
 
       expect(product.categories).to include(cat1, cat2)
 
@@ -88,7 +89,7 @@ describe 'Product editor - description', type: :feature do
         expect(find("#cat-3-input", visible: false)).to be_checked
         expect(find("#cat-all-clinical-input", visible: false)).to_not be_checked
       end
-      click_button 'Submit'
+      click_link 'Save and continue'
 
       expect(product.categories).to include(cat2)
       expect(product.categories).to_not include(cat1)

--- a/spec/features/product_editor/intrapreneur_spec.rb
+++ b/spec/features/product_editor/intrapreneur_spec.rb
@@ -51,9 +51,11 @@ describe 'Product editor - intrapreneur details', type: :feature do
           all('.va-employee-role').last.set('New Role')
         end
 
-        click_button 'Submit'
+        click_link "Save and continue"
         new_va_employee = product.va_employees.last
         expect(page).to have_content('Product was successfully updated.')
+        expect(page).to have_current_path(product_multimedia_path(product))
+        visit product_intrapreneur_path(product)
         expect(page).to have_field("product_va_employees_attributes_#{new_va_employee.id - 1}_name", with: new_va_employee.name)
         expect(page).to have_field("product_va_employees_attributes_#{new_va_employee.id - 1}_role", with: new_va_employee.role)
       end
@@ -63,9 +65,11 @@ describe 'Product editor - intrapreneur details', type: :feature do
 
         fill_in "product_va_employees_attributes_0_name", with: 'Updated Name'
         fill_in "product_va_employees_attributes_0_role", with: 'Updated Role'
-        click_button 'Submit'
+        click_link "Save and continue"
         va_employee = product.va_employees.first
         expect(page).to have_content('Product was successfully updated.')
+        expect(page).to have_current_path(product_multimedia_path(product))
+        visit product_intrapreneur_path(product)
         expect(page).to have_field("product_va_employees_attributes_#{va_employee.id - 1}_name", with: 'Updated Name')
         expect(page).to have_field("product_va_employees_attributes_#{va_employee.id - 1}_role", with: 'Updated Role')
       end
@@ -76,7 +80,7 @@ describe 'Product editor - intrapreneur details', type: :feature do
         within '#innovators-container' do
           all('a', text: 'Delete entry').last.click
         end
-        click_button 'Submit'
+        click_link "Save and continue"
 
         expect(page).to have_content('Product was successfully updated.')
         expect(product.va_employees.count).to eq(2)
@@ -86,9 +90,11 @@ describe 'Product editor - intrapreneur details', type: :feature do
         visit product_intrapreneur_path(product)
 
         fill_in 'product_origin_story', with: 'Updated text'
-        click_button 'Submit'
+        click_link "Save and continue"
 
         expect(page).to have_content('Product was successfully updated.')
+        expect(page).to have_current_path(product_multimedia_path(product))
+        visit product_intrapreneur_path(product)
         expect(page).to have_field("product_origin_story", with: 'Updated text')
       end
     end

--- a/spec/features/product_editor/multimedia_spec.rb
+++ b/spec/features/product_editor/multimedia_spec.rb
@@ -59,6 +59,7 @@ describe 'Product editor - multimedia details', type: :feature do
         click_button 'Add image'
         click_button 'Submit'
         expect(page).to have_content('Product was successfully updated.')
+        visit product_multimedia_path(product)
         expect(page).to have_field("practice[practice_multimedia_attributes][1_image][name]", with: 'Test Image')
         expect(page).to have_selector("img[src*='acceptable_img.jpg']")
       end
@@ -72,6 +73,7 @@ describe 'Product editor - multimedia details', type: :feature do
         click_button 'Add video'
         click_button 'Submit'
         expect(page).to have_content('Product was successfully updated.')
+        visit product_multimedia_path(product)
         expect(page).to have_field("practice[practice_multimedia_attributes][1_video][name]", with: 'Test Video')
         expect(page).to have_field("practice[practice_multimedia_attributes][1_video][link_url]", with: 'https://www.youtube.com/watch?v=example')
       end
@@ -83,6 +85,7 @@ describe 'Product editor - multimedia details', type: :feature do
         click_button 'Submit'
 
         expect(page).to have_content('Product was successfully updated.')
+        visit product_multimedia_path(product)
         expect(page).to have_field("practice[practice_multimedia_attributes][0_image][name]", with: 'Updated Media Name')
       end
 


### PR DESCRIPTION
### JIRA issue link
https://agile6.atlassian.net/jira/software/c/projects/DM/boards/22?assignee=712020%3A6d33742e-4379-4071-bed6-7036f39efe97&selectedIssue=DM-5200

## Description - what does this code do?
adds footer (re-uses the practice footer) for product editor workflow, note: the "Submit" button is still available at the bottom of the `/multimedia` page, once the header is in place with a submit button this can be removed

## Testing done - how did you test it/steps on how can another person can test it 
1. Go through the product editor and verify that all fields are updatable and persist as expected upon clicking the "Save and continue"
2. Upon clicking the "Save and continue" button you should be nav'd to the next page in the editor workflow, if you made any changes it should display a success flash at the top of the form, if no changes were made then no success flash should appear. Submitting the last page will nav to the product show page.
3. Verify the "Back" buttons in the footer on the `/intrapreneur` and `/multimedia` pages work as expected.

## Screenshots, Gifs, Videos from application (if applicable)
![Screenshot 2024-09-27 at 11 45 56 AM](https://github.com/user-attachments/assets/1a6bd673-39ef-4c96-b034-767329414eeb)

## Link to mock-ups/mock ups (image file if you have it) (if applicable)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Unit tests written (if applicable)
- [ ] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating JIRA issue
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs