### PR TITLE
DM-5220: Add siderail with Tags to Product page

### DIFF
--- a/app/assets/stylesheets/dm/components/_tags.scss
+++ b/app/assets/stylesheets/dm/components/_tags.scss
@@ -22,7 +22,13 @@
   @include u-padding-y('05');
 }
 
-
+// Product / Editor page tags
+.show-page-tag {
+  @extend .usa-tag;
+  @include transition-btn-colors;
+  @include u-text('uppercase');
+  @include u-text('semibold');
+}
 
 // CUSTOM TAGS
 .dm-tag--big--action-primary {

--- a/app/assets/stylesheets/dm/pages/_products.scss
+++ b/app/assets/stylesheets/dm/pages/_products.scss
@@ -1,4 +1,24 @@
-.products.show-main {
+#main-content.products.show-main {
+	#show-page-siderail { // TO DO: extract this after migrating practices template
+		.desktop-tags {
+			display: none;
+			border: 1px solid color($theme-color-base-lighter);
+			@include u-radius('lg');
+			@include u-padding-x(3);
+			@include u-padding-bottom(2);
+			@include at-media(tablet) {
+	      		display: none;
+	      	}
+	    	@include at-media(desktop) {
+	        	display: block;
+	    	}
+		}
+		.show-page-tag {
+			display: block;
+			width: fit-content;
+		}
+	}
+
 	#practice-show-intrapreneur {
 		.origin-story p {
 			margin-bottom: 0.5rem;

--- a/app/controllers/practices_controller.rb
+++ b/app/controllers/practices_controller.rb
@@ -39,7 +39,7 @@ class PracticesController < ApplicationController # rubocop:disable Metrics/Clas
   # GET /innovations/1
   # GET /practices/1.json
   def show
-    @search_terms = Naturalsorter::Sorter.sort(@practice.categories.get_category_names.sort, true)
+    @search_terms = @practice.categories.get_category_names
     # This allows comments thread to show up without the need to click a link
     commontator_thread_show(@practice)
     diffusion_histories = @practice.diffusion_histories

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -19,7 +19,7 @@ class ProductsController < ApplicationController
   end
 
   def show
-    @search_terms = @product.categories.pluck(:name)
+    @search_terms = @product.categories.get_category_names
     render 'products/show'
   end
 

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -13,13 +13,13 @@ class ProductsController < ApplicationController
     render 'products/form/intrapreneur'
   end
 
-
   def multimedia
     @show_return_to_top = true
     render 'products/form/multimedia'
   end
 
   def show
+    @search_terms = @product.categories.pluck(:name)
     render 'products/show'
   end
 

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -14,7 +14,7 @@ class Category < ApplicationRecord
 
   scope :with_practices,   -> { not_none.joins(:innovable_practices).where(practices: {approved: true, published: true, enabled: true} ).order_by_name.uniq }
   scope :order_by_name, -> { order(Arel.sql("lower(categories.name) ASC")) }
-  scope :not_none, -> { where.not('LOWER(name) = ?', 'none') }
+  scope :not_none, -> { where.not('LOWER(categories.name) = ?', 'none') }
   scope :get_category_by_name, -> (cat_name) { where('lower(name) = ?', cat_name.downcase) }
   scope :get_category_names, -> { not_none.order(:name).pluck(:name) }
 

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -14,7 +14,7 @@ class Category < ApplicationRecord
 
   scope :with_practices,   -> { not_none.joins(:innovable_practices).where(practices: {approved: true, published: true, enabled: true} ).order_by_name.uniq }
   scope :order_by_name, -> { order(Arel.sql("lower(categories.name) ASC")) }
-  scope :not_none, -> { where.not(name: 'None').where.not(name: 'none') }
+  scope :not_none, -> { where.not('LOWER(name) = ?', 'none') }
   scope :get_category_by_name, -> (cat_name) { where('lower(name) = ?', cat_name.downcase) }
   scope :get_category_names, -> { not_none.order(:name).pluck(:name) }
 

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -16,7 +16,7 @@ class Category < ApplicationRecord
   scope :order_by_name, -> { order(Arel.sql("lower(categories.name) ASC")) }
   scope :not_none, -> { where.not(name: 'None').where.not(name: 'none') }
   scope :get_category_by_name, -> (cat_name) { where('lower(name) = ?', cat_name.downcase) }
-  scope :get_category_names, -> { not_none.pluck(:name) }
+  scope :get_category_names, -> { not_none.order(:name).pluck(:name) }
 
   attr_accessor :related_terms_raw
   attr_accessor :reset_cached_categories

--- a/app/views/practices/show/desktop_partials/_search_terms.html.erb
+++ b/app/views/practices/show/desktop_partials/_search_terms.html.erb
@@ -1,5 +1,5 @@
-<div>
-  <h5 class="font-sans-3xs margin-bottom-2 text-bold">TAGS:</h5>
+<div class="desktop-tags">
+  <h3 class="usa-prose-h4 margin-bottom-2 text-bold">Tags:</h5>
   <% if search_terms.count > 10 %>
     <% search_terms[0..9].each do |term| %>
       <%= render partial: 'practices/show/search_terms/category', locals: {term: term} %>

--- a/app/views/practices/show/search_terms/_category.html.erb
+++ b/app/views/practices/show/search_terms/_category.html.erb
@@ -1,5 +1,5 @@
 <a
-  class="usa-tag text-uppercase text-semibold"
+  class="show-page-tag"
   href="/search?category=<%= term %>">
   <%= term %>
 </a>

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -41,10 +41,10 @@
 			<% product_description_fields = [
 				[:description, "Executive Summary"],
 				[:main_display_image, "Main Product Image", {heading: false}], # replace this with partial to render
+				[:practice_partners, "Partners", {content: @product&.practice_partners.pluck(:name).join(', ')}],
 				[:item_number, "Item Number"],
 				[:vendor, "Vendor", {content: @product.vendor_link.present? ? link_to(@product.vendor, @product.vendor_link, class: ".usa-link .usa-link--external") : @product.vendor }],
 				[:duns, "DUNS"],
-				[:practice_partners, "Partners", {content: @product&.practice_partners.pluck(:name).join(', ')}],
 				[:shipping_timeline_estimate, "Shipping Timeline Estimate"]
 			] %>
 			<% product_description_fields.each do |arr| %>

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -1,3 +1,10 @@
+<% provide :head_tags do %>
+  <%= javascript_include_tag 'practice_page', 'data-turbolinks-track': 'reload' %>
+  <%= javascript_tag 'data-turbolinks-track': 'reload' do %>
+    <% #TO DO: create separate tracking for productsrender partial: 'practices/show/ahoy_event_tracking', formats: [:js] if current_user.present? %>
+  <% end %>
+<% end %>
+
 <section class="padding-y-0 margin-bottom-1 margin-top-0">
   <div class="grid-container position-relative">
     <div class="grid-row grid-gap">
@@ -9,93 +16,104 @@
   </div>
 </section>
 
-<section id="pr-view-introduction" class="grid-container margin-bottom-3">
-	<div class="grid-row grid-gap-2">
-		<div class="desktop:grid-col-8 grid-col-12">
-		      <h1 class="margin-top-0 margin-bottom-1 dm-word-break-break-word dm-hyphens-auto">
-		      	<%= @product.name %>
-		      </h1>
-		      <%# innovation last update timestamp %>
-		      <p class="grid-col-12 font-sans-3xs text-base line-height-sans-4 margin-bottom-2">
-		        Last updated <%= timeago(@product&.updated_at) %>
-		      </p>
-		</div>
+<div class="grid-container grid-row">
+	<div id="show-page-siderail" class="grid-col-12 tablet:grid-col-3">
+		<% if @search_terms.any? %>
+	        <%= render partial: 'practices/show/desktop_partials/search_terms', locals: { search_terms: @search_terms } %>
+	  <% end %>
 	</div>
-</section>
-
-<section id="practice-show-product-description" class="grid-container">
-	<h2>Product Description</h2>
-	<% product_description_fields = [
-		[:description, "Executive Summary"],
-		[:main_display_image, "Main Product Image", {heading: false}], # replace this with partial to render
-		[:item_number, "Item Number"],
-		[:vendor, "Vendor", {content: @product.vendor_link.present? ? link_to(@product.vendor, @product.vendor_link, class: ".usa-link .usa-link--external") : @product.vendor }],
-		[:duns, "DUNS"],
-		[:practice_partners, "Partners", {content: @product&.practice_partners.pluck(:name).join(', ')}],
-		[:shipping_timeline_estimate, "Shipping Timeline Estimate"]
-	] %>
-	<% product_description_fields.each do |arr| %>
-		<%	field_name, field_label, field_options = arr %>
-		<% if field_options&.present? %>
-			<% if field_name == :main_display_image && @product.main_display_image.exists? %>
-				<%= render partial: 'main_display_image', locals: { product: @product} %>
-			<% else %>
-				<%= tag.h3 field_label, class: 'font-sans-lg line-height-25px margin-top-2 margin-bottom-1' unless field_options[:heading] == false %>
-				<%= tag.p field_options[:content] %>
+	<div class="grid-col-12 tablet:grid-col-9">
+		<section id="pr-view-introduction" class="grid-container margin-bottom-3">
+			<div class="grid-row grid-gap-2">
+				<div class="desktop:grid-col-8 grid-col-12">
+				      <h1 class="margin-top-0 margin-bottom-1 dm-word-break-break-word dm-hyphens-auto">
+				      	<%= @product.name %>
+				      </h1>
+				      <%# innovation last update timestamp %>
+				      <p class="grid-col-12 font-sans-3xs text-base line-height-sans-4 margin-bottom-2">
+				        Last updated <%= timeago(@product&.updated_at) %>
+				      </p>
+				</div>
+			</div>
+		</section>
+		<section id="practice-show-product-description" class="grid-container">
+			<h2>Product Description</h2>
+			<% product_description_fields = [
+				[:description, "Executive Summary"],
+				[:main_display_image, "Main Product Image", {heading: false}], # replace this with partial to render
+				[:item_number, "Item Number"],
+				[:vendor, "Vendor", {content: @product.vendor_link.present? ? link_to(@product.vendor, @product.vendor_link, class: ".usa-link .usa-link--external") : @product.vendor }],
+				[:duns, "DUNS"],
+				[:practice_partners, "Partners", {content: @product&.practice_partners.pluck(:name).join(', ')}],
+				[:shipping_timeline_estimate, "Shipping Timeline Estimate"]
+			] %>
+			<% product_description_fields.each do |arr| %>
+				<%	field_name, field_label, field_options = arr %>
+				<% if field_options&.present? %>
+					<% if field_name == :main_display_image && @product.main_display_image.exists? %>
+						<%= render partial: 'main_display_image', locals: { product: @product} %>
+					<% else %>
+						<%= tag.h3 field_label, class: 'font-sans-lg line-height-25px margin-top-2 margin-bottom-1' unless field_options[:heading] == false %>
+						<%= tag.p field_options[:content] %>
+					<% end %>
+				<% else # default fields %>
+					<% next if @product.send(field_name.to_sym).blank? %>
+					<h3 class="font-sans-lg line-height-25px margin-top-2 margin-bottom-1"><%= field_label %></h3>
+					<p><%= @product.send(field_name.to_sym) %></p>
+				<% end %>
 			<% end %>
-		<% else # default fields %>
-			<% next if @product.send(field_name.to_sym).blank? %>
-			<h3 class="font-sans-lg line-height-25px margin-top-2 margin-bottom-1"><%= field_label %></h3>
-			<p><%= @product.send(field_name.to_sym) %></p>
+		</section>
+		<section id="practice-show-intrapreneur" class="grid-container">
+			<h2>Intrapreneur</h2>
+			<h3><%= 'Innovator'.pluralize(@product.va_employee_practices.count) %></h3>
+			<% @product.va_employee_practices.each do |innovator| %>
+				<div class="innovators margin-bottom-1">
+				<p><%= innovator.va_employee&.name %></p>
+				<p class="text-italic"><%= innovator.va_employee&.role %></p>
+				</div>
+			<% end %>
+			<h3>From the Innovator</h3>
+			<div class="origin-story"><%= simple_format(@product.origin_story, wrapper_tag: "p") %></div>
+		</section>
+		<% if @product.practice_multimedia.any? %>
+		  <section id="practice-show-multimedia" class="margin-bottom-5 grid-container">
+		    <div class="grid-row grid-gap-2">
+		      <div class="desktop:grid-col-9 grid-col-12">
+		      	<h2>Multimedia</h2><span>TO DO: fix partial to fix different heading levels</span>
+		        <div class="multimedia-section practice-section">
+		        	<% # temporarily skip files while troubleshooting %>
+		        	<% multimedia = @product.practice_multimedia.where.not(resource_type: "file") %>
+		          <%= render partial: 'practices/show/overview/overview_sections', locals: {resources: multimedia, statement: '', title: 'Multimedia', s_area: 'multimedia'} %>
+		        </div>
+		      </div>
+		    </div>
+		  </section>
 		<% end %>
+		<section id="practice-show-order-instructions" class="grid-container">
+			<h2>Order Product</h2>
+			<ol class="usa-process-list">
+			  <li class="usa-process-list__item">
+			    <h4 class="usa-process-list__heading">Order from the Marketplace</h4>
+			    <p class="margin-top-05">
+			      VA employees wishing to order a product should copy and paste the details under the "Order" tab and send it to their usual service-line purchasing agent. If the order is above the purchase card threshold, contact <a class="usa-link" href="mailto:VAIMPSupport@va.gov">VAIMPSupport@va.gov</a>for information on contracting with the vendor. VA employees cannot order directly from the manufacturer unless they are authorized to do so.
+			    </p>
+			  </li>
+			  <li class="usa-process-list__item">
+			    <h4 class="usa-process-list__heading">Obtain a Completed VA Form 1091</h4>
+			    <p>
+			      For first-time purchases from a vendor, contact <a class="usa-link" href="mailto:VAIPMVendorizationRequest@va.gov">VAIPMVendorizationRequest@va.gov</a> to obtain a copy of the completed VA Form 10091 (FSC Vendor File Request Form).
+			    </p>
+			  </li>
+			  <li class="usa-process-list__item">
+			    <h4 class="usa-process-list__heading">Request a Local Vendor Number</h4>
+			    <p>
+			      Follow your local vendorization process to request the assignment of a local vendor number.
+			    </p>
+			  </li>
+			</ol>
+		</section>
+		<% if @search_terms.present? %>
+	  <%= render partial: 'practices/show/mobile_partials/search_terms', locals: { search_terms: @search_terms } %>
 	<% end %>
-</section>
-<section id="practice-show-intrapreneur" class="grid-container">
-	<h2>Intrapreneur</h2>
-	<h3><%= 'Innovator'.pluralize(@product.va_employee_practices.count) %></h3>
-	<% @product.va_employee_practices.each do |innovator| %>
-		<div class="innovators margin-bottom-1">
-		<p><%= innovator.va_employee&.name %></p>
-		<p class="text-italic"><%= innovator.va_employee&.role %></p>
-		</div>
-	<% end %>
-	<h3>From the Innovator</h3>
-	<div class="origin-story"><%= simple_format(@product.origin_story, wrapper_tag: "p") %></div>
-</section>
-<% if @product.practice_multimedia.any? %>
-  <section id="practice-show-multimedia" class="margin-bottom-5 grid-container">
-    <div class="grid-row grid-gap-2">
-      <div class="desktop:grid-col-9 grid-col-12">
-      	<h2>Multimedia</h2><span>TO DO: fix partial to fix different heading levels</span>
-        <div class="multimedia-section practice-section">
-        	<% # temporarily skip files while troubleshooting %>
-        	<% multimedia = @product.practice_multimedia.where.not(resource_type: "file") %>
-          <%= render partial: 'practices/show/overview/overview_sections', locals: {resources: multimedia, statement: '', title: 'Multimedia', s_area: 'multimedia'} %>
-        </div>
-      </div>
-    </div>
-  </section>
-<% end %>
-<section id="practice-show-order-instructions" class="grid-container">
-	<h2>Order Product</h2>
-	<ol class="usa-process-list">
-	  <li class="usa-process-list__item">
-	    <h4 class="usa-process-list__heading">Order from the Marketplace</h4>
-	    <p class="margin-top-05">
-	      VA employees wishing to order a product should copy and paste the details under the "Order" tab and send it to their usual service-line purchasing agent. If the order is above the purchase card threshold, contact <a class="usa-link" href="mailto:VAIMPSupport@va.gov">VAIMPSupport@va.gov</a>for information on contracting with the vendor. VA employees cannot order directly from the manufacturer unless they are authorized to do so.
-	    </p>
-	  </li>
-	  <li class="usa-process-list__item">
-	    <h4 class="usa-process-list__heading">Obtain a Completed VA Form 1091</h4>
-	    <p>
-	      For first-time purchases from a vendor, contact <a class="usa-link" href="mailto:VAIPMVendorizationRequest@va.gov">VAIPMVendorizationRequest@va.gov</a> to obtain a copy of the completed VA Form 10091 (FSC Vendor File Request Form).
-	    </p>
-	  </li>
-	  <li class="usa-process-list__item">
-	    <h4 class="usa-process-list__heading">Request a Local Vendor Number</h4>
-	    <p>
-	      Follow your local vendorization process to request the assignment of a local vendor number.
-	    </p>
-	  </li>
-	</ol>
-</section>
+	</div>
+</div>

--- a/spec/factories/category_practices.rb
+++ b/spec/factories/category_practices.rb
@@ -2,8 +2,12 @@ FactoryBot.define do
   factory :category_practice do
     association :category
 
-    factory :category_practice_for_product do
+    trait :for_product do
       association :innovable, factory: :product
+    end
+
+    trait :for_practice do
+      association :innovable, factory: :practice
     end
   end
 end

--- a/spec/factories/category_practices.rb
+++ b/spec/factories/category_practices.rb
@@ -1,6 +1,9 @@
 FactoryBot.define do
   factory :category_practice do
     association :category
-    association :innovable, factory: :practice
+
+    factory :category_practice_for_product do
+      association :innovable, factory: :product
+    end
   end
 end

--- a/spec/factories/products.rb
+++ b/spec/factories/products.rb
@@ -67,5 +67,17 @@ FactoryBot.define do
         end
       end
     end
+
+    trait :with_tags do
+        sequence(:name) { |n| "Sample Product with Tags #{n}" }
+        after(:create) do |product|
+        create_list(:category, 11).each do |category|
+          CategoryPractice.create(
+            innovable: product,
+            category: category
+          )
+        end
+      end
+    end
   end
 end

--- a/spec/factories/products.rb
+++ b/spec/factories/products.rb
@@ -72,10 +72,7 @@ FactoryBot.define do
         sequence(:name) { |n| "Sample Product with Tags #{n}" }
         after(:create) do |product|
         create_list(:category, 11).each do |category|
-          CategoryPractice.create(
-            innovable: product,
-            category: category
-          )
+          create(:category_practice, :for_product, innovable: product, category: category)
         end
       end
     end

--- a/spec/features/practice_viewer/introduction_spec.rb
+++ b/spec/features/practice_viewer/introduction_spec.rb
@@ -191,7 +191,7 @@ describe 'Practice viewer - introduction', type: :feature, js: true do
     end
 
     it 'should take the user to the search page with results that match the category that was clicked on' do
-      all('.usa-tag').first.click
+      all('.show-page-tag').first.click
       expect(page).to have_current_path('/search?category=COVID')
       expect(page).to have_selector('#search-page', visible: true)
       expect(page).to have_content('2 Results')

--- a/spec/features/product_viewer_spec.rb
+++ b/spec/features/product_viewer_spec.rb
@@ -2,7 +2,8 @@ require 'rails_helper'
 
 describe 'Product show page', type: :feature do
   let!(:product) { create(:product)}
-  let!(:product_with_images) { create(:product, :with_image, :with_multimedia, name: 'Product with Images', published: true) }
+  let(:product_with_images) { create(:product, :with_image, :with_multimedia, name: 'Product with Images', published: true) }
+  let(:product_with_tags) { create(:product, :with_tags, published: true) }
   let!(:user) { create(:user) }
   let!(:admin) { create(:user, :admin)}
 
@@ -52,6 +53,14 @@ describe 'Product show page', type: :feature do
     within('.multimedia-section') do
       expect(page).to have_css('.practice-editor-impact-photo')
       expect(page).to have_css('.video-container')
+    end
+  end
+
+  it 'renders associated categories / tags', js: true do
+    visit(product_path(product_with_tags))
+    within('#show-page-siderail') do
+      expect(page).to have_css('.show-page-tag', count: 10)
+      expect(page).to have_content(/See more/i)
     end
   end
 end


### PR DESCRIPTION
### JIRA issue link
[DM-5220](https://agile6.atlassian.net/browse/DM-5220)

## Description - what does this code do?
 - Adds a siderail to the Product show page
 - Create a class for the customized USWDS `Tags` used on the show pages to make it clearer these are modded components
 - Utilize existing practice page JS for see more / see less logic and showing the Tags section in different parts of the page. (Note: I've left this in the same file for now. I'll decide if all the functions can be in a shared partial after I've finished [DM-5069 for updating the in page nav](https://agile6.atlassian.net/browse/DM-5081))
 - Move `Partners` further up the page in response to client feedback / updated show page designs

## Testing done - how did you test it/steps on how can another person can test it 
1. Go to `/admin/products/` and choose a product to edit
2. Go to the product's description page and add 11 tags to it.
3. Go to the product's show page and confirm that a `See more` link is rendered and works as expected
4. Resize the page to tablet width. Confirm the tags disappear from the siderail (but the whitespace is maintained - this is where in-page nav will go later). The tags should now appear at the bottom of the show page.
5. Resize the page to mobile width. Confirm the tags are still showing at the bottom of the page. The siderail should no longer be there (e.g. the main product content should take up the whole width).

## Screenshots, Gifs, Videos from application (if applicable)
![Screenshot 2024-09-27 at 6 51 56 PM](https://github.com/user-attachments/assets/ddfc6b2b-3db4-4276-9a99-2ec9ff04e7ba)