### PR TITLE
Cache homepage features

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -7,7 +7,9 @@ class HomeController < ApplicationController
     @dropdown_categories = get_categories_by_popularity
     @dropdown_communities = get_categories_by_popularity(true)
     @dropdown_practices, @practice_names = get_dropdown_practices
-    @homepage = Homepage.where(published: true)&.first
+    @homepage = Rails.cache.fetch("homepage_with_features") do
+      Homepage.current
+    end
     if @homepage
       current_features = @homepage&.homepage_features
       @section_one_features = current_features&.where(section_id: 1)&.first(3)

--- a/app/models/homepage.rb
+++ b/app/models/homepage.rb
@@ -3,6 +3,9 @@ class Homepage < ApplicationRecord
   accepts_nested_attributes_for :homepage_features, allow_destroy: true
 
   before_save :unpublish_other_homepages, if: :published?
+  after_save :conditionally_clear_cache
+
+  scope :published, -> { where(published: true) }
 
   def unpublish_other_homepages
     # Unpublish all other homepages with published: true
@@ -15,5 +18,21 @@ class Homepage < ApplicationRecord
 
   def self.ransackable_attributes(auth_object = nil)
     []
+  end
+
+  def self.current
+    published.includes(:homepage_features).last
+  end
+
+  private
+
+  def conditionally_clear_cache
+    # Check if this instance is the currently published one
+    if self.published? && self == Homepage.current
+      Rails.cache.delete("homepage_with_features")
+    # Check if this instance was just changed to published:true
+    elsif saved_change_to_attribute?(:published, from: false, to: true)
+      Rails.cache.delete("homepage_with_features")
+    end
   end
 end


### PR DESCRIPTION
### JIRA issue link
[DM-5241](https://agile6.atlassian.net/browse/DM-5241)

## Description - what does this code do?
- Store the currently published homepage and its features in the Rails cache

## Testing done - how did you test it/steps on how can another person can test it 
Locally: 
1. Checkout `homepage-seeds` so it pulls data from `origin` (#1009). 
2. Switch back to this branch `git checkout homepage-caching`
3. Merge in-progress seeds file `git merge homepage-seeds`
4. Open the rails console and run `FactoryBot.create(:september_homepage)`.
5. Close the rails console and navigate to `/admin/homepages` and publish the homepage.
6. Visit the homepage.
7. Confirm the homepage and its features are stored in the Rails cache `Rails.cache.fetch("homepage_with_features")`.