### PR TITLE
Temporarily disable Communities dropdown preview for admins

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -13,7 +13,7 @@ class ApplicationController < ActionController::Base
   before_action :user_accepted_terms?
   before_action :set_visit_props
   before_action :set_visitor_props
-  before_action :set_communities_for_header
+  # before_action :set_communities_for_header
 
 
   def reload_turbolinks

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -80,14 +80,13 @@
           </button>
 
           <ul id="communities-dropdown" class="display-none usa-nav__submenu">
-            <% if @communities %>
-              <% @communities.each do |name, slug| %>
-                  <li class="usa-nav__submenu-item border-base-light">
-                    <a class="font-sans-sm desktop:font-sans-2xs margin-y-2px desktop:margin-y-0" href="/communities/<%= slug %>">
-                      <%=  name %>
-                    </a>
-                  </li>
-              <% end %>
+            <% communities = { "VA Immersive": "va-immersive", "Suicide Prevention": "suicide-prevention", "Age-Friendly": "age-friendly" } %>
+            <% communities.each do |name, slug| %>
+                <li class="usa-nav__submenu-item border-base-light">
+                  <a class="font-sans-sm desktop:font-sans-2xs margin-y-2px desktop:margin-y-0" href="/communities/<%= slug %>">
+                    <%=  name %>
+                  </a>
+                </li>
             <% end %>
           </ul>
         </li>

--- a/spec/features/shared/header_spec.rb
+++ b/spec/features/shared/header_spec.rb
@@ -117,7 +117,7 @@ describe 'Diffusion Marketplace header', type: :feature, js: true do
       end
     end
 
-    it 'shows in-progress communities to admins' do
+    xit 'shows in-progress communities to admins' do
       log_in_as_admin_and_visit_homepage
 
       click_on 'Communities'
@@ -131,7 +131,7 @@ describe 'Diffusion Marketplace header', type: :feature, js: true do
       end
     end
 
-    it 'shows soft-launched communities to VA users' do
+    xit 'shows soft-launched communities to VA users' do
       login_as(@non_admin, :scope => :user, :run_callbacks => false)
       visit('/')
 
@@ -146,7 +146,7 @@ describe 'Diffusion Marketplace header', type: :feature, js: true do
       end
     end
 
-    it 'shows in-progress communities to editors' do
+    xit 'shows in-progress communities to editors' do
       editor = create(:user)
       editor.add_role(:page_group_editor, @unpublished_community)
       login_as(editor, :scope => :user, :run_callbacks => false)


### PR DESCRIPTION
### JIRA issue link
[DM-5242](https://agile6.atlassian.net/browse/DM-5242)

## Description - what does this code do?
- Temporarily use hardcoding for Communities dropdown links to improve site performance. 

## Testing done - how did you test it/steps on how can another person can test it 
- Access the site as a public user and confirm the relevant communities are rendered in the dropdown

## Screenshots, Gifs, Videos from application (if applicable)
![Screenshot 2024-10-01 at 11 43 47 AM](https://github.com/user-attachments/assets/3d1ee2aa-ce76-4e79-a38c-1374023c4681)
