### PR TITLE
DM-5249: Update admin menu items

### DIFF
--- a/app/admin/adoptions.rb
+++ b/app/admin/adoptions.rb
@@ -1,6 +1,7 @@
 include ActiveAdminHelpers
 
 ActiveAdmin.register_page "Adoptions" do
+  menu false
   controller do
     helper_method :adoption_facility_name
     helper_method :adoption_date

--- a/app/admin/homepage.rb
+++ b/app/admin/homepage.rb
@@ -1,4 +1,5 @@
 ActiveAdmin.register Homepage do
+  menu label: "Homepage Editor"
   permit_params :internal_title,
                 :section_title_one,
                 :section_title_two,

--- a/app/admin/innovation_search_terms.rb
+++ b/app/admin/innovation_search_terms.rb
@@ -1,7 +1,8 @@
 include ActiveAdminHelpers
 
 ActiveAdmin.register_page 'Innovation Search Terms' do
-  menu label: proc {I18n.t('active_admin.innovation_search_terms')}
+  menu false
+  # menu label: proc {I18n.t('active_admin.innovation_search_terms')}
 
   controller do
     helper_method :set_date_values

--- a/app/admin/site_metrics.rb
+++ b/app/admin/site_metrics.rb
@@ -1,7 +1,8 @@
 include ActiveAdminHelpers
 
 ActiveAdmin.register_page 'Site Metrics' do
-  menu label: proc {I18n.t('active_admin.site_metrics')}
+  menu false
+  # menu label: proc {I18n.t('active_admin.site_metrics')}
 
   controller do
     helper_method :set_date_values

--- a/config/initializers/active_admin.rb
+++ b/config/initializers/active_admin.rb
@@ -125,7 +125,7 @@ ActiveAdmin.setup do |config|
   # This allows your users to comment on any resource registered with Active Admin.
   #
   # You can completely disable comments:
-  # config.comments = false
+  config.comments = false
   #
   # You can change the name under which comments are registered:
   # config.comments_registration_name = 'AdminComment'

--- a/spec/features/admin/admin_adoptions_spec.rb
+++ b/spec/features/admin/admin_adoptions_spec.rb
@@ -24,9 +24,7 @@ describe 'Admin Adoptions Tab', type: :feature do
   end
 
   it 'should show all adoptions and adoption counts for practices that have at least one adoption' do
-    visit '/admin'
-    click_link 'Adoptions'
-
+    go_to_adoptions
     expect(page).to have_selector("input[value='Download All']")
     expect(page).to have_selector('.panel', count: 2)
     expect(page).to have_content('CURRENT MONTH')
@@ -39,9 +37,7 @@ describe 'Admin Adoptions Tab', type: :feature do
   end
 
   it 'should show the total adoptions for all practices and adoptions made within a 3-month interval(current month, one month ago, two months ago)' do
-    visit '/admin'
-    click_link 'Adoptions'
-
+    go_to_adoptions
     expect(page).to have_content('All adoptions')
     within(:css, '.all-adoptions-columns') do
       current_month_el = all(".all-adoptions-current-month").last
@@ -57,12 +53,15 @@ describe 'Admin Adoptions Tab', type: :feature do
   end
 
   it 'should allow an admin to download adoption data as a .xlsx file' do
-    visit '/admin'
-    click_link 'Adoptions'
-    export_button = find(:css, "input[value='Download All']")
+    go_to_adoptions
+    export_button  find(:css, "input[value='Download All']")
     export_button.click
 
     # should not navigate away from metrics page
     expect(page).to have_current_path(admin_adoptions_path)
+  end
+
+  def go_to_adoptions
+    visit admin_adoptions_path
   end
 end

--- a/spec/features/admin/admin_spec.rb
+++ b/spec/features/admin/admin_spec.rb
@@ -110,20 +110,17 @@ describe 'The admin dashboard', type: :feature do
       expect(page).to be_accessible.according_to :wcag2a, :section508
 
       within(:css, '#header') do
-        click_link('Site Metrics')
-        expect(page).to have_current_path(admin_site_metrics_path)
+        # click_link('Site Metrics')
+        # expect(page).to have_current_path(admin_site_metrics_path)
 
         click_link('Tags')
         expect(page).to have_current_path(admin_categories_path)
 
-        click_link('Comments')
-        expect(page).to have_current_path(admin_comments_path)
-
         click_link('Departments')
         expect(page).to have_current_path(admin_departments_path)
 
-        click_link('Innovation Search Terms')
-        expect(page).to have_current_path(admin_innovation_search_terms_path)
+        # click_link('Innovation Search Terms')
+        # expect(page).to have_current_path(admin_innovation_search_terms_path)
 
         click_link('Innovation Views Leaderboard')
         expect(page).to have_current_path(admin_innovation_views_leaderboard_path)


### PR DESCRIPTION
### JIRA issue link
https://agile6.atlassian.net/browse/DM-5249

## Description - what does this code do?
- Remove admin menu items that are not being used / need to be refactored
- Disable ActiveAdmin comments feature (this is not the same as the `commontator` comments)

## Testing done - how did you test it/steps on how can another person can test it 
1. In PROD, review each of the removed menu items 
2. In local, review this branch and confirm the removed items are still accessible at their URL `e.g. `/admin/adoptions`)
