### PR TITLE
Add versioning to Homepages

### DIFF
--- a/app/models/homepage.rb
+++ b/app/models/homepage.rb
@@ -1,4 +1,5 @@
 class Homepage < ApplicationRecord
+  has_paper_trail
   has_many :homepage_features, dependent: :destroy
   accepts_nested_attributes_for :homepage_features, allow_destroy: true
 


### PR DESCRIPTION
### JIRA issue link
N/A

## Description - what does this code do?
- Add PaperTrail versioning to Homepages 

## Testing done - how did you test it/steps on how can another person can test it 
1. Log in as an admin user
2. Go to `/admin/homepages`
3. Create a homepage
4.  edit the page's internal title and save
5. In another terminal, open the rails console and check the `Homepage` responds to `versions` and records a user ID for `whodunnit`. 
```
rails console
Homepage.last.versions
```
