### PR TITLE
Clean up specs from disabled Communities navbar preview

### DIFF
--- a/spec/features/shared/header_spec.rb
+++ b/spec/features/shared/header_spec.rb
@@ -106,7 +106,19 @@ describe 'Diffusion Marketplace header', type: :feature, js: true do
   end
 
   describe 'Communities dropdown' do
-    it 'shows published communities to all users' do
+    it 'shows hard-coded communities to all users' do
+      click_on 'Communities'
+      within('#communities-dropdown') do
+        expect(page).to have_content('VA Immersive')
+        expect(page).to have_content('Suicide Prevention')
+        expect(page).to have_content('Age-Friendly')
+        expect(page).to have_link(href: '/communities/suicide-prevention')
+        expect(page).to have_link(href: '/communities/age-friendly')
+        expect(page).to have_link(href: '/communities/va-immersive')
+      end
+    end
+
+    xit 'shows published communities to all users' do
       click_on 'Communities'
       within('#communities-dropdown') do
         expect(page).to have_content('VA Immersive')


### PR DESCRIPTION
### JIRA issue link
N/A

## Description - what does this code do?
Cleans up CI by disabling a test. This feature was disabled to improve performance in #1055

