### PR TITLE
DM-5254: Add Products to homepage search dropdown

### DIFF
--- a/app/assets/javascripts/homepage_search_dropdown.es6
+++ b/app/assets/javascripts/homepage_search_dropdown.es6
@@ -126,7 +126,17 @@ function setupClickTracking(listSelector, eventName, dataAttribute) {
       const id = e.target.closest('.search-result').getAttribute(dataAttribute);
 
       let properties = { from_homepage: true};
-      properties[dataAttribute === 'data-practice-id' ? 'practice_name' : 'category_name'] = name;
+      switch(dataAttribute) {
+        case 'data-practice-id';
+          properties['practice_name'] = name;
+          break;
+        case 'data-product-id';
+          properties['product_name'] = name;
+          break;
+        default: // tags and communities-as-tags
+          properties['category_name'] = name;
+      }
+
       properties[dataAttribute.slice(5)] = parseInt(id); // Removes 'data-' and uses the rest as the key
 
       ahoy.track(eventName, properties);

--- a/app/assets/javascripts/homepage_search_dropdown.es6
+++ b/app/assets/javascripts/homepage_search_dropdown.es6
@@ -11,6 +11,9 @@ function setupSearchDropdown() {
     const allCommunities = JSON.parse($('.homepage-search').attr('data-communities') || '[]');
     const mostPopularCommunities = allCommunities.slice(0, 3);
 
+    const allProducts = JSON.parse($('.homepage-search').attr('data-products') || '[]');
+    const mostRecentProducts = allProducts.slice(0, 3);
+
     searchInput.focus(function() {
         dropdown.show();
         searchInput.attr('aria-expanded', 'true');
@@ -21,7 +24,8 @@ function setupSearchDropdown() {
         let filteredCategories = searchTerm ? allCategories.filter(category => category.name.toLowerCase().includes(searchTerm)).slice(0,3) : mostPopularCategories;
         let filteredInnovations = searchTerm ? allInnovations.filter(innovation => innovation.name.toLowerCase().includes(searchTerm)).slice(0,3) : mostRecentInnovations;
         let filteredCommunities = searchTerm ? allCommunities.filter(community => community.name.toLowerCase().includes(searchTerm)).slice(0,3) : mostPopularCommunities;
-        updateDropdown(filteredCategories, filteredInnovations, filteredCommunities);
+        let filteredProducts = searchTerm ? allProducts.filter(product => product.name.toLowerCase().includes(searchTerm)).slice(0,3) : mostRecentProducts;
+        updateDropdown(filteredCategories, filteredInnovations, filteredCommunities, filteredProducts);
     });
 
     $(document).keydown(function(e) {
@@ -56,8 +60,8 @@ function setupSearchDropdown() {
     });
 }
 
-function updateDropdown(categories, innovations, communities) {
-  $('#category-list, #practice-list, #community-list').empty();
+function updateDropdown(categories, innovations, communities, products) {
+  $('#category-list, #practice-list, #community-list, #product-list').empty();
 
   categories.forEach(function(category) {
       let link = $('<a></a>')
@@ -93,6 +97,18 @@ function updateDropdown(categories, innovations, communities) {
           .append(link);
 
       $('#community-list').append(listItem);
+  });
+
+  products.forEach(function(product) {
+      let link = $('<a></a>')
+          .attr('href', `/products/${product.slug}`)
+          .text(product.name);
+      let listItem = $('<li></li>')
+          .addClass('search-result')
+          .attr('data-product-id', product.id)
+          .append(link);
+
+      $('#product-list').append(listItem);
   });
 }
 
@@ -149,5 +165,6 @@ addEventListener('turbolinks:load', function () {
     setupClickTracking('#practice-list', "Dropdown Practice Link Clicked", 'data-practice-id');
     setupClickTracking('#category-list', "Category selected", 'data-category_id');
     setupClickTracking('#community-list', "Category selected", 'data-category_id');
+    setupClickTracking('#product-list', "Dropdown Product Link Clicked", 'data-product_id');
   }
 });

--- a/app/assets/javascripts/homepage_search_dropdown.es6
+++ b/app/assets/javascripts/homepage_search_dropdown.es6
@@ -175,6 +175,6 @@ addEventListener('turbolinks:load', function () {
     setupClickTracking('#practice-list', "Dropdown Practice Link Clicked", 'data-practice-id');
     setupClickTracking('#category-list', "Category selected", 'data-category_id');
     setupClickTracking('#community-list', "Category selected", 'data-category_id');
-    setupClickTracking('#product-list', "Dropdown Product Link Clicked", 'data-product_id');
+    setupClickTracking('#product-list', "Dropdown Product Link Clicked", 'data-product-id');
   }
 });

--- a/app/assets/javascripts/homepage_search_dropdown.es6
+++ b/app/assets/javascripts/homepage_search_dropdown.es6
@@ -3,16 +3,16 @@ function setupSearchDropdown() {
     const dropdown = $('#search-dropdown');
 
     const allCategories = JSON.parse($('.homepage-search').attr('data-categories') || '[]');
-    const mostPopularCategories = allCategories.slice(0, 3);
+    const mostPopularCategories = allCategories.slice(0, 2);
 
     const allInnovations = JSON.parse($('.homepage-search').attr('data-innovations') || '[]');
-    const mostRecentInnovations = allInnovations.slice(0, 3);
+    const mostRecentInnovations = allInnovations.slice(0, 2);
 
     const allCommunities = JSON.parse($('.homepage-search').attr('data-communities') || '[]');
-    const mostPopularCommunities = allCommunities.slice(0, 3);
+    const mostPopularCommunities = allCommunities.slice(0, 2);
 
     const allProducts = JSON.parse($('.homepage-search').attr('data-products') || '[]');
-    const mostRecentProducts = allProducts.slice(0, 3);
+    const mostRecentProducts = allProducts.slice(0, 2);
 
     searchInput.focus(function() {
         dropdown.show();
@@ -21,10 +21,10 @@ function setupSearchDropdown() {
 
     searchInput.on('input', function() {
         let searchTerm = searchInput.val().toLowerCase();
-        let filteredCategories = searchTerm ? allCategories.filter(category => category.name.toLowerCase().includes(searchTerm)).slice(0,3) : mostPopularCategories;
-        let filteredInnovations = searchTerm ? allInnovations.filter(innovation => innovation.name.toLowerCase().includes(searchTerm)).slice(0,3) : mostRecentInnovations;
-        let filteredCommunities = searchTerm ? allCommunities.filter(community => community.name.toLowerCase().includes(searchTerm)).slice(0,3) : mostPopularCommunities;
-        let filteredProducts = searchTerm ? allProducts.filter(product => product.name.toLowerCase().includes(searchTerm)).slice(0,3) : mostRecentProducts;
+        let filteredCategories = searchTerm ? allCategories.filter(category => category.name.toLowerCase().includes(searchTerm)).slice(0,2) : mostPopularCategories;
+        let filteredInnovations = searchTerm ? allInnovations.filter(innovation => innovation.name.toLowerCase().includes(searchTerm)).slice(0,2) : mostRecentInnovations;
+        let filteredCommunities = searchTerm ? allCommunities.filter(community => community.name.toLowerCase().includes(searchTerm)).slice(0,2) : mostPopularCommunities;
+        let filteredProducts = searchTerm ? allProducts.filter(product => product.name.toLowerCase().includes(searchTerm)).slice(0,2) : mostRecentProducts;
         updateDropdown(filteredCategories, filteredInnovations, filteredCommunities, filteredProducts);
     });
 

--- a/app/assets/javascripts/homepage_search_dropdown.es6
+++ b/app/assets/javascripts/homepage_search_dropdown.es6
@@ -127,10 +127,10 @@ function setupClickTracking(listSelector, eventName, dataAttribute) {
 
       let properties = { from_homepage: true};
       switch(dataAttribute) {
-        case 'data-practice-id';
+        case 'data-practice-id':
           properties['practice_name'] = name;
           break;
-        case 'data-product-id';
+        case 'data-product-id':
           properties['product_name'] = name;
           break;
         default: // tags and communities-as-tags

--- a/app/assets/stylesheets/dm/pages/_home.scss
+++ b/app/assets/stylesheets/dm/pages/_home.scss
@@ -46,7 +46,9 @@
 
     #category-list,
     #practice-list,
-    #community-list {
+    #community-list,
+    #product-list
+     {
       a {
         text-decoration: none;
         color: color($theme-color-base-ink);

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -146,7 +146,7 @@ class HomeController < ApplicationController
 
   def get_dropdown_products
     product_names = []
-    dropdown_products = Product.where(published: true, retired: false)
+    dropdown_products = Product.where(published: true, retired: false).order("created_at DESC")
     products_hash = dropdown_products.pluck(:id, :name, :slug).map do |id, name, slug|
       product_names << name
       {name: name, id: id, slug: slug }

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -7,6 +7,7 @@ class HomeController < ApplicationController
     @dropdown_categories = get_categories_by_popularity
     @dropdown_communities = get_categories_by_popularity(true)
     @dropdown_practices, @practice_names = get_dropdown_practices
+    @dropdown_products = get_dropdown_products
     @homepage = Homepage.where(published: true)&.first
     if @homepage
       current_features = @homepage&.homepage_features
@@ -141,6 +142,17 @@ class HomeController < ApplicationController
     scope = scope.where(is_public: true) if !current_user
     scope = scope.order("created_at DESC")
     scope
+  end
+
+  def get_dropdown_products
+    product_names = []
+    dropdown_products = Product.where(published: true, retired: false)
+    products_hash = dropdown_products.pluck(:id, :name, :slug).map do |id, name, slug|
+      product_names << name
+      {name: name, id: id, slug: slug }
+    end
+
+    return products_hash
   end
 
   def get_diffusion_histories(is_public_practice)

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -7,7 +7,7 @@ class HomeController < ApplicationController
     @dropdown_categories = get_categories_by_popularity
     @dropdown_communities = get_categories_by_popularity(true)
     @dropdown_practices, @practice_names = get_dropdown_practices
-    @dropdown_products = get_dropdown_products
+    @dropdown_products, @product_names = get_dropdown_products
     @homepage = Homepage.where(published: true)&.first
     if @homepage
       current_features = @homepage&.homepage_features
@@ -152,7 +152,7 @@ class HomeController < ApplicationController
       {name: name, id: id, slug: slug }
     end
 
-    return products_hash
+    return products_hash, product_names
   end
 
   def get_diffusion_histories(is_public_practice)

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -45,7 +45,7 @@
             style="display: none;"
           >
 
-          <% if @dropdown_practices.present? && @dropdown_categories.present? && @dropdown_communities.present? %>
+          <% if @dropdown_practices.present? && @dropdown_categories.present? && @dropdown_communities.present? && @dropdown_products.present? %>
           <div class="dropdown-content margin-4">
             <div class="result-section" data-type="innovation">
               <h3 class="search-header usa-prose-h3 margin-bottom-0">Innovations</h3>
@@ -86,12 +86,12 @@
               <h3 class="search-header usa-prose-h3 margin-bottom-0">Products</h3>
               <ul id="product-list" class="usa-list usa-list--unstyled padding-bottom-1 padding-top-1 display-block">
                 <% @dropdown_products[0..2].each do |product| %>
-                  <li class="search-result" data-category_id=<%= product[:id] %>>
-                    <a href=<%= "/products/#{URI.encode_www_form_component(product[:name])}" %>><%= product[:name] %></a>
+                  <li class="search-result" data-product-id=<%= product[:id]%>>
+                    <a href=<%= "/products/#{product[:slug]}" %>><%= product[:name] %></a>
                   </li>
                 <% end %>
               </ul>
-              <a class="browse-all-link text-bold" href="<%= search_path %>?all_communities=true">Browse all Products</a>
+              <a class="browse-all-link text-bold" href="/intrapreneurial-product-marketplace">Browse all Products</a>
             </div>
           </div>
           <% end %>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -50,7 +50,7 @@
             <div class="result-section" data-type="innovation">
               <h3 class="search-header usa-prose-h3 margin-bottom-0">Innovations</h3>
               <ul id="practice-list" class="usa-list usa-list--unstyled padding-bottom-1 padding-top-1 display-block">
-                <% @dropdown_practices[0..2].each do |practice| %>
+                <% @dropdown_practices[0..1].each do |practice| %>
                   <li class="search-result" data-practice-id=<%= practice[:id] %>>
                     <a href="/innovations/<%= practice[:slug] %>"><%= practice[:name] %></a>
                   </li>
@@ -62,7 +62,7 @@
             <div class="result-section" data-type="category">
               <h3 class="search-header usa-prose-h3 margin-bottom-0" aria-label="Tags">Tags</h3>
               <ul id="category-list" class="usa-list usa-list--unstyled padding-bottom-1 padding-top-1 display-block">
-                <% @dropdown_categories[0..2].each do |category| %>
+                <% @dropdown_categories[0..1].each do |category| %>
                   <li class="search-result" data-category_id=<%= category[:id] %>>
                     <a href=<%= "/search?category=#{URI.encode_www_form_component(category[:name])}" %>><%= category[:name] %></a>
                   </li>
@@ -74,7 +74,7 @@
             <div class="result-section" data-type="community">
               <h3 class="search-header usa-prose-h3 margin-bottom-0">Communities</h3>
               <ul id="community-list" class="usa-list usa-list--unstyled padding-bottom-1 padding-top-1 display-block">
-                <% @dropdown_communities[0..2].each do |community| %>
+                <% @dropdown_communities[0..1].each do |community| %>
                   <li class="search-result" data-category_id=<%= community[:id] %>>
                     <a href=<%= "/search?category=#{URI.encode_www_form_component(community[:name])}" %>><%= community[:name] %></a>
                   </li>
@@ -85,7 +85,7 @@
             <div class="result-section" data-type="product">
               <h3 class="search-header usa-prose-h3 margin-bottom-0">Products</h3>
               <ul id="product-list" class="usa-list usa-list--unstyled padding-bottom-1 padding-top-1 display-block">
-                <% @dropdown_products[0..2].each do |product| %>
+                <% @dropdown_products[0..1].each do |product| %>
                   <li class="search-result" data-product-id=<%= product[:id]%>>
                     <a href=<%= "/products/#{product[:slug]}" %>><%= product[:name] %></a>
                   </li>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -154,7 +154,7 @@
           <p class="usa-prose-body margin-bottom-5">
             The VA Intrapreneurial Product Marketplace highlights frontline VA employee innovators and their products available for purchase to put back in the hands of who they were designed with and for, Veterans.
           </p>
-          <%= link_to 'Learn more', '/intrapreneurial-product-marketplace', class: 'usa-link', 'aria-describedby': 'ipm-section-title', data: { turbolinks: false } %>
+          <%= link_to 'Learn More', '/intrapreneurial-product-marketplace', class: 'usa-link', 'aria-describedby': 'ipm-section-title', data: { turbolinks: false } %>
         </div>
       </div>
     </section>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -26,6 +26,7 @@
     data-categories="<%= @dropdown_categories.to_json %>"
     data-innovations="<%= @dropdown_practices.to_json %>"
     data-communities="<%= @dropdown_communities.to_json %>"
+    data-products="<%= @dropdown_products.to_json %>"
   >
     <form id="dm-homepage-search-form" class="usa-search margin-bottom-2" role="search" aria-label="Search innovations and categories">
       <div class="dm-homepage-search-container width-full">
@@ -80,6 +81,17 @@
                 <% end %>
               </ul>
               <a class="browse-all-link text-bold" href="<%= search_path %>?all_communities=true">Browse all Community Innovations</a>
+            </div>
+            <div class="result-section" data-type="product">
+              <h3 class="search-header usa-prose-h3 margin-bottom-0">Products</h3>
+              <ul id="product-list" class="usa-list usa-list--unstyled padding-bottom-1 padding-top-1 display-block">
+                <% @dropdown_products[0..2].each do |product| %>
+                  <li class="search-result" data-category_id=<%= product[:id] %>>
+                    <a href=<%= "/products/#{URI.encode_www_form_component(product[:name])}" %>><%= product[:name] %></a>
+                  </li>
+                <% end %>
+              </ul>
+              <a class="browse-all-link text-bold" href="<%= search_path %>?all_communities=true">Browse all Products</a>
             </div>
           </div>
           <% end %>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -58,7 +58,17 @@
               </ul>
               <a class="browse-all-link text-bold" href="<%= search_path %>">Browse all Innovations</a>
             </div>
-
+            <div class="result-section" data-type="product">
+              <h3 class="search-header usa-prose-h3 margin-bottom-0">Products</h3>
+              <ul id="product-list" class="usa-list usa-list--unstyled padding-bottom-1 padding-top-1 display-block">
+                <% @dropdown_products[0..1].each do |product| %>
+                  <li class="search-result" data-product-id=<%= product[:id]%>>
+                    <a href=<%= "/products/#{product[:slug]}" %>><%= product[:name] %></a>
+                  </li>
+                <% end %>
+              </ul>
+              <a class="browse-all-link text-bold" href="/intrapreneurial-product-marketplace">Browse all Products</a>
+            </div>
             <div class="result-section" data-type="category">
               <h3 class="search-header usa-prose-h3 margin-bottom-0" aria-label="Tags">Tags</h3>
               <ul id="category-list" class="usa-list usa-list--unstyled padding-bottom-1 padding-top-1 display-block">
@@ -70,7 +80,6 @@
               </ul>
               <a class="browse-all-link text-bold" href="<%= search_path %>">Browse all Tags</a>
             </div>
-
             <div class="result-section" data-type="community">
               <h3 class="search-header usa-prose-h3 margin-bottom-0">Communities</h3>
               <ul id="community-list" class="usa-list usa-list--unstyled padding-bottom-1 padding-top-1 display-block">
@@ -81,17 +90,6 @@
                 <% end %>
               </ul>
               <a class="browse-all-link text-bold" href="<%= search_path %>?all_communities=true">Browse all Community Innovations</a>
-            </div>
-            <div class="result-section" data-type="product">
-              <h3 class="search-header usa-prose-h3 margin-bottom-0">Products</h3>
-              <ul id="product-list" class="usa-list usa-list--unstyled padding-bottom-1 padding-top-1 display-block">
-                <% @dropdown_products[0..1].each do |product| %>
-                  <li class="search-result" data-product-id=<%= product[:id]%>>
-                    <a href=<%= "/products/#{product[:slug]}" %>><%= product[:name] %></a>
-                  </li>
-                <% end %>
-              </ul>
-              <a class="browse-all-link text-bold" href="/intrapreneurial-product-marketplace">Browse all Products</a>
             </div>
           </div>
           <% end %>

--- a/spec/features/homepage_spec.rb
+++ b/spec/features/homepage_spec.rb
@@ -18,6 +18,8 @@ describe 'Homepage', type: :feature do
     @product_1 = create(:product, published: true)
     @product_2 = create(:product , published: true)
     @product_3 = create(:product, published: true)
+    @ipm = create(:page_group, name: "Intrapreneurial Product Marketplace")
+    @ipm_homepage = create(:page, page_group: @ipm, slug: "home", title: "Intrapreneurial Product Marketplace" )
 
     create(:practice_origin_facility, practice: @practice, facility_type: 0, va_facility_id: 1)
 
@@ -240,7 +242,7 @@ describe 'Homepage', type: :feature do
       event = wait_for_ahoy_js('Browse all Products')
 
       expect(event.name).to eq("Dropdown Browse-all Link Clicked")
-      expect(event.properties["type"]).to eq("products")
+      expect(event.properties["type"]).to eq("product")
     end
   end
 

--- a/spec/features/homepage_spec.rb
+++ b/spec/features/homepage_spec.rb
@@ -112,13 +112,13 @@ describe 'Homepage', type: :feature do
         find('#dm-homepage-search-field').click
 
         expect(page).to have_content('Recent VA-only practice!')
-        expect(page).to have_content('The Second Best Practice Ever!')
+        expect(page).to have_content('The Third Best Practice Ever!')
     end
 
     it 'lists popular categories' do
       within '#category-list' do
         expect(page).to have_content('COVID')
-        expect(page).to have_content('Telehealth')
+        expect(page).to have_content('Nutrition & Food')
       end
     end
 
@@ -173,7 +173,7 @@ describe 'Homepage', type: :feature do
     end
 
     it 'lets a user navigate results with arrow keys' do
-      page.send_keys :down, :down, :down, :down, :down # navigate to first category
+      7.times { page.send_keys :down} # navigate to first category
       page.send_keys :enter # select category
       expect(page).to have_current_path('/search?category=COVID')
       expect(page).to have_content("2 Results: TAG: COVID")
@@ -234,7 +234,7 @@ describe 'Homepage', type: :feature do
       event = wait_for_ahoy_js(@product_2.name)
 
       expect(event.name).to eq("Dropdown Product Link Clicked")
-      # expect(event.properties["product_name"]).to eq(@product_2.name) # TODO: fix ahoy event
+      expect(event.properties["product_name"]).to eq(@product_2.name)
       expect(event.properties["from_homepage"]).to be_truthy
     end
 

--- a/spec/features/homepage_spec.rb
+++ b/spec/features/homepage_spec.rb
@@ -15,6 +15,9 @@ describe 'Homepage', type: :feature do
     @practice_2 = create(:practice, name: 'The Second Best Practice Ever!', initiating_facility_type: 'facility', tagline: 'Test tagline', date_initiated: 'Sun, 06 Feb 1992 00:00:00 UTC +00:00', created_at: 'Sun, 06 Feb 1992 00:00:00 UTC +00:00', summary: 'This is the best practice ever.', overview_problem: 'overview-problem', is_public: true, published: true, approved: true, user: @user)
     @practice_3 = create(:practice, name: 'The Third Best Practice Ever!', initiating_facility_type: 'facility', tagline: 'Test tagline', date_initiated: 'Sun, 07 Feb 1992 00:00:00 UTC +00:00', created_at: 'Sun, 07 Feb 1992 00:00:00 UTC +00:00', summary: 'This is the best practice ever.', overview_problem: 'overview-problem', is_public: true, published: true, approved: true, user: @user)
     @va_only_practice = create(:practice, name: 'Recent VA-only practice!', initiating_facility_type: 'facility', tagline: 'Test tagline', date_initiated: 'Sun, 08 Feb 1992 00:00:00 UTC +00:00', created_at: 'Sun, 07 Feb 1992 00:00:00 UTC +00:00', summary: 'This is the best practice ever.', overview_problem: 'overview-problem', is_public: false, published: true, approved: true, user: @user)
+    @product_1 = create(:product, published: true)
+    @product_2 = create(:product , published: true)
+    @product_3 = create(:product, published: true)
 
     create(:practice_origin_facility, practice: @practice, facility_type: 0, va_facility_id: 1)
 
@@ -93,7 +96,6 @@ describe 'Homepage', type: :feature do
 
     it 'lists most recently created innovations' do
       within '#practice-list' do
-        expect(page).to have_content('The Best Practice Ever!')
         expect(page).to have_content('The Second Best Practice Ever!')
         expect(page).to have_content('The Third Best Practice Ever!')
 
@@ -109,7 +111,6 @@ describe 'Homepage', type: :feature do
 
         expect(page).to have_content('Recent VA-only practice!')
         expect(page).to have_content('The Second Best Practice Ever!')
-        expect(page).to have_content('The Third Best Practice Ever!')
     end
 
     it 'lists popular categories' do
@@ -155,6 +156,18 @@ describe 'Homepage', type: :feature do
         expect(page).to have_content("1 Result:")
         expect(page).to have_content(@practice_3.name)
       end
+
+      it 'temporarily links to IPM pagebuilder page' do
+         within '#search-dropdown' do
+          expect(page).to have_link('Browse all Products', href: '/intrapreneurial-product-marketplace')
+        end
+      end
+
+      it 'lists most recently created products' do
+        expect(page).to have_content(@product_3.name)
+        expect(page).to have_content(@product_2.name)
+        expect(page).not_to have_content(@product_1.name)
+      end
     end
 
     it 'lets a user navigate results with arrow keys' do
@@ -171,10 +184,10 @@ describe 'Homepage', type: :feature do
     end
 
     it 'tracks clicks on practice links' do
-      event = wait_for_ahoy_js('The Best Practice Ever!')
+      event = wait_for_ahoy_js(@practice_2.name)
 
       expect(event.name).to eq("Dropdown Practice Link Clicked")
-      expect(event.properties["practice_name"]).to eq("The Best Practice Ever!")
+      expect(event.properties["practice_name"]).to eq(@practice_2.name)
       expect(event.properties["from_homepage"]).to be_truthy
     end
 
@@ -213,6 +226,21 @@ describe 'Homepage', type: :feature do
 
       expect(event.name).to eq("Dropdown Browse-all Link Clicked")
       expect(event.properties["type"]).to eq("community")
+    end
+
+    it 'tracks clicks on product links' do
+      event = wait_for_ahoy_js(@product_2.name)
+
+      expect(event.name).to eq("Dropdown Product Link Clicked")
+      # expect(event.properties["product_name"]).to eq(@product_2.name) # TODO: fix ahoy event
+      expect(event.properties["from_homepage"]).to be_truthy
+    end
+
+    it 'tracks clicks on "Browse All Products Link' do
+      event = wait_for_ahoy_js('Browse all Products')
+
+      expect(event.name).to eq("Dropdown Browse-all Link Clicked")
+      expect(event.properties["type"]).to eq("products")
     end
   end
 


### PR DESCRIPTION
### JIRA issue link
[DM-5254](https://agile6.atlassian.net/browse/DM-5074)

## Description - what does this code do?
- Adds published Products to homepage dropdown search
- Adds Ahoy tracking events products and `Browse all Products` link 
  - Note: `Browse all` links to IPM PageBuilder page for MVP
- Move Products above Tags in dropdown
- Only show 2 items per type in dropdown. Updates spec expectations to account for this

## Testing done - how did you test it/steps on how can another person can test it 
1. Run the `rake dm:reset_up` task to make sure Products are in your DB
2. In the rails console, run `Product.all.update(published: true) to publish products
3. Create a page group and page for the incoming IPM pagebuilder page `pg = FactoryBot.create(:page_group, name: "Intrapreneurial Product Marketplace"); FactoryBot.create(:page, page_group: pg, title: "Intrapreneurial Product Marketplace")`
4. Log in as an admin
5. Place cursor in the search dropdown
6. Confirm that 2 items are rendered for each section
7. Confirm that the 2 Products listed are the most recently created
8. Confirm that user can navigate up and down list with arrows keys
9. Start typing and confirm that products list is being filtered by matching product name
10. Click on a product and confirm it directs to the correct show page


## Screenshots, Gifs, Videos from application (if applicable)

![Screenshot 2024-10-07 at 1 39 51 PM](https://github.com/user-attachments/assets/c040a9fb-6efa-4d93-b2d0-21bfd8d7ec09)
