### PR TITLE
dm-5201 prod editor mdi alt text field

### DIFF
--- a/app/controllers/practices_controller.rb
+++ b/app/controllers/practices_controller.rb
@@ -333,6 +333,7 @@ class PracticesController < ApplicationController # rubocop:disable Metrics/Clas
 
   # /practices/slug/editors
   def editors
+    @practice_editors = PracticeEditor.where(innovable: @practice).order(created_at: :asc)
     render 'practices/form/editors'
   end
 

--- a/app/controllers/practices_controller.rb
+++ b/app/controllers/practices_controller.rb
@@ -170,7 +170,7 @@ class PracticesController < ApplicationController # rubocop:disable Metrics/Clas
             format.json { render json: @practice, status: :ok }
           end
           # Update last_edited field for the Practice Editor unless the current_user is the Practice Editor and their Practice Editor record was just created
-          practice_editor = PracticeEditor.find_by(practice: @practice, user: current_user)
+          practice_editor = PracticeEditor.find_by(innovable: @practice, user: current_user)
           if practice_editor.present? && Time.current - practice_editor.created_at > 2
             practice_editor.update(last_edited_at: DateTime.current)
           end

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -76,6 +76,7 @@ class ProductsController < ApplicationController
       :price,
       :origin_story,
       :main_display_image,
+      :main_display_image_alt_text,
       :crop_x,
       :crop_y,
       :crop_w,

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -37,8 +37,8 @@ class ProductsController < ApplicationController
       product_params: params[:product].nil? ? {} : product_params,
       multimedia_params: params[:practice].nil? ? {} : multimedia_params
     )
-
-    if service.call
+    service.call
+    if service.errors.empty?
       notice =  if service.added_editor
                   "Editor was added to the list. Product was successfully updated."
                 elsif service.editor_removed

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -76,6 +76,7 @@ class ProductsController < ApplicationController
       :price,
       :origin_story,
       :main_display_image,
+      :main_display_image_caption,
       :main_display_image_alt_text,
       :crop_x,
       :crop_y,

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -1,11 +1,12 @@
 class ProductsController < ApplicationController
-  include InnovationControllerMethods
+  include InnovationControllerMethods, UsersHelper
   before_action :authenticate_user!, except: [:show, :search, :index]
   before_action :set_product, only: [:show, :update, :editors, :description, :intrapreneur, :multimedia]
   before_action :check_product_permissions, only: [:show, :update, :editors, :description, :intrapreneur, :multimedia]
   before_action :set_return_to_top_flag, only: [:show, :editors, :description, :intrapreneur, :multimedia]
 
   def editors
+    @editors = PracticeEditor.where(innovable: @product).order(created_at: :asc)
     render 'products/form/editors'
   end
 
@@ -38,20 +39,21 @@ class ProductsController < ApplicationController
     )
 
     if service.call
-      notice = service.product_updated ? "Product was successfully updated." : nil
-      next_page = params[:next] ? "#{Product::PRODUCT_EDITOR_NEXT_PAGE[submitted_page.to_sym]}" : "multimedia"
+      notice =  if service.added_editor
+                  "Editor was added to the list. Product was successfully updated."
+                elsif service.editor_removed
+                  "Editor was removed from the list. Product was successfully updated."
+                elsif service.product_updated
+                  "Product was successfully updated."
+                else
+                  nil
+                end
+      next_page = params[:next] ? Product::PRODUCT_EDITOR_NEXT_PAGE[submitted_page.to_sym] : submitted_page
       redirect_to send("product_#{next_page}_path", @product), notice: notice
-    elsif service.errors.any?
-      flash[:error] = service.errors.join(', ')
-      redirect_to send("product_#{submitted_page}_path", @product) || admin_product_path(@product)
     else
-      next_page = params[:next] ? "#{Product::PRODUCT_EDITOR_NEXT_PAGE[submitted_page.to_sym]}_" : nil
-      redirect_to send("product_#{next_page}path", @product)
+      flash[:error] = service.errors.any? ? service.errors.join(', ') : "An unexpected error occurred."
+      redirect_back(fallback_location: admin_product_path(@product))
     end
-  rescue => e
-    logger.error "Product update failed: #{e.message}"
-    flash[:error] = "An unexpected error occurred: #{e.message}"
-    redirect_to send("product_#{submitted_page}_path", @product) || admin_product_path(@product)
   end
 
   private
@@ -79,6 +81,8 @@ class ProductsController < ApplicationController
       :crop_w,
       :crop_h,
       :delete_main_display_image,
+      :add_editor,
+      :delete_editor,
       va_employees_attributes: [:id, :name, :role, :_destroy],
       category: permitted_dynamic_keys(params[:product][:category]),
     )

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -48,7 +48,8 @@ class ProductsController < ApplicationController
                 else
                   nil
                 end
-      next_page = params[:next] ? Product::PRODUCT_EDITOR_NEXT_PAGE[submitted_page.to_sym] : submitted_page
+
+      next_page = params[:next] ? Product::PRODUCT_EDITOR_NEXT_PAGE[submitted_page] : submitted_page
       redirect_to send("product_#{next_page}_path", @product), notice: notice
     else
       flash[:error] = service.errors.any? ? service.errors.join(', ') : "An unexpected error occurred."

--- a/app/mailers/practice_editor_mailer.rb
+++ b/app/mailers/practice_editor_mailer.rb
@@ -3,14 +3,16 @@ class PracticeEditorMailer < ApplicationMailer
   layout 'mailer'
   MAILER_RETURN = "marketplace@va.gov"
 
-  def invite_to_edit_practice_email(practice, user)
-    practice_user_editor_text = "You have been added to the list of practice editors for the #{practice.name} Diffusion Marketplace Page!"
-    practice_editor_text = "You are invited to edit the #{practice.name} Diffusion Marketplace Page!"
+  def invite_to_edit(resource, user)
+    resource_name = resource.is_a?(Practice) ? "practice" : "product"
+    editor_text = "You are invited to edit the #{resource.name} Diffusion Marketplace Page!"
+    user_editor_text = "You have been added to the list of #{resource_name} editors for the #{resource.name} Diffusion Marketplace Page!"
+
     mail(
-        to: user.email,
-        subject: practice.user === user ? practice_user_editor_text : practice_editor_text
+      to: user.email,
+      subject: resource.user == user ? user_editor_text : editor_text
     ) do |format|
-      format.html { render "practice_editor_mailer/invite_to_edit_practice_email".html_safe, locals: { practice: practice } }
+      format.html { render "#{resource_name}_editor_mailer/invite_to_edit_#{resource_name}_email".html_safe, locals: { resource_name.to_sym => resource } }
     end
   end
 

--- a/app/models/innovation.rb
+++ b/app/models/innovation.rb
@@ -10,6 +10,7 @@ class Innovation < ApplicationRecord
   has_many :practice_multimedia, -> { order(id: :asc) }, as: :innovable, dependent: :destroy
   has_many :practice_partner_practices, as: :innovable, dependent: :destroy
   has_many :practice_partners, through: :practice_partner_practices
+  has_many :practice_editors, -> { order(id: :asc) }, as: :innovable, dependent: :destroy
 
   accepts_nested_attributes_for :va_employees, allow_destroy: true, reject_if: proc { |attributes| attributes['name'].blank? || attributes['role'].blank? }
   accepts_nested_attributes_for :practice_multimedia, allow_destroy: true

--- a/app/models/practice.rb
+++ b/app/models/practice.rb
@@ -258,7 +258,6 @@ class Practice < Innovation
   has_many :practice_emails, -> {order(id: :asc) }, dependent: :destroy
   has_many :practice_resources, -> {order(id: :asc) }, dependent: :destroy
   has_many :practice_editor_sessions, -> {order(id: :asc) }, dependent: :destroy
-  has_many :practice_editors, -> {order(created_at: :asc) }, dependent: :destroy
 
   # This allows the practice model to be commented on with the use of the Commontator gem
   acts_as_commontable dependent: :destroy

--- a/app/models/practice_editor.rb
+++ b/app/models/practice_editor.rb
@@ -1,7 +1,7 @@
 class PracticeEditor < ApplicationRecord
   include VaEmail
 
-  belongs_to :practice
+  belongs_to :innovable, polymorphic: true
   belongs_to :user
 
   attr_accessor :email
@@ -15,14 +15,14 @@ class PracticeEditor < ApplicationRecord
 
   def self.create_and_invite(practice, user)
     # Email param ensures the user associated with the practice editor has a valid va.gov email address
-    self.create!(practice: practice, user: user, email: user.email)
+    self.create!(innovable: practice, user: user, email: user.email)
     if (Rails.env.production? && ENV['PROD_SERVERNAME'] == 'PROD') || Rails.env.test?
-      PracticeEditorMailer.invite_to_edit_practice_email(practice, user).deliver
+      PracticeEditorMailer.invite_to_edit(practice, user).deliver
     end
   end
 
   def ensure_practice_has_at_least_one_practice_editor
-    if self.practice.practice_editors.count == 1
+    if self.innovable.practice_editors.count == 1
       errors.add(:base, 'At least one editor is required')
       throw :abort
     end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -1,7 +1,8 @@
 class Product < Innovation
   has_attached_file :main_display_image, styles: {thumb: '768x432>'}, :processors => [:cropper]
 
-  # validates :main_display_image_alt_text, presence: true, if: :main_display_image_present?
+  validates :main_display_image_alt_text, presence: true, if: :main_display_image_present?
+  validates :main_display_image_caption, presence: true, if: :main_display_image_present?
   validates_attachment_content_type :main_display_image, content_type: /\Aimage\/.*\z/
   validates :name, presence: true
   validates_uniqueness_of :name, {message: 'Product name already exists'}
@@ -12,9 +13,9 @@ class Product < Innovation
 
   PRODUCT_EDITOR_NEXT_PAGE =
     {
-      'editors': 'description',
-      'description': 'intrapreneur',
-      'intrapreneur': 'multimedia',
+      'editors' => 'description',
+      'description' => 'intrapreneur',
+      'intrapreneur' => 'multimedia',
     }
 
   extend FriendlyId

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -1,11 +1,9 @@
 class Product < Innovation
   has_attached_file :main_display_image, styles: {thumb: '768x432>'}, :processors => [:cropper]
 
-  validates :main_display_image_alt_text, presence: true, if: :main_display_image_present?
-  validates :main_display_image_caption, presence: true, if: :main_display_image_present?
   validates_attachment_content_type :main_display_image, content_type: /\Aimage\/.*\z/
   validates :name, presence: true
-  validates_uniqueness_of :name, {message: 'Product name already exists'}
+  validates :name, uniqueness: {message: 'Product name already exists'}
 
   after_update :update_date_published
 
@@ -25,6 +23,10 @@ class Product < Innovation
     user&.email
   end
 
+  def self.ransackable_attributes(auth_object = nil)
+    ["name", "user_email", "published"]
+  end
+
   private
 
   def main_display_image_present?
@@ -35,16 +37,13 @@ class Product < Innovation
     Arel.sql("users.email")
   end
 
-  def self.ransackable_attributes(auth_object = nil)
-    ["name", "user_email", "published"]
-  end
 
   def update_date_published
     if saved_change_to_published?
       if published
-        update_column(:date_published, Time.current)
+        update(date_published: Time.current)
       else
-        update_column(:date_published, nil)
+        update(date_published: nil)
       end
     end
   end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -8,6 +8,8 @@ class Product < Innovation
 
   after_update :update_date_published
 
+  attr_accessor :add_editor, :delete_editor
+
   PRODUCT_EDITOR_NEXT_PAGE =
     {
       'editors': 'description',

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -78,7 +78,7 @@ class User < ApplicationRecord
 
   def created_practices
     # returns a list of Practices a user has created or can edit
-    editor_practices = PracticeEditor.where(user: self).collect { |pe| pe.practice }
+    editor_practices = PracticeEditor.where(user: self, innovable_type: 'Practice').collect { |pe| pe.innovable }
     created_practices = Practice.where(user_id: id)
     all_created_practices = (editor_practices + created_practices).uniq
     all_created_practices = all_created_practices.sort_by{ |a| a.retired ? 1 : 0 }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -113,7 +113,7 @@ class User < ApplicationRecord
   end
 
   def user_role
-    roles.collect(&:name).join(', ')
+    roles.pluck(:name).join(', ')
   end
 
   def full_name

--- a/app/services/practice_mailer_service.rb
+++ b/app/services/practice_mailer_service.rb
@@ -33,13 +33,14 @@ class PracticeMailerService
       practice_ids_to_update << practice.id
     end
 
-    editor_practices = PracticeEditor.joins(:user, :practice).where(practice_id: practices.ids)
+    editor_practices = PracticeEditor.where(innovable_type: 'Practice', innovable_id: practices.ids)
+                                    .includes(:user, innovable: :practice_editors)
     editor_practices.each_with_object(user_practices) do |editor, hash|
-      next unless editor.user.present? && editor.practice.published?
+      next unless editor.user.present? && editor.innovable.published?
       hash[editor.user] ||= Set.new
-      hash[editor.user] << editor.practice
-      practice_names << editor.practice.name
-      practice_ids_to_update << editor.practice.id
+      hash[editor.user] << editor.innovable
+      practice_names << editor.innovable.name
+      practice_ids_to_update << editor.innovable.id
     end
 
     if Rails.env.production? && ENV['PROD_SERVERNAME'] != 'PROD'

--- a/app/services/save_practice_service.rb
+++ b/app/services/save_practice_service.rb
@@ -367,7 +367,7 @@ class SavePracticeService
     else
       email_param = editors.values.first.values.first.downcase
       user = User.find_by(email: email_param)
-      practice_editor = PracticeEditor.find_by(practice: @practice, user: user)
+      practice_editor = PracticeEditor.find_by(innovable: @practice, user: user)
 
       # if the user tries to save with a blank email field, raise an error
       raise StandardError.new "error. Email field cannot be blank" if email_param.blank?

--- a/app/services/save_product_service.rb
+++ b/app/services/save_product_service.rb
@@ -174,7 +174,7 @@ class SaveProductService
     editor = @product.practice_editors.find_by(id: editor_id)
 
     if editor.nil?
-      @errors << "Editor has already been removed"
+      @errors << "User is not an editor for this practice"
       return false
     end
 

--- a/app/services/save_product_service.rb
+++ b/app/services/save_product_service.rb
@@ -22,21 +22,21 @@ class SaveProductService
     ActiveRecord::Base.transaction do
       handle_product_params if @product_params.present?
       handle_multimedia_params if @multimedia_params.present?
-
       merged_params = @product_params.merge(@multimedia_params)
       @product.assign_attributes(merged_params)
 
       handle_main_display_image_cropping if main_display_image_cropping_params_present?(merged_params)
 
-      if @product.changed? || product_associations_changed? || @product_updated
+      if @product.changed? || product_associations_changed?
+        @product_updated = true
+      end
+
+      if @product_updated
         unless @product.save
           collect_errors
         end
 
         send_editor_invitation if @added_editor
-        @product_updated
-      else
-        false
       end
     end
   end

--- a/app/views/practices/form/editors.html.erb
+++ b/app/views/practices/form/editors.html.erb
@@ -15,17 +15,16 @@
       <%= render partial: "practices/shared/step_indicator" %>
       <section class="usa-section padding-top-0 padding-bottom-0 editors">
         <h1 class="font-sans-2xl line-height-46px margin-bottom-3 margin-top-0">Editors</h1>
-        <% practice_editors = PracticeEditor.where(practice: @practice).order(created_at: :asc) %>
-        <% practice_editors.each do |pe| %>
+        <% @practice_editors.each do |pe| %>
           <%
             user = pe.user
             email = user.email
           %>
-          <div class="grid-row flex-align-center border-bottom-1px <%= 'border-top-1px' if practice_editors.first === pe %> practice-editor-entry">
+          <div class="grid-row flex-align-center border-bottom-1px <%= 'border-top-1px' if @practice_editors.first === pe %> practice-editor-entry">
             <div class="grid-col-11 padding-y-3 line-height-26">
               <p class="text-bold <%= 'display-none' unless is_full_name_present(user) %>"><%= user_full_name(user) %></p>
-              <a target="_blank" 
-                  href="mailto:<%= email %>" 
+              <a target="_blank"
+                  href="mailto:<%= email %>"
                   class="usa-link usa-link--external line-height-26"
                   rel="noopener noreferrer">
                 <%= email %>

--- a/app/views/practices/introduction_forms/_image_editor.html.erb
+++ b/app/views/practices/introduction_forms/_image_editor.html.erb
@@ -11,7 +11,7 @@
     <% else %>
       <label class="usa-label text-bold margin-top-0 margin-bottom-1"><%= section_title %></label>
     <% end %>
-  <div class="dm-cropper-boundary grid-col-12 margin-top-2">
+  <div class="dm-cropper-boundary grid-col-12 margin-top-2" data-model-type="<%= practice.class.name.downcase %>">
     <label class="dm-cropper-upload-image-label line-height-26" for="practice_main_display_image">
       Choose a photograph to represent the Innovation in Search Results.
     </label>

--- a/app/views/product_editor_mailer/invite_to_edit_product_email.html.erb
+++ b/app/views/product_editor_mailer/invite_to_edit_product_email.html.erb
@@ -1,0 +1,1 @@
+<p>Visit your page <%= link_to 'here', product_url(product) %> and click "Edit" to begin editing.</p>

--- a/app/views/products/form/description.html.erb
+++ b/app/views/products/form/description.html.erb
@@ -159,6 +159,18 @@
 
             <%= render partial: 'practices/introduction_forms/image_editor', locals: { section_title: 'Thumbnail', form: f, practice: @product, modal_link: true } %>
 
+            <div>
+              <%= render partial: 'practices/shared/image_alt_text_label',
+                locals: {
+                  practice_field: "practice_main_display_image_alt_text",
+                  label_classes: 'margin-top-0 text-bold',
+                  form_field: "practice_main_display_image_alt_text"
+                }
+              %>
+              <%= f.text_area :main_display_image_alt_text,
+                                 class: "usa-textarea main-display-image-alt-text" %>
+            </div>
+
             <%= hidden_field_tag :submitted_page, params[:action] %>
           </fieldset>
         <% end %>

--- a/app/views/products/form/description.html.erb
+++ b/app/views/products/form/description.html.erb
@@ -1,9 +1,10 @@
 <% provide :head_tags do %>
   <%= javascript_include_tag '_allCategories', 'data-turbolinks-track': 'reload' %>
   <%= javascript_include_tag '_introduction_image_editor', 'data-turbolinks-track': 'reload' %>
+  <%= javascript_include_tag '_practice_editor_header', 'data-turbolinks-track': 'reload' %>
 <% end %>
 
-
+<%= render partial: 'practices/introduction_forms/main_display_image_guidance_modal' %>
 <div class="grid-container">
   <div class="grid-row grid-gap">
     <div id="description" class="grid-col-12 margin-top-4">
@@ -157,20 +158,33 @@
               <% end %>
             </div>
 
-            <%= render partial: 'practices/introduction_forms/image_editor', locals: { section_title: 'Thumbnail', form: f, practice: @product, modal_link: true } %>
+            <h3>Thumbnail Image</h3>
+            <fieldset class="usa-fieldset border border-base-light padding-2 margin-top-3 margin-bottom-4">
+              <%= render partial: 'practices/introduction_forms/image_editor', locals: { section_title: 'Thumbnail', form: f, practice: @product, modal_link: true } %>
 
-            <div>
-              <%= render partial: 'practices/shared/image_alt_text_label',
-                locals: {
-                  practice_field: "practice_main_display_image_alt_text",
-                  label_classes: 'margin-top-0 text-bold',
-                  form_field: "practice_main_display_image_alt_text"
-                }
-              %>
-              <%= f.text_area :main_display_image_alt_text,
-                                 class: "usa-textarea main-display-image-alt-text" %>
-            </div>
+              <div>
+                  <%= f.label :main_display_image_caption, class: 'usa-label text-bold display-block margin-top-0' do %>
+                    Caption*
+                  <% end %>
+                </div>
+                <%= f.text_field :main_display_image_caption, class: "usa-input #{ @product.errors[:main_display_image_caption].any? ? 'usa-input--error' : '' } display-block practice-editor-name-input dm-required-field  margin-bottom-2" %>
 
+                <p class="usa-error-message <%= @product.errors[:tagline].any? ? 'fas fa-exclamation-circle fon' : 'display-none' %>">&nbsp;
+                  <span class="font-family-sans"><%= show_errors(@product, :tagline) %></span>
+                </p>
+
+              <div>
+                <%= render partial: 'practices/shared/image_alt_text_label',
+                  locals: {
+                    practice_field: "practice_main_display_image_alt_text",
+                    label_classes: 'margin-top-0 text-bold',
+                    form_field: "practice_main_display_image_alt_text"
+                  }
+                %>
+                <%= f.text_area :main_display_image_alt_text,
+                                  class: "usa-textarea main-display-image-alt-text" %>
+              </div>
+            </fieldset>
             <%= hidden_field_tag :submitted_page, params[:action] %>
           </fieldset>
         <% end %>

--- a/app/views/products/form/editors.html.erb
+++ b/app/views/products/form/editors.html.erb
@@ -1,10 +1,65 @@
+<% innovation = @practice || @product %>
+
+<%# TODO: separate into partial to be shared when able to refactor editor management for practices %>
 <div class="grid-container">
   <div class="grid-row grid-gap">
     <div id="description" class="grid-col-12 margin-top-4">
       <%= render partial: "shared/messages", locals: {small_text: false} %>
-      <%= render partial: "products/step_indicator", locals: {product: @product} %>
-      <section class="usa-section padding-y-0 introduction">
-        <h1 class="margin-top-0">Editors</h1>
+      <%= render partial: "products/step_indicator", locals: {product: innovation} %>
+      <section class="usa-section padding-top-0 padding-bottom-0 editors">
+        <h1 class="font-sans-2xl line-height-46px margin-bottom-3 margin-top-0">Editors</h1>
+        <% @editors.each do |pe| %>
+          <%
+            user = pe.user
+            email = user.email
+          %>
+          <div class="grid-row flex-align-center border-bottom-1px <%= 'border-top-1px' if @editors.first === pe %> practice-editor-entry">
+            <div class="grid-col-11 padding-y-3 line-height-26">
+              <p class="text-bold <%= 'display-none' unless is_full_name_present(user) %>"><%= user_full_name(user) %></p>
+              <a target="_blank"
+                  href="mailto:<%= email %>"
+                  class="usa-link usa-link--external line-height-26"
+                  rel="noopener noreferrer">
+                <%= email %>
+              </a>
+              <%
+                last_edited = pe.last_edited_at
+              %>
+              <% if last_edited.present? %>
+                <%= render partial: 'practices/practice_editor_status', locals: { status_text: 'Last edited on', status: last_edited } %>
+              <% else %>
+                <%= render partial: 'practices/practice_editor_status', locals: { status_text: 'Added to the team on', status: pe.created_at } %>
+              <% end %>
+            </div>
+            <div class="grid-col-1 display-flex flex-justify-center">
+              <%= link_to '', product_path(innovation,
+                    product: { delete_editor: pe.id },
+                    submitted_page: params[:action]),
+                    data: { confirm: "Are you sure you want to remove #{user.email} from the editors list?" },
+                    method: 'put',
+                    class: 'fas fa-trash-alt fa-2x text-middle',
+                    id: "delete-practice-editor-#{pe.id}",
+                    'aria-label': "Remove #{user.email} from practice editors"
+              %>
+            </div>
+          </div>
+        <% end %>
+        <%= nested_form_for(innovation, html: {style: 'max-width: 100%', class: 'usa-form', id: 'form'}) do |f| %>
+          <fieldset class="usa-fieldset grid-col-12">
+            <legend class="usa-sr-only">Product Editors</legend>
+            <div class="grid-col-12">
+              <h2 class="line-height-37px font-sans-xl margin-bottom-3 margin-top-10">Add Editor</h2>
+              <div class="editor-input-container">
+                <%= f.label :add_editor, 'Provide va.gov email of the individual who can help you edit this Innovation Page.', class: 'usa-label editor-label margin-top-0' %>
+                <%= f.text_field :add_editor, class: 'usa-input editor-input', type: 'email', pattern: '.+@va.gov', required: true %>
+              </div>
+            </div>
+            <%= hidden_field_tag :submitted_page, params[:action] %>
+          </fieldset>
+          <div>
+            <%= f.submit "Send Invitation", class: 'usa-button dm-button--outline-secondary margin-top-2 invite-practice-editor-button' %>
+          </div>
+        <% end %>
       </section>
     </div>
   </div>

--- a/app/views/products/form/editors.html.erb
+++ b/app/views/products/form/editors.html.erb
@@ -8,6 +8,14 @@
       <%= render partial: "products/step_indicator", locals: {product: innovation} %>
       <section class="usa-section padding-top-0 padding-bottom-0 editors">
         <h1 class="font-sans-2xl line-height-46px margin-bottom-3 margin-top-0">Editors</h1>
+        <div class="grid-col-11 padding-y-3 line-height-26">
+          Product owner: <a target="_blank"
+                  href="mailto:<%= @product.user %>"
+                  class="usa-link usa-link--external line-height-26"
+                  rel="noopener noreferrer">
+                <%= @product.user %>
+              </a>
+        </div>
         <% @editors.each do |pe| %>
           <%
             user = pe.user

--- a/db/migrate/20241007232231_update_practice_editors_for_polymorphic_association.rb
+++ b/db/migrate/20241007232231_update_practice_editors_for_polymorphic_association.rb
@@ -1,0 +1,13 @@
+class UpdatePracticeEditorsForPolymorphicAssociation < ActiveRecord::Migration[6.1]
+  def change
+    add_reference :practice_editors, :innovable, polymorphic: true, index: true
+
+    execute <<-SQL
+      UPDATE practice_editors
+      SET innovable_id = practice_id, innovable_type = 'Practice'
+      WHERE practice_id IS NOT NULL
+    SQL
+
+    remove_column :practice_editors, :practice_id
+  end
+end

--- a/db/migrate/20241010210000_add_main_display_image_caption_to_products.rb
+++ b/db/migrate/20241010210000_add_main_display_image_caption_to_products.rb
@@ -1,0 +1,5 @@
+class AddMainDisplayImageCaptionToProducts < ActiveRecord::Migration[6.1]
+  def change
+    add_column :products, :main_display_image_caption, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_09_30_214407) do
+ActiveRecord::Schema.define(version: 2024_10_07_232231) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -813,12 +813,13 @@ ActiveRecord::Schema.define(version: 2024_09_30_214407) do
   end
 
   create_table "practice_editors", force: :cascade do |t|
-    t.bigint "practice_id"
     t.bigint "user_id"
     t.datetime "last_edited_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["practice_id"], name: "index_practice_editors_on_practice_id"
+    t.string "innovable_type"
+    t.bigint "innovable_id"
+    t.index ["innovable_type", "innovable_id"], name: "index_practice_editors_on_innovable"
     t.index ["user_id"], name: "index_practice_editors_on_user_id"
   end
 
@@ -1462,7 +1463,6 @@ ActiveRecord::Schema.define(version: 2024_09_30_214407) do
   add_foreign_key "practice_creators", "practices"
   add_foreign_key "practice_creators", "users"
   add_foreign_key "practice_editor_sessions", "practices"
-  add_foreign_key "practice_editors", "practices"
   add_foreign_key "practice_editors", "users"
   add_foreign_key "practice_emails", "practices"
   add_foreign_key "practice_management_practices", "practice_managements"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_10_07_232231) do
+ActiveRecord::Schema.define(version: 2024_10_10_210000) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -1103,6 +1103,7 @@ ActiveRecord::Schema.define(version: 2024_10_07_232231) do
     t.boolean "retired", default: false, null: false
     t.string "slug"
     t.string "vendor_link"
+    t.text "main_display_image_caption"
     t.index ["name"], name: "index_products_on_name", unique: true
     t.index ["slug"], name: "index_products_on_slug", unique: true
     t.index ["user_id"], name: "index_products_on_user_id"

--- a/lib/modules/practice_editor_utils.rb
+++ b/lib/modules/practice_editor_utils.rb
@@ -1,5 +1,5 @@
 module PracticeEditorUtils
   def is_user_an_editor_for_practice(practice, user)
-    PracticeEditor.where(practice: practice, user: user).present?
+    PracticeEditor.where(innovable: practice, user: user).present?
   end
 end

--- a/lib/tasks/practice_editors.rake
+++ b/lib/tasks/practice_editors.rake
@@ -5,12 +5,10 @@ namespace :practice_editors do
 
     practices.each do |practice|
       if practice.user.present? && practice.practice_editors.where(user: practice.user).empty?
-        PracticeEditor.create!(practice: practice, user: practice.user, email: practice.user.email)
+        PracticeEditor.create!(innovable: practice, user: practice.user, email: practice.user.email)
       end
     end
 
     puts "A practice editor has been created for every practice that has an owner!!"
   end
 end
-
-

--- a/lib/tasks/products.rake
+++ b/lib/tasks/products.rake
@@ -64,6 +64,10 @@ namespace :products do
             user_changed = true
           end
 
+          if product.user.present? && product.practice_editors.where(user: product.user).empty?
+            PracticeEditor.create!(innovable: product, user: product.user, email: product.user.email)
+          end
+
           product.save! if product.changed? || user_changed
 
           if PRACTICE_PARTNER_MAPPING[origin]

--- a/spec/factories/practice_editors.rb
+++ b/spec/factories/practice_editors.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :practice_editor do
-    association :practice
+    association :innovable
     association :user
 
     after(:build) do |practice_editor|

--- a/spec/factories/products.rb
+++ b/spec/factories/products.rb
@@ -14,7 +14,8 @@ FactoryBot.define do
 
     trait :with_image do
       main_display_image { File.new(Rails.root.join('spec', 'assets', 'acceptable_img.jpg')) }
-      main_display_image_alt_text { "sample image" }
+      main_display_image_caption { "sample image caption" }
+      main_display_image_alt_text { "sample image alt text" }
     end
 
     trait :with_multimedia do

--- a/spec/features/admin/admin_adoptions_spec.rb
+++ b/spec/features/admin/admin_adoptions_spec.rb
@@ -54,7 +54,7 @@ describe 'Admin Adoptions Tab', type: :feature do
 
   it 'should allow an admin to download adoption data as a .xlsx file' do
     go_to_adoptions
-    export_button  find(:css, "input[value='Download All']")
+    export_button = find(:css, "input[value='Download All']")
     export_button.click
 
     # should not navigate away from metrics page

--- a/spec/features/admin/email_selected_practices_editors_spec.rb
+++ b/spec/features/admin/email_selected_practices_editors_spec.rb
@@ -51,7 +51,7 @@ describe 'Admin email all editors button', type: :feature do
     visit admin_practices_path
 
     [recently_updated_practice, older_practice, unemailed_practice].each do |practice|
-      create(:practice_editor, user: editors.first, practice: practice)
+      create(:practice_editor, user: editors.first, innovable: practice)
     end
 
     page.driver.browser.manage.window.resize_to(1920, 1080)
@@ -62,8 +62,8 @@ describe 'Admin email all editors button', type: :feature do
   end
 
   it 'sends an email to all editors of unfiltered and published practices' do
-    create(:practice_editor, user: editors.second, practice: recently_updated_practice)
-    create(:practice_editor, user: user, practice: recently_updated_practice)
+    create(:practice_editor, user: editors.second, innovable: recently_updated_practice)
+    create(:practice_editor, user: user, innovable: recently_updated_practice)
 
     filter_practices_and_send_email
 

--- a/spec/features/practice_editor/authorization_spec.rb
+++ b/spec/features/practice_editor/authorization_spec.rb
@@ -10,7 +10,7 @@ describe 'Practice editor', type: :feature, js: true do
         @admin.add_role(User::USER_ROLES[0].to_sym)
         @approver.add_role(User::USER_ROLES[0].to_sym)
         @user_practice = Practice.create!(name: 'The Best Innovation Ever!', user: @user, initiating_facility: 'Test facility name', initiating_facility_type: 'other', tagline: 'Test tagline')
-        @practice_editor = PracticeEditor.create!(practice: @practice, user: @user_2, email: @user_2.email)
+        @practice_editor = PracticeEditor.create!(innovable: @practice, user: @user_2, email: @user_2.email)
     end
 
     describe 'Authorization' do

--- a/spec/features/practice_editor/editors_spec.rb
+++ b/spec/features/practice_editor/editors_spec.rb
@@ -41,7 +41,7 @@ describe 'Practice editor', type: :feature, js: true do
       end
 
       it 'should allow a user to reach the Editors page if they are at least one of the following: practice owner, admin, or practice editor' do
-        PracticeEditor.create!(practice: @practice, user: @user, email: @user.email)
+        PracticeEditor.create!(innovable: @practice, user: @user, email: @user.email)
         login_and_visit_editors(@user)
         expect(page).to have_content('Editors')
         expect(page).to have_content('Add Editor')

--- a/spec/features/practice_editor/introduction/introduction_spec.rb
+++ b/spec/features/practice_editor/introduction/introduction_spec.rb
@@ -541,7 +541,7 @@ describe 'Practice editor - introduction', type: :feature do
 
       it 'does not show Communities categories for non-admin' do
         editor = User.create!(email: 'some.guy@va.gov', password: 'Password123', password_confirmation: 'Password123', skip_va_validation: true, confirmed_at: Time.now, accepted_terms: true)
-        PracticeEditor.create!(user: editor, practice: @practice, email: editor.email)
+        PracticeEditor.create!(user: editor, innovable: @practice, email: editor.email)
 
         login_as(editor, :scope => :user, :run_callbacks => false)
         visit_practice_edit

--- a/spec/features/product_editor/description_spec.rb
+++ b/spec/features/product_editor/description_spec.rb
@@ -94,6 +94,51 @@ describe 'Product editor - description', type: :feature do
       expect(product.categories).to include(cat2)
       expect(product.categories).to_not include(cat1)
     end
+
+    context 'when managing the thumbnail image' do
+      it 'uploads and displays the thumbnail image' do
+        visit product_description_path(product)
+        attach_file 'product_main_display_image', Rails.root.join('spec/assets/acceptable_img.jpg')
+        fill_in 'product_main_display_image_caption', with: 'Caption text'
+        fill_in 'product_main_display_image_alt_text', with: 'Alt Text'
+        click_link 'Save and Continue'
+
+        expect(page).to have_content('Product was successfully updated.')
+        visit product_description_path(product)
+        expect(page).to have_css("img[src*='acceptable_img.jpg']")
+      end
+
+      it 'updates the caption and alt text for the thumbnail image' do
+        product.update!(main_display_image_alt_text: "Test", main_display_image_caption: "Other Test")
+        visit product_description_path(product)
+
+        attach_file 'product_main_display_image', Rails.root.join('spec/assets/acceptable_img.jpg')
+
+        fill_in 'product_main_display_image_caption', with: 'Updated Caption'
+        fill_in 'product_main_display_image_alt_text', with: 'Updated Alt Text'
+        click_link 'Save and Continue'
+
+        expect(page).to have_content('Product was successfully updated.')
+        product.reload
+        expect(product.main_display_image_caption).to eq('Updated Caption')
+        expect(product.main_display_image_alt_text).to eq('Updated Alt Text')
+      end
+
+      it 'removes the thumbnail image' do
+        product.update!(main_display_image_alt_text: "Test", main_display_image_caption: "Other Test")
+        product.update(main_display_image: fixture_file_upload('spec/assets/acceptable_img.jpg', 'image/jpg'))
+
+        visit product_description_path(product)
+        find('label', text: 'Remove image').click
+        click_link 'Save and Continue'
+
+        expect(page).to have_content('Product was successfully updated.')
+        visit product_description_path(product)
+
+        product.reload
+        expect(product.main_display_image.exists?).to be false
+      end
+    end
   end
 
   describe 'when not logged in' do

--- a/spec/features/product_editor/editors_spec.rb
+++ b/spec/features/product_editor/editors_spec.rb
@@ -1,12 +1,10 @@
-require 'rails_helper'
-
 describe 'Product editor - Editors', type: :feature do
-  let!(:product) { create(:product)}
-  let!(:user) { create(:user) } 
-  let!(:admin) { create(:user, :admin)}
+  let!(:product) { create(:product) }
+  let!(:user) { create(:user) }
+  let!(:admin) { create(:user, :admin) }
 
   before do
-    login_as(current_user, :scope => :user, :run_callbacks => false)
+    login_as(current_user, scope: :user, run_callbacks: false)
   end
 
   describe 'when logged in as a regular user' do
@@ -24,9 +22,75 @@ describe 'Product editor - Editors', type: :feature do
   describe 'when logged in as an admin' do
     let(:current_user) { admin }
 
-    it 'allows access and displays the product description form' do
+    it 'allows access and displays the product editors form' do
       visit product_editors_path(product)
-      expect(page).to have_selector('h1', text:'Editors')
+      expect(page).to have_selector('h1', text: 'Editors')
+    end
+
+    context 'Adding and managing editors' do
+      describe 'Adding a new editor successfully' do
+        before do
+          allow(PracticeEditorMailer).to receive(:invite_to_edit).and_return(double("mailer", deliver: true))
+        end
+
+        it 'adds the editor and shows a confirmation message' do
+          visit product_editors_path(product)
+          fill_in 'Provide va.gov email of the individual who can help you edit this Innovation Page.', with: user.email
+          click_button 'Send Invitation'
+
+          expect(PracticeEditorMailer).to have_received(:invite_to_edit).with(product, anything)
+          expect(page).to have_content("Editor was added to the list. Product was successfully updated.")
+          within('.editors') do
+            expect(page).to have_content(user.email)
+          end
+        end
+      end
+
+      describe 'Adding an editor who is already on the list' do
+        before { product.practice_editors.create(user: user, email: user.email) }
+
+        it 'displays an error message' do
+          visit product_editors_path(product)
+          fill_in 'Provide va.gov email of the individual who can help you edit this Innovation Page.', with: user.email
+          click_button 'Send Invitation'
+
+          expect(page).to have_content("A user with the email \"#{user.email}\" is already an editor for this product")
+        end
+      end
+
+      describe 'Removing an existing editor' do
+        let!(:editor) { product.practice_editors.create(user: user, email: user.email) }
+        let(:user2) { create(:user) }
+        let!(:editor2) { product.practice_editors.create(user: user2, email: user2.email) }
+
+        it 'removes the editor and shows a confirmation message' do
+          visit product_editors_path(product)
+          accept_confirm("Are you sure you want to remove #{user.email} from the editors list?") do
+            find("a#delete-practice-editor-#{editor.id}").click
+          end
+
+          expect(page).to have_content("Editor was removed from the list. Product was successfully updated.")
+          within('.editors') do
+            expect(page).not_to have_content(user.email)
+          end
+        end
+      end
+
+      describe 'Attempting to remove the last editor' do
+        let!(:editor) { product.practice_editors.create(user: user, email: user.email) }
+
+        it 'shows an error message and keeps the editor in the list' do
+          visit product_editors_path(product)
+          accept_confirm("Are you sure you want to remove #{user.email} from the editors list?") do
+            find("a#delete-practice-editor-#{editor.id}").click
+          end
+
+          expect(page).to have_content("At least one editor is required")
+          within('.editors') do
+            expect(page).to have_content(user.email)
+          end
+        end
+      end
     end
   end
 

--- a/spec/features/users/recommended_for_you_spec.rb
+++ b/spec/features/users/recommended_for_you_spec.rb
@@ -35,10 +35,10 @@ describe 'Recommended for you page', type: :feature do
     @user_practice2 = UserPractice.create!(practice: @practice2, user: @user2, favorited: true, time_favorited: DateTime.now.midnight - 8.days)
     @user_practice3 = UserPractice.create!(practice: @practice3, user: @user2, favorited: true, time_favorited: DateTime.now.midnight - 6.days)
     @user_practice4 = UserPractice.create!(practice: @practice4, user: @user2, favorited: true, time_favorited: nil)
-    PracticeEditor.create!(practice: @practice, user: @user2, email: @user2.email)
-    PracticeEditor.create!(practice: @practice2, user: @user2, email: @user2.email)
-    PracticeEditor.create!(practice: @practice3, user: @user2, email: @user2.email)
-    PracticeEditor.create!(practice: @practice4, user: @user2, email: @user2.email)
+    PracticeEditor.create!(innovable: @practice, user: @user2, email: @user2.email)
+    PracticeEditor.create!(innovable: @practice2, user: @user2, email: @user2.email)
+    PracticeEditor.create!(innovable: @practice3, user: @user2, email: @user2.email)
+    PracticeEditor.create!(innovable: @practice4, user: @user2, email: @user2.email)
   end
 
   def login_and_visit_recommended_path(user)

--- a/spec/features/users/user_profile_spec.rb
+++ b/spec/features/users/user_profile_spec.rb
@@ -92,7 +92,7 @@ describe 'The user index', type: :feature do
     it 'should have created practices' do
     @practice1 = Practice.create!(name: 'A public practice', approved: true, published: true, tagline: 'Test tagline', user: @user)
     @practice2 = Practice.create!(name: 'The Best Innovation Ever!', approved: true, published: true, tagline: 'Test tagline', user: @user2)
-    @user_pr1_editor = PracticeEditor.create!(practice: @practice1, user: @user, email: @user.email)
+    @user_pr1_editor = PracticeEditor.create!(innovable: @practice1, user: @user, email: @user.email)
 
     login_as(@user, scope: :user, run_callbacks: false)
     visit "/users/#{@user.id}"
@@ -114,7 +114,7 @@ describe 'The user index', type: :feature do
     end
 
     # add user as just an editor of practice2
-    PracticeEditor.create!(practice: @practice2, user: @user, email: @user.email)
+    PracticeEditor.create!(innovable: @practice2, user: @user, email: @user.email)
     visit "/users/#{@user.id}"
 
     within(:css, '.dm-created-practices') do

--- a/spec/models/practice_editor_spec.rb
+++ b/spec/models/practice_editor_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe PracticeEditor, type: :model do
   describe 'associations' do
-    it { should belong_to(:practice) }
+    it { should belong_to(:innovable) }
     it { should belong_to(:user) }
   end
 end

--- a/spec/services/practice_mailer_service_spec.rb
+++ b/spec/services/practice_mailer_service_spec.rb
@@ -15,9 +15,9 @@ RSpec.describe PracticeMailerService do
     let!(:unpublished_practice) { create(:practice, name: "Innovation C", user: user, published: false, updated_at: 1.day.ago) }
 
     before do
-      create(:practice_editor, user: user2, practice: practice_a)
-      create(:practice_editor, user: user, practice: practice_b)
-      create(:practice_editor, user: user3, practice: unpublished_practice)
+      create(:practice_editor, user: user2, innovable: practice_a)
+      create(:practice_editor, user: user, innovable: practice_b)
+      create(:practice_editor, user: user3, innovable: unpublished_practice)
 
       ActionMailer::Base.deliveries.clear
       Sidekiq::Testing.inline!

--- a/spec/services/save_product_service_spec.rb
+++ b/spec/services/save_product_service_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe SaveProductService do
+  subject(:service) { described_class.new(product: product, product_params: product_params, multimedia_params: multimedia_params) }
+
   let!(:category) { create(:category) }
   let!(:sub_category) { create(:category, parent_category: category) }
   let!(:product) { create(:product, :with_image, :with_multimedia, :with_va_employees) }
@@ -28,24 +30,23 @@ RSpec.describe SaveProductService do
     }
   end
 
-  subject { described_class.new(product: product, product_params: product_params, multimedia_params: multimedia_params) }
 
   describe "#call" do
     context "when valid product params are provided" do
       it "successfully updates the product" do
-        result = subject.call
-        expect(result).to be true
+        service.call
+
         expect(product.reload.name).to eq "Updated Product"
         expect(product.tagline).to eq "Updated tagline"
       end
 
       it "updates the multimedia attributes" do
-        subject.call
+        service.call
         expect(product.practice_multimedia.first.link_url).to eq "https://updated.com"
       end
 
       it "updates the category associations" do
-        subject.call
+        service.call
         expect(product.categories).to include(sub_category)
       end
     end
@@ -57,7 +58,7 @@ RSpec.describe SaveProductService do
 
       it "removes the image and updates the product" do
         expect(product.main_display_image.present?).to be true
-        subject.call
+        service.call
         expect(product.reload.main_display_image.present?).to be false
       end
     end
@@ -70,7 +71,7 @@ RSpec.describe SaveProductService do
       end
 
       it "successfully adds an editor" do
-        expect { subject.call }.to change { product.practice_editors.count }.by(1)
+        expect { service.call }.to change { product.practice_editors.count }.by(1)
         expect(product.practice_editors.last.user).to eq(user)
         expect(PracticeEditorMailer).to have_received(:invite_to_edit).with(product, instance_of(User)).once
       end
@@ -78,8 +79,8 @@ RSpec.describe SaveProductService do
       it "does not add a duplicate editor" do
         product.practice_editors.create(user: user, email: user.email)
 
-        expect { subject.call }.not_to change { product.practice_editors.count }
-        expect(subject.errors).to include("A user with the email \"#{user.email}\" is already an editor for this product")
+        expect { service.call }.not_to(change { product.practice_editors.count })
+        expect(service.errors).to include("A user with the email \"#{user.email}\" is already an editor for this product")
       end
 
       it "fails when no matching user exists" do
@@ -91,7 +92,10 @@ RSpec.describe SaveProductService do
           multimedia_params: {}
         )
 
-        expect(service_with_invalid_email.call).to be false
+        service_with_invalid_email.call
+        product.reload
+
+        expect(product.practice_editors).not_to include(non_existent_email)
         expect(service_with_invalid_email.errors).to include("No user found with the email \"#{non_existent_email}\"")
       end
     end
@@ -102,15 +106,18 @@ RSpec.describe SaveProductService do
       let!(:practice_editor2) { product.practice_editors.create(user: user2, email: user2.email) }
       let(:product_params) { { delete_editor: practice_editor.id } }
 
-      it "successfully removes the editor" do
-        expect { subject.call }.to change { product.practice_editors.count }.by(-1)
+      it "successfully removes the specified editor and retains the other editor" do
+        service.call
+
+        expect(product.practice_editors.reload).not_to include(practice_editor)
+        expect(product.practice_editors).to include(practice_editor2)
       end
 
       it "fails when the editor does not exist" do
         invalid_params = { delete_editor: 999 }
         service_with_invalid_id = described_class.new(product: product, product_params: invalid_params, multimedia_params: {})
-        expect(service_with_invalid_id.call).to be false
-        expect(service_with_invalid_id.errors).to include("Editor has already been removed")
+        service_with_invalid_id.call
+        expect(service_with_invalid_id.errors).to include("User is not an editor for this practice")
       end
     end
 
@@ -121,8 +128,7 @@ RSpec.describe SaveProductService do
           product_params: {},
           multimedia_params: {}
         )
-        result = service.call
-        expect(result).to be false
+        service.call
         expect(product.reload.name).not_to eq "Updated Product"
       end
     end
@@ -132,9 +138,9 @@ RSpec.describe SaveProductService do
       let(:multimedia_params) { {} }
 
       it "returns false and adds the error message" do
-        result = subject.call
-        expect(result).to be false
-        expect(subject.errors).to include("Name can't be blank") # Adjust to match actual validation message
+        service.call
+
+        expect(service.errors).to include("Name can't be blank")
       end
     end
   end


### PR DESCRIPTION
### JIRA issue link
https://agile6.atlassian.net/browse/DM-5201

## Description - what does this code do?
* Adds `:main_display_image_caption` col to `products` table

* Adds `Product` model validation for `:main_display_image_caption` and `:main_display_image_alt_text` when main disp image is present

* Adds text field for `:main_display_image_alt_text` and `:main_display_image_caption` to `/editor/description` page in product editor workflow

* Also re-adds `data-model-type` value to top-level div in `image_editor` partial that was mistakenly removed in rebase of last branch merged into feature branch (needed for making the image handling js work)

## Testing done - how did you test it/steps on how can another person can test it 
1. go `/products/thermal-fuse-cover/edit/description` and verify you can add text to the caption and alt-text fields
2. go back to the previous page and verify you can switch out the "Thumbnail" image with a different image and the change persists upon form submission.
3. go to the "Introduction" page of the innovation editor for a `practice` and repeat step 2 to verify the "Thumbnail" image can be switched and the change persists upon form submission.
4. Verify the form will refresh with an error indicating you cannot leave the caption or alt-text fields blank when there is no image present.

## Screenshots, Gifs, Videos from application (if applicable)
![Screenshot 2024-10-14 at 12 17 49 PM](https://github.com/user-attachments/assets/153b904b-c174-40f8-9b79-39da90ef4cd1)

## Link to mock-ups/mock ups (image file if you have it) (if applicable)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Unit tests written (if applicable)
- [ ] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating JIRA issue
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs