### PR TITLE
DM-5081: In-page sidenav and other Product page tweaks

### DIFF
--- a/app/assets/javascripts/practice_page.es6
+++ b/app/assets/javascripts/practice_page.es6
@@ -15,7 +15,7 @@
 
     function highlightSidebarSectionWhenInView() {
         let sections = {};
-        const sideNavHeaders = $('.nav-header');
+        const sideNavHeaders = $('.sidenav-header');
         sideNavHeaders.each(function() {
             const headerSelector = `#${this.id}`;
             sections[headerSelector] = `.sidebar-${this.id}`;

--- a/app/assets/stylesheets/dm/components/_sidenav.scss
+++ b/app/assets/stylesheets/dm/components/_sidenav.scss
@@ -1,6 +1,7 @@
 // `usa-sidenav` OVERRIDES
 .usa-sidenav__item {
-  .usa-current, a:hover {
+  .usa-current,
+  a:hover {
     color: color($theme-link-color) !important;
   }
 }

--- a/app/assets/stylesheets/dm/components/_sidenav.scss
+++ b/app/assets/stylesheets/dm/components/_sidenav.scss
@@ -1,6 +1,6 @@
 // `usa-sidenav` OVERRIDES
 .usa-sidenav__item {
   .usa-current, a:hover {
-    color: color($theme-color-primary-vivid) !important;
+    color: color($theme-link-color) !important;
   }
 }

--- a/app/assets/stylesheets/dm/pages/_products.scss
+++ b/app/assets/stylesheets/dm/pages/_products.scss
@@ -1,5 +1,10 @@
 #main-content.products.show-main {
 	#show-page-siderail { // TO DO: extract this after migrating practices template
+		#show-page-siderail-sticky {
+			position: sticky;
+			top: 4rem;
+		}
+
 		.desktop-tags {
 			display: none;
 			border: 1px solid color($theme-color-base-lighter);
@@ -13,6 +18,7 @@
 	        	display: block;
 	    	}
 		}
+
 		.show-page-tag {
 			display: block;
 			width: fit-content;

--- a/app/assets/stylesheets/dm/pages/_products.scss
+++ b/app/assets/stylesheets/dm/pages/_products.scss
@@ -5,6 +5,28 @@
 			top: 4rem;
 		}
 
+		#product-show-sidenav {
+			ul.usa-sidenav  {
+				border-left: 1px solid color($theme-color-base-lighter);
+				border-bottom: none;
+			}
+			.usa-sidenav__item {
+				border: none;
+				a, a:hover, a:focus, a:active, a:visited {
+					color: color($theme-link-color);
+					font-weight: 700;
+
+					&.usa-current {
+						color: color($theme-color-base-ink) !important;
+					}
+
+					&.usa-current::after {
+						background-color: color($theme-color-base-ink);
+					}
+				}
+			}
+		}
+
 		.desktop-tags {
 			display: none;
 			border: 1px solid color($theme-color-base-lighter);

--- a/app/views/practices/show/about/_about.html.erb
+++ b/app/views/practices/show/about/_about.html.erb
@@ -3,7 +3,7 @@
   team_members = @practice.va_employees
 %>
 
-<section id="about" class="grid-container nav-header">
+<section id="about" class="grid-container sidenav-header">
   <div class="grid-row grid-gap">
     <div class="desktop:grid-col-3 desktop:grid-col-auto desktop:z-bottom desktop:display-block display-none">&nbsp;</div>
     <div class="desktop:grid-col-9 grid-col-12 padding-top-10">

--- a/app/views/practices/show/contact/_contact.html.erb
+++ b/app/views/practices/show/contact/_contact.html.erb
@@ -1,4 +1,4 @@
-<section id="contact" class="grid-container nav-header">
+<section id="contact" class="grid-container sidenav-header">
   <div class="grid-row grid-gap-2">
     <div class="desktop:grid-col-3 desktop:grid-col-auto desktop:z-bottom desktop:display-block display-none">&nbsp;</div>
     <div class="desktop:grid-col-9 grid-col-12 padding-top-10">

--- a/app/views/practices/show/mobile_partials/_search_terms.html.erb
+++ b/app/views/practices/show/mobile_partials/_search_terms.html.erb
@@ -1,4 +1,4 @@
-<section class="search-terms-section margin-bottom-neg-1 desktop-hide">
+<section class="search-terms-section margin-bottom-2 desktop-hide">
   <div class="grid-container">
     <div class="height-05 width-8 border-top-05 border-primary-dark margin-top-5"></div>
     <h3 class="font-sans-lg margin-y-2">Search tags</h3>

--- a/app/views/practices/show/show.html.erb
+++ b/app/views/practices/show/show.html.erb
@@ -74,7 +74,7 @@
 </div>
 
 <!-- Overview-Problem-->
-<section id="overview" class="margin-bottom-5 grid-container nav-header">
+<section id="overview" class="margin-bottom-5 grid-container sidenav-header">
   <div class="grid-row grid-gap-2">
     <div class="desktop:grid-col-3 desktop:grid-col-auto desktop:z-bottom desktop:display-block display-none">&nbsp;</div>
     <div class="desktop:grid-col-9 grid-col-12 padding-top-6">
@@ -150,7 +150,7 @@
 
 <!-- Implementation section -->
 <% if implementation_data_present %>
-  <section id="implementation" class="grid-container nav-header">
+  <section id="implementation" class="grid-container sidenav-header">
     <div class="grid-row grid-gap-2">
       <div class="desktop:grid-col-3 desktop:grid-col-auto desktop:z-bottom desktop:display-block display-none">&nbsp;</div>
       <div class="desktop:grid-col-9 grid-col-12 padding-top-10">

--- a/app/views/products/form/description.html.erb
+++ b/app/views/products/form/description.html.erb
@@ -21,7 +21,7 @@
                 <% end %>
                 <span>What should your product be called?</span>&nbsp;
               </div>
-              <%= f.text_field :name, class: "usa-input #{ @product.errors[:name].any? ? 'usa-input--error' : '' } display-block practice-editor-name-input dm-required-field", required: true %>
+              <%= f.text_field :name, class: "usa-input #{ @product.errors[:name].any? ? 'usa-input--error' : '' } display-block practice-editor-name-input dm-required-field" %>
 
               <p class="usa-error-message <%= @product.errors[:name].any? ? 'fas fa-exclamation-circle fon' : 'display-none' %>">&nbsp;<span class="font-family-sans"><%= show_errors(@product, :name) %></span>
               </p>
@@ -33,7 +33,7 @@
                 <% end %>
                 <span>How would you summarize the key outcomes of your product in the shortest sentence possible? Note that this will only be leveraged on the search results page.</span>&nbsp;
               </div>
-              <%= f.text_field :tagline, class: "usa-input #{ @product.errors[:tagline].any? ? 'usa-input--error' : '' } display-block practice-editor-name-input dm-required-field", required: true %>
+              <%= f.text_field :tagline, class: "usa-input #{ @product.errors[:tagline].any? ? 'usa-input--error' : '' } display-block practice-editor-name-input dm-required-field" %>
 
               <p class="usa-error-message <%= @product.errors[:tagline].any? ? 'fas fa-exclamation-circle fon' : 'display-none' %>">&nbsp;<span class="font-family-sans"><%= show_errors(@product, :tagline) %></span>
               </p>
@@ -45,7 +45,7 @@
                 <% end %>
                 <span>Provide a short summary of your product’s mission. Include relevant information about the product's features, material, size, and more.</span>&nbsp;
               </div>
-              <%= f.text_area :description, class: "usa-textarea #{ @product.errors[:description].any? ? 'usa-input--error' : '' } display-block practice-editor-overview-statement-input dm-required-field", required: true %>
+              <%= f.text_area :description, class: "usa-textarea #{ @product.errors[:description].any? ? 'usa-input--error' : '' } display-block practice-editor-overview-statement-input dm-required-field" %>
 
               <p class="usa-error-message <%= @product.errors[:description].any? ? 'fas fa-exclamation-circle fon' : 'display-none' %>">&nbsp;
                 <span class="font-family-sans"><%= show_errors(@product, :description) %></span>
@@ -58,7 +58,7 @@
                 <% end %>
                 <span>Provide the item number to help individuals identify and purchase your product.</span>&nbsp;
               </div>
-              <%= f.text_field :item_number, class: "usa-input #{ @product.errors[:item_number].any? ? 'usa-input--error' : '' } display-block practice-editor-name-input dm-required-field", required: true %>
+              <%= f.text_field :item_number, class: "usa-input #{ @product.errors[:item_number].any? ? 'usa-input--error' : '' } display-block practice-editor-name-input dm-required-field" %>
 
               <p class="usa-error-message <%= @product.errors[:item_number].any? ? 'fas fa-exclamation-circle fon' : 'display-none' %>">&nbsp;
                 <span class="font-family-sans"><%= show_errors(@product, :item_number) %></span>
@@ -71,7 +71,7 @@
                 <% end %>
                 <span>Provide the name of the person or business that sells your product.</span>&nbsp;
               </div>
-              <%= f.text_field :vendor, class: "usa-input #{ @product.errors[:vendor].any? ? 'usa-input--error' : '' } display-block practice-editor-name-input dm-required-field", required: true %>
+              <%= f.text_field :vendor, class: "usa-input #{ @product.errors[:vendor].any? ? 'usa-input--error' : '' } display-block practice-editor-name-input dm-required-field" %>
 
               <p class="usa-error-message <%= @product.errors[:vendor].any? ? 'fas fa-exclamation-circle fon' : 'display-none' %>">&nbsp;
                 <span class="font-family-sans"><%= show_errors(@product, :vendor) %></span>
@@ -84,7 +84,7 @@
                 <% end %>
                 <span>Et harum quidem rerum facilis est et expedita distinctio.</span>&nbsp;
               </div>
-              <%= f.text_field :vendor_link, class: "usa-input #{ @product.errors[:vendor_link].any? ? 'usa-input--error' : '' } display-block practice-editor-name-input dm-required-field", required: false %>
+              <%= f.text_field :vendor_link, class: "usa-input #{ @product.errors[:vendor_link].any? ? 'usa-input--error' : '' } display-block practice-editor-name-input dm-required-field" %>
 
               <p class="usa-error-message <%= @product.errors[:vendor].any? ? 'fas fa-exclamation-circle fon' : 'display-none' %>">&nbsp;
                 <span class="font-family-sans"><%= show_errors(@product, :vendor) %></span>

--- a/app/views/products/form/description.html.erb
+++ b/app/views/products/form/description.html.erb
@@ -15,13 +15,13 @@
           <fieldset class="usa-fieldset grid-col-10">
             <legend class="usa-sr-only">Product Description</legend>
             <div class="margin-bottom-5 margin-top-3">
-              <div>
+              <div> 
                 <%= f.label :name, class: 'usa-label text-bold display-block margin-top-0 margin-bottom-2' do %>
                   Product Title*
                 <% end %>
                 <span>What should your product be called?</span>&nbsp;
               </div>
-              <%= f.text_field :name, class: "usa-input #{ @product.errors[:name].any? ? 'usa-input--error' : '' } display-block practice-editor-name-input dm-required-field" %>
+              <%= f.text_field :name, class: "usa-input #{ @product.errors[:name].any? ? 'usa-input--error' : '' } display-block practice-editor-name-input dm-required-field", required: true %>
 
               <p class="usa-error-message <%= @product.errors[:name].any? ? 'fas fa-exclamation-circle fon' : 'display-none' %>">&nbsp;<span class="font-family-sans"><%= show_errors(@product, :name) %></span>
               </p>
@@ -45,7 +45,7 @@
                 <% end %>
                 <span>Provide a short summary of your product’s mission. Include relevant information about the product's features, material, size, and more.</span>&nbsp;
               </div>
-              <%= f.text_area :description, class: "usa-textarea #{ @product.errors[:description].any? ? 'usa-input--error' : '' } display-block practice-editor-overview-statement-input dm-required-field" %>
+              <%= f.text_area :description, class: "usa-textarea #{ @product.errors[:description].any? ? 'usa-input--error' : '' } display-block practice-editor-overview-statement-input" %>
 
               <p class="usa-error-message <%= @product.errors[:description].any? ? 'fas fa-exclamation-circle fon' : 'display-none' %>">&nbsp;
                 <span class="font-family-sans"><%= show_errors(@product, :description) %></span>
@@ -54,11 +54,11 @@
             <div class="margin-bottom-5 margin-top-3">
               <div>
                 <%= f.label :item_number, class: 'usa-label text-bold display-block margin-top-0 margin-bottom-2' do %>
-                  Item Number*
+                  Item Number
                 <% end %>
                 <span>Provide the item number to help individuals identify and purchase your product.</span>&nbsp;
               </div>
-              <%= f.text_field :item_number, class: "usa-input #{ @product.errors[:item_number].any? ? 'usa-input--error' : '' } display-block practice-editor-name-input dm-required-field" %>
+              <%= f.text_field :item_number, class: "usa-input #{ @product.errors[:item_number].any? ? 'usa-input--error' : '' } display-block practice-editor-name-input" %>
 
               <p class="usa-error-message <%= @product.errors[:item_number].any? ? 'fas fa-exclamation-circle fon' : 'display-none' %>">&nbsp;
                 <span class="font-family-sans"><%= show_errors(@product, :item_number) %></span>
@@ -67,11 +67,11 @@
             <div class="margin-bottom-5 margin-top-3">
               <div>
                 <%= f.label :vendor, class: 'usa-label text-bold display-block margin-top-0 margin-bottom-2' do %>
-                  Vendor*
+                  Vendor
                 <% end %>
                 <span>Provide the name of the person or business that sells your product.</span>&nbsp;
               </div>
-              <%= f.text_field :vendor, class: "usa-input #{ @product.errors[:vendor].any? ? 'usa-input--error' : '' } display-block practice-editor-name-input dm-required-field" %>
+              <%= f.text_field :vendor, class: "usa-input #{ @product.errors[:vendor].any? ? 'usa-input--error' : '' } display-block practice-editor-name-input" %>
 
               <p class="usa-error-message <%= @product.errors[:vendor].any? ? 'fas fa-exclamation-circle fon' : 'display-none' %>">&nbsp;
                 <span class="font-family-sans"><%= show_errors(@product, :vendor) %></span>
@@ -84,7 +84,7 @@
                 <% end %>
                 <span>Et harum quidem rerum facilis est et expedita distinctio.</span>&nbsp;
               </div>
-              <%= f.text_field :vendor_link, class: "usa-input #{ @product.errors[:vendor_link].any? ? 'usa-input--error' : '' } display-block practice-editor-name-input dm-required-field" %>
+              <%= f.text_field :vendor_link, class: "usa-input #{ @product.errors[:vendor_link].any? ? 'usa-input--error' : '' } display-block practice-editor-name-input" %>
 
               <p class="usa-error-message <%= @product.errors[:vendor].any? ? 'fas fa-exclamation-circle fon' : 'display-none' %>">&nbsp;
                 <span class="font-family-sans"><%= show_errors(@product, :vendor) %></span>

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -17,27 +17,27 @@
 
 <div class="grid-container grid-row">
 	<div id="show-page-siderail" class="grid-col-12 tablet:grid-col-3">
-		  <div class="margin-bottom-4">
-		    <nav id="product-show-sidenav" aria-label="Side navigation,">
-				  <ul class="usa-sidenav">
-				    <li class="usa-sidenav__item">
-				      <a href="#product-description" class="usa-current scroll-to" data-target="#product-description" data-turbolinks="false" class="usa-current">Product Description</a>
-				    </li>
-				    <li class="usa-sidenav__item">
-				      <a href="#intrapreneur" class="scroll-to" data-target="#intrapreneur" data-turbolinks="false">Intrapreneur</a>
-				    </li>
-				    <li class="usa-sidenav__item">
-				      <a href="#multimedia" class="scroll-to" data-target="#multimedia" data-turbolinks="false">Multimedia</a>
-				    </li>
-				    <li class="usa-sidenav__item">
-				      <a href="#order" class="scroll-to" data-target="#order" data-turbolinks="false">Order Product</a>
-				    </li>
-				  </ul>
-				</nav>
-		  </div>
-		<% if @search_terms.any? %>
-	        <%= render partial: 'practices/show/desktop_partials/search_terms', locals: { search_terms: @search_terms } %>
-	  <% end %>
+		<div id="show-page-siderail-sticky">
+	    <nav id="product-show-sidenav" class="margin-bottom-4" aria-label="Side navigation,">
+			  <ul class="usa-sidenav">
+			    <li class="usa-sidenav__item">
+			      <a href="#product-description" class="usa-current scroll-to" data-target="#product-description" data-turbolinks="false" class="usa-current">Product Description</a>
+			    </li>
+			    <li class="usa-sidenav__item">
+			      <a href="#intrapreneur" class="scroll-to" data-target="#intrapreneur" data-turbolinks="false">Intrapreneur</a>
+			    </li>
+			    <li class="usa-sidenav__item">
+			      <a href="#multimedia" class="scroll-to" data-target="#multimedia" data-turbolinks="false">Multimedia</a>
+			    </li>
+			    <li class="usa-sidenav__item">
+			      <a href="#order" class="scroll-to" data-target="#order" data-turbolinks="false">Order Product</a>
+			    </li>
+			  </ul>
+			</nav>
+			<% if @search_terms.any? %>
+		        <%= render partial: 'practices/show/desktop_partials/search_terms', locals: { search_terms: @search_terms } %>
+		  <% end %>
+		</div>
 	</div>
 	<div class="grid-col-12 tablet:grid-col-9">
 		<section id="pr-view-introduction" class="grid-container margin-bottom-3">

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -60,7 +60,7 @@
 				[:main_display_image, "Main Product Image", {heading: false}], # replace this with partial to render
 				[:practice_partners, "Partners", {content: @product&.practice_partners.pluck(:name).join(', ')}],
 				[:item_number, "Item Number"],
-				[:vendor, "Vendor", {content: @product.vendor_link.present? ? link_to(@product.vendor, @product.vendor_link, class: ".usa-link .usa-link--external") : @product.vendor }],
+				[:vendor, "Vendor", {content: (@product.vendor_link.present? && @product.vendor.present?) ? link_to(@product.vendor, @product.vendor_link, class: ".usa-link .usa-link--external") : @product.vendor }],
 				[:duns, "DUNS"],
         [:shipping_timeline_estimate, "Shipping Timeline Estimate"],
 		    [:price, "Price"]
@@ -71,6 +71,7 @@
 					<% if field_name == :main_display_image && @product.main_display_image.exists? %>
 						<%= render partial: 'main_display_image', locals: { product: @product} %>
 					<% else %>
+						<% next if field_options[:content].blank? && @product.send(field_name.to_sym).blank? %>
 						<%= tag.h3 field_label, class: 'font-sans-lg line-height-25px margin-top-2 margin-bottom-1' unless field_options[:heading] == false %>
 						<%= tag.p field_options[:content] %>
 					<% end %>

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -17,6 +17,24 @@
 
 <div class="grid-container grid-row">
 	<div id="show-page-siderail" class="grid-col-12 tablet:grid-col-3">
+		  <div class="margin-bottom-4">
+		    <nav aria-label="Side navigation,">
+				  <ul class="usa-sidenav">
+				    <li class="usa-sidenav__item">
+				      <a href="javascript:void(0);" class="usa-current">Product Description</a>
+				    </li>
+				    <li class="usa-sidenav__item">
+				      <a href="javascript:void(0);">Intrapreneur</a>
+				    </li>
+				    <li class="usa-sidenav__item">
+				      <a href="javascript:void(0);">Multimedia</a>
+				    </li>
+				    <li class="usa-sidenav__item">
+				      <a href="javascript:void(0);">Order Product</a>
+				    </li>
+				  </ul>
+				</nav>
+		  </div>
 		<% if @search_terms.any? %>
 	        <%= render partial: 'practices/show/desktop_partials/search_terms', locals: { search_terms: @search_terms } %>
 	  <% end %>

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -97,11 +97,11 @@
 		  <section id="practice-show-multimedia" class="margin-bottom-5 grid-container">
 		    <div class="grid-row grid-gap-2">
 		      <div class="desktop:grid-col-9 grid-col-12">
-		      	<h2>Multimedia</h2><span>TO DO: fix partial to fix different heading levels</span>
+		      	<h2>Images and Video</h2>
 		        <div class="multimedia-section practice-section">
 		        	<% # temporarily skip files while troubleshooting %>
 		        	<% multimedia = @product.practice_multimedia.where.not(resource_type: "file") %>
-		          <%= render partial: 'practices/show/overview/overview_sections', locals: {resources: multimedia, statement: '', title: 'Multimedia', s_area: 'multimedia'} %>
+		          <%= render partial: 'practices/show/overview/overview_sections', locals: {resources: multimedia, statement: '', title: '', s_area: 'multimedia'} %>
 		        </div>
 		      </div>
 		    </div>

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -43,13 +43,13 @@
 		<section id="pr-view-introduction" class="grid-container margin-bottom-3">
 			<div class="grid-row grid-gap-2">
 				<div class="desktop:grid-col-8 grid-col-12">
-				      <h1 class="margin-top-0 margin-bottom-1 dm-word-break-break-word dm-hyphens-auto">
-				      	<%= @product.name %>
-				      </h1>
-				      <%# innovation last update timestamp %>
+							<%# innovation last update timestamp %>
 				      <p class="grid-col-12 font-sans-3xs text-base line-height-sans-4 margin-bottom-2">
 				        Last updated <%= timeago(@product&.updated_at) %>
 				      </p>
+				      <h1 class="margin-top-0 margin-bottom-1 dm-word-break-break-word dm-hyphens-auto">
+				      	<%= @product.name %>
+				      </h1>
 				</div>
 			</div>
 		</section>

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -18,19 +18,19 @@
 <div class="grid-container grid-row">
 	<div id="show-page-siderail" class="grid-col-12 tablet:grid-col-3">
 		  <div class="margin-bottom-4">
-		    <nav aria-label="Side navigation,">
+		    <nav id="product-show-sidenav" aria-label="Side navigation,">
 				  <ul class="usa-sidenav">
 				    <li class="usa-sidenav__item">
-				      <a href="javascript:void(0);" class="usa-current">Product Description</a>
+				      <a href="#product-description" class="scroll-to" data-target="#product-description" data-turbolinks="false" class="usa-current">Product Description</a>
 				    </li>
 				    <li class="usa-sidenav__item">
-				      <a href="javascript:void(0);">Intrapreneur</a>
+				      <a href="#intrapreneur" class="scroll-to" data-target="#intrapreneur" data-turbolinks="false">Intrapreneur</a>
 				    </li>
 				    <li class="usa-sidenav__item">
-				      <a href="javascript:void(0);">Multimedia</a>
+				      <a href="#multimedia" class="scroll-to" data-target="#multimedia" data-turbolinks="false">Multimedia</a>
 				    </li>
 				    <li class="usa-sidenav__item">
-				      <a href="javascript:void(0);">Order Product</a>
+				      <a href="#order" class="scroll-to" data-target="#order" data-turbolinks="false">Order Product</a>
 				    </li>
 				  </ul>
 				</nav>
@@ -54,7 +54,7 @@
 			</div>
 		</section>
 		<section id="practice-show-product-description" class="grid-container">
-			<h2>Product Description</h2>
+			<h2 id="product-description">Product Description</h2>
 			<% product_description_fields = [
 				[:description, "Executive Summary"],
 				[:main_display_image, "Main Product Image", {heading: false}], # replace this with partial to render
@@ -82,7 +82,7 @@
 			<% end %>
 		</section>
 		<section id="practice-show-intrapreneur" class="grid-container">
-			<h2>Intrapreneur</h2>
+			<h2 id="intrapreneur">Intrapreneur</h2>
 			<h3><%= 'Innovator'.pluralize(@product.va_employee_practices.count) %></h3>
 			<% @product.va_employee_practices.each do |innovator| %>
 				<div class="innovators margin-bottom-1">
@@ -97,7 +97,7 @@
 		  <section id="practice-show-multimedia" class="margin-bottom-5 grid-container">
 		    <div class="grid-row grid-gap-2">
 		      <div class="desktop:grid-col-9 grid-col-12">
-		      	<h2>Images and Video</h2>
+		      	<h2 id="multimedia">Images and Video</h2>
 		        <div class="multimedia-section practice-section">
 		        	<% # temporarily skip files while troubleshooting %>
 		        	<% multimedia = @product.practice_multimedia.where.not(resource_type: "file") %>
@@ -108,7 +108,7 @@
 		  </section>
 		<% end %>
 		<section id="practice-show-order-instructions" class="grid-container">
-			<h2>Order Product</h2>
+			<h2 id="order">Order Product</h2>
 			<ol class="usa-process-list">
 			  <li class="usa-process-list__item">
 			    <h4 class="usa-process-list__heading">Order from the Marketplace</h4>

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -21,7 +21,7 @@
 		    <nav id="product-show-sidenav" aria-label="Side navigation,">
 				  <ul class="usa-sidenav">
 				    <li class="usa-sidenav__item">
-				      <a href="#product-description" class="scroll-to" data-target="#product-description" data-turbolinks="false" class="usa-current">Product Description</a>
+				      <a href="#product-description" class="usa-current scroll-to" data-target="#product-description" data-turbolinks="false" class="usa-current">Product Description</a>
 				    </li>
 				    <li class="usa-sidenav__item">
 				      <a href="#intrapreneur" class="scroll-to" data-target="#intrapreneur" data-turbolinks="false">Intrapreneur</a>

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -21,16 +21,16 @@
 	    <nav id="product-show-sidenav" class="margin-bottom-4" aria-label="Side navigation,">
 			  <ul class="usa-sidenav">
 			    <li class="usa-sidenav__item">
-			      <a href="#product-description" class="usa-current scroll-to" data-target="#product-description" data-turbolinks="false" class="usa-current">Product Description</a>
+			      <a href="#product-description" class="sidebar-product-description usa-current scroll-to" data-target="#product-description" data-turbolinks="false" class="usa-current">Product Description</a>
 			    </li>
 			    <li class="usa-sidenav__item">
-			      <a href="#intrapreneur" class="scroll-to" data-target="#intrapreneur" data-turbolinks="false">Intrapreneur</a>
+			      <a href="#intrapreneur" class="sidebar-intrapreneur scroll-to" data-target="#intrapreneur" data-turbolinks="false">Intrapreneur</a>
 			    </li>
 			    <li class="usa-sidenav__item">
-			      <a href="#multimedia" class="scroll-to" data-target="#multimedia" data-turbolinks="false">Multimedia</a>
+			      <a href="#multimedia" class="sidebar-multimedia scroll-to" data-target="#multimedia" data-turbolinks="false">Multimedia</a>
 			    </li>
 			    <li class="usa-sidenav__item">
-			      <a href="#order" class="scroll-to" data-target="#order" data-turbolinks="false">Order Product</a>
+			      <a href="#order" class="sidebar-order scroll-to" data-target="#order" data-turbolinks="false">Order Product</a>
 			    </li>
 			  </ul>
 			</nav>
@@ -54,7 +54,7 @@
 			</div>
 		</section>
 		<section id="practice-show-product-description" class="grid-container">
-			<h2 id="product-description">Product Description</h2>
+			<h2 id="product-description" class="sidenav-header">Product Description</h2>
 			<% product_description_fields = [
 				[:description, "Executive Summary"],
 				[:main_display_image, "Main Product Image", {heading: false}], # replace this with partial to render
@@ -82,7 +82,7 @@
 			<% end %>
 		</section>
 		<section id="practice-show-intrapreneur" class="grid-container">
-			<h2 id="intrapreneur">Intrapreneur</h2>
+			<h2 id="intrapreneur" class="sidenav-header">Intrapreneur</h2>
 			<h3><%= 'Innovator'.pluralize(@product.va_employee_practices.count) %></h3>
 			<% @product.va_employee_practices.each do |innovator| %>
 				<div class="innovators margin-bottom-1">
@@ -97,7 +97,7 @@
 		  <section id="practice-show-multimedia" class="margin-bottom-5 grid-container">
 		    <div class="grid-row grid-gap-2">
 		      <div class="desktop:grid-col-9 grid-col-12">
-		      	<h2 id="multimedia">Images and Video</h2>
+		      	<h2 id="multimedia" class="sidenav-header">Images and Video</h2>
 		        <div class="multimedia-section practice-section">
 		        	<% # temporarily skip files while troubleshooting %>
 		        	<% multimedia = @product.practice_multimedia.where.not(resource_type: "file") %>
@@ -108,7 +108,7 @@
 		  </section>
 		<% end %>
 		<section id="practice-show-order-instructions" class="grid-container">
-			<h2 id="order">Order Product</h2>
+			<h2 id="order" class="sidenav-header">Order Product</h2>
 			<ol class="usa-process-list">
 			  <li class="usa-process-list__item">
 			    <h4 class="usa-process-list__heading">Order from the Marketplace</h4>

--- a/spec/factories/practice_partners.rb
+++ b/spec/factories/practice_partners.rb
@@ -12,5 +12,9 @@ FactoryBot.define do
     end
 
     is_major { true }
+
+    trait :for_products do
+      sequence :name, ["VHA Innovators Network", "VA Technology Transfer Program", "iNet Seed-Spark-Spread Innovation Investment Program"].cycle
+    end
   end
 end

--- a/spec/factories/products.rb
+++ b/spec/factories/products.rb
@@ -7,6 +7,7 @@ FactoryBot.define do
     vendor_link { "https://va.gov"}
     duns { "123456789" }
     shipping_timeline_estimate { "2-3 weeks" }
+    price { "$1000 and $100 shipping" }
     origin_story { "This product has an interesting origin story." }
     description { "This is a sample product description." }
 

--- a/spec/factories/products.rb
+++ b/spec/factories/products.rb
@@ -68,6 +68,14 @@ FactoryBot.define do
       end
     end
 
+    trait :with_partners do
+      after(:create) do |product|
+        create_list(:practice_partner, 2, :for_products) do |partner|
+          create(:practice_partner_practice, innovable: product, practice_partner: partner)
+        end
+      end
+    end
+
     trait :with_tags do
         sequence(:name) { |n| "Sample Product with Tags #{n}" }
         after(:create) do |product|

--- a/spec/features/product_viewer_spec.rb
+++ b/spec/features/product_viewer_spec.rb
@@ -31,7 +31,7 @@ describe 'Product show page', type: :feature do
     expect(page).to have_content 'Item Number'
     expect(page).to have_content 'Vendor'
     expect(page).to have_content 'DUNS'
-    expect(page).to have_content 'Partners'
+    # expect(page).to have_content 'Partners' # TODO: add Partners to factory
     expect(page).to have_content 'Shipping Timeline Estimate'
     product.update(vendor: nil)
     visit product_path(product)

--- a/spec/features/product_viewer_spec.rb
+++ b/spec/features/product_viewer_spec.rb
@@ -33,6 +33,7 @@ describe 'Product show page', type: :feature do
     expect(page).to have_content 'DUNS'
     expect(page).to have_content 'Partners'
     expect(page).to have_content 'Shipping Timeline Estimate'
+    expect(page).to have_content 'Price'
     product.update(vendor: nil)
     visit product_path(product)
     expect(page).to have_no_selector('h3', text: 'Vendor')

--- a/spec/features/product_viewer_spec.rb
+++ b/spec/features/product_viewer_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe 'Product show page', type: :feature do
-  let!(:product) { create(:product)}
+  let!(:product) { create(:product, :with_partners)}
   let(:product_with_images) { create(:product, :with_image, :with_multimedia, name: 'Product with Images', published: true) }
   let(:product_with_tags) { create(:product, :with_tags, published: true) }
   let!(:user) { create(:user) }
@@ -31,7 +31,7 @@ describe 'Product show page', type: :feature do
     expect(page).to have_content 'Item Number'
     expect(page).to have_content 'Vendor'
     expect(page).to have_content 'DUNS'
-    # expect(page).to have_content 'Partners' # TODO: add Partners to factory
+    expect(page).to have_content 'Partners'
     expect(page).to have_content 'Shipping Timeline Estimate'
     product.update(vendor: nil)
     visit product_path(product)


### PR DESCRIPTION
### JIRA issue link
[DM-5081](https://agile6.atlassian.net/browse/DM-5081)

## Description - what does this code do?
- Add an in-page nav to the Product page side rails
- Update render logic for Vendors so that `Vendors` header is not rendered if Vendor name is missing (e.g. if a link is present by Vendor name is not)
- Add Partners to factories and show page spec
- Add Price to factories and show page spec

## Testing done - how did you test it/steps on how can another person can test it 
### In-page nav
1. Go to a product show page, e.g. `/products/thermal-fuse-cover`
2. Click on each sidenav link 
3. Confirm that your browser's URL is updated to show the section's ID (e.g. `#intrapreneur`)
4. Confirm the window scrolls to the appropriate heading
5. Scroll up and down the show page. Confirm that the sidenav's "current" style changes as you scroll. e.g. You should see "Order Product" highlighted when you have scrolled towards the bottom of the page.

### Vendor rendering logic
1. Go to the `Description` section of a product in the editor. `/products/thermal-fuse-cover/edit/description`
2. Remove the vendor's name but leave the link in place
3. Go to the product's show page and confirm the `Vendors` heading is not rendered

### Factories
Open the rails console and run
```
FactoryBot.create(:product, :with_partners)
```
Confirm that the newly created Product has Partners and a Price.

## Screenshots, Gifs, Videos from application (if applicable)
![Screenshot 2024-10-09 at 3 39 39 PM](https://github.com/user-attachments/assets/9a7c2096-0576-4ba7-b07c-048e2e3d81a6)


