### PR TITLE
dm-5201 prod editor mdi alt text field

### DIFF
--- a/app/assets/stylesheets/dm/pages/_products.scss
+++ b/app/assets/stylesheets/dm/pages/_products.scss
@@ -47,6 +47,10 @@
 		}
 	}
 
+	.show-page-image-caption {
+		color: color($theme-color-base);
+	}
+
 	#practice-show-intrapreneur {
 		.origin-story p {
 			margin-bottom: 0.5rem;

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -76,6 +76,7 @@ class ProductsController < ApplicationController
       :price,
       :origin_story,
       :main_display_image,
+      :main_display_image_alt_text,
       :crop_x,
       :crop_y,
       :crop_w,

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -76,6 +76,7 @@ class ProductsController < ApplicationController
       :price,
       :origin_story,
       :main_display_image,
+      :main_display_image_caption,
       :main_display_image_alt_text,
       :crop_x,
       :crop_y,

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -48,7 +48,8 @@ class ProductsController < ApplicationController
                 else
                   nil
                 end
-      next_page = params[:next] ? Product::PRODUCT_EDITOR_NEXT_PAGE[submitted_page.to_sym] : submitted_page
+
+      next_page = params[:next] ? Product::PRODUCT_EDITOR_NEXT_PAGE[submitted_page] : submitted_page
       redirect_to send("product_#{next_page}_path", @product), notice: notice
     else
       flash[:error] = service.errors.any? ? service.errors.join(', ') : "An unexpected error occurred."

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -1,7 +1,8 @@
 class Product < Innovation
   has_attached_file :main_display_image, styles: {thumb: '768x432>'}, :processors => [:cropper]
 
-  # validates :main_display_image_alt_text, presence: true, if: :main_display_image_present?
+  validates :main_display_image_alt_text, presence: true, if: :main_display_image_present?
+  validates :main_display_image_caption, presence: true, if: :main_display_image_present?
   validates_attachment_content_type :main_display_image, content_type: /\Aimage\/.*\z/
   validates :name, presence: true
   validates_uniqueness_of :name, {message: 'Product name already exists'}
@@ -12,9 +13,9 @@ class Product < Innovation
 
   PRODUCT_EDITOR_NEXT_PAGE =
     {
-      'editors': 'description',
-      'description': 'intrapreneur',
-      'intrapreneur': 'multimedia',
+      'editors' => 'description',
+      'description' => 'intrapreneur',
+      'intrapreneur' => 'multimedia',
     }
 
   extend FriendlyId

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -1,11 +1,9 @@
 class Product < Innovation
   has_attached_file :main_display_image, styles: {thumb: '768x432>'}, :processors => [:cropper]
 
-  validates :main_display_image_alt_text, presence: true, if: :main_display_image_present?
-  validates :main_display_image_caption, presence: true, if: :main_display_image_present?
   validates_attachment_content_type :main_display_image, content_type: /\Aimage\/.*\z/
   validates :name, presence: true
-  validates_uniqueness_of :name, {message: 'Product name already exists'}
+  validates :name, uniqueness: {message: 'Product name already exists'}
 
   after_update :update_date_published
 
@@ -25,6 +23,10 @@ class Product < Innovation
     user&.email
   end
 
+  def self.ransackable_attributes(auth_object = nil)
+    ["name", "user_email", "published"]
+  end
+
   private
 
   def main_display_image_present?
@@ -35,16 +37,13 @@ class Product < Innovation
     Arel.sql("users.email")
   end
 
-  def self.ransackable_attributes(auth_object = nil)
-    ["name", "user_email", "published"]
-  end
 
   def update_date_published
     if saved_change_to_published?
       if published
-        update_column(:date_published, Time.current)
+        update(date_published: Time.current)
       else
-        update_column(:date_published, nil)
+        update(date_published: nil)
       end
     end
   end

--- a/app/views/practices/introduction_forms/_image_editor.html.erb
+++ b/app/views/practices/introduction_forms/_image_editor.html.erb
@@ -11,7 +11,7 @@
     <% else %>
       <label class="usa-label text-bold margin-top-0 margin-bottom-1"><%= section_title %></label>
     <% end %>
-  <div class="dm-cropper-boundary grid-col-12 margin-top-2">
+  <div class="dm-cropper-boundary grid-col-12 margin-top-2" data-model-type="<%= practice.class.name.downcase %>">
     <label class="dm-cropper-upload-image-label line-height-26" for="practice_main_display_image">
       Choose a photograph to represent the Innovation in Search Results.
     </label>

--- a/app/views/practices/show/overview/_overview_sections.html.erb
+++ b/app/views/practices/show/overview/_overview_sections.html.erb
@@ -36,8 +36,7 @@
         <% name = pr.name %>
         <% if name.present? %>
           <div class="margin-top-1">
-            <h5 class="text-uppercase display-inline margin-y-0">Above:</h5>
-            <p class="display-inline line-height-26"><%= name %></p>
+            <p class="show-page-image-caption line-height-26"><%= name %></p>
           </div>
         <% end %>
       </div>
@@ -52,8 +51,7 @@
       <%= youtube_embed(pr.link_url) %>
       <% if pr.name.present? %>
         <div class="margin-top-1 width-full">
-          <h5 class="text-uppercase display-inline margin-y-0">Above:</h5>
-          <p class="display-inline line-height-26"><%= pr.name %></p>
+          <p class="show-page-image-caption line-height-26"><%= pr.name %></p>
         </div>
       <% end %>
     </div>

--- a/app/views/practices/show/overview/_overview_sections.html.erb
+++ b/app/views/practices/show/overview/_overview_sections.html.erb
@@ -36,7 +36,7 @@
         <% name = pr.name %>
         <% if name.present? %>
           <div class="margin-top-1">
-            <p class="show-page-image-caption line-height-26"><%= name %></p>
+            <p class="show-page-image-caption text-base line-height-26"><%= name %></p>
           </div>
         <% end %>
       </div>
@@ -51,7 +51,7 @@
       <%= youtube_embed(pr.link_url) %>
       <% if pr.name.present? %>
         <div class="margin-top-1 width-full">
-          <p class="show-page-image-caption line-height-26"><%= pr.name %></p>
+          <p class="show-page-image-caption text-base line-height-26"><%= pr.name %></p>
         </div>
       <% end %>
     </div>

--- a/app/views/products/_main_display_image.html.erb
+++ b/app/views/products/_main_display_image.html.erb
@@ -2,3 +2,8 @@
 	 alt="<%= product&.main_display_image_alt_text %>"[]
 	 class="product-main-display-image margin-top-2"
 />
+<% if product.main_display_image_caption? %>
+	<p class="show-page-image-caption font-sans-xs line-height-26 margin-top-1 width-full">
+		<%= product.main_display_image_caption %>
+	</p>
+<% end %>

--- a/app/views/products/form/description.html.erb
+++ b/app/views/products/form/description.html.erb
@@ -159,6 +159,18 @@
 
             <%= render partial: 'practices/introduction_forms/image_editor', locals: { section_title: 'Thumbnail', form: f, practice: @product, modal_link: true } %>
 
+            <div>
+              <%= render partial: 'practices/shared/image_alt_text_label',
+                locals: {
+                  practice_field: "practice_main_display_image_alt_text",
+                  label_classes: 'margin-top-0 text-bold',
+                  form_field: "practice_main_display_image_alt_text"
+                }
+              %>
+              <%= f.text_area :main_display_image_alt_text,
+                                 class: "usa-textarea main-display-image-alt-text" %>
+            </div>
+
             <%= hidden_field_tag :submitted_page, params[:action] %>
           </fieldset>
         <% end %>

--- a/app/views/products/form/description.html.erb
+++ b/app/views/products/form/description.html.erb
@@ -164,8 +164,9 @@
 
               <div>
                   <%= f.label :main_display_image_caption, class: 'usa-label text-bold display-block margin-top-0' do %>
-                    Caption*
+                    Image Caption*
                   <% end %>
+                  <span>What caption would you like to accompany your thumbnail image?</span>
                 </div>
                 <%= f.text_field :main_display_image_caption, class: "usa-input #{ @product.errors[:main_display_image_caption].any? ? 'usa-input--error' : '' } display-block practice-editor-name-input dm-required-field  margin-bottom-2" %>
 

--- a/app/views/products/form/description.html.erb
+++ b/app/views/products/form/description.html.erb
@@ -1,9 +1,10 @@
 <% provide :head_tags do %>
   <%= javascript_include_tag '_allCategories', 'data-turbolinks-track': 'reload' %>
   <%= javascript_include_tag '_introduction_image_editor', 'data-turbolinks-track': 'reload' %>
+  <%= javascript_include_tag '_practice_editor_header', 'data-turbolinks-track': 'reload' %>
 <% end %>
 
-
+<%= render partial: 'practices/introduction_forms/main_display_image_guidance_modal' %>
 <div class="grid-container">
   <div class="grid-row grid-gap">
     <div id="description" class="grid-col-12 margin-top-4">
@@ -157,20 +158,33 @@
               <% end %>
             </div>
 
-            <%= render partial: 'practices/introduction_forms/image_editor', locals: { section_title: 'Thumbnail', form: f, practice: @product, modal_link: true } %>
+            <h3>Thumbnail Image</h3>
+            <fieldset class="usa-fieldset border border-base-light padding-2 margin-top-3 margin-bottom-4">
+              <%= render partial: 'practices/introduction_forms/image_editor', locals: { section_title: 'Thumbnail', form: f, practice: @product, modal_link: true } %>
 
-            <div>
-              <%= render partial: 'practices/shared/image_alt_text_label',
-                locals: {
-                  practice_field: "practice_main_display_image_alt_text",
-                  label_classes: 'margin-top-0 text-bold',
-                  form_field: "practice_main_display_image_alt_text"
-                }
-              %>
-              <%= f.text_area :main_display_image_alt_text,
-                                 class: "usa-textarea main-display-image-alt-text" %>
-            </div>
+              <div>
+                  <%= f.label :main_display_image_caption, class: 'usa-label text-bold display-block margin-top-0' do %>
+                    Caption*
+                  <% end %>
+                </div>
+                <%= f.text_field :main_display_image_caption, class: "usa-input #{ @product.errors[:main_display_image_caption].any? ? 'usa-input--error' : '' } display-block practice-editor-name-input dm-required-field  margin-bottom-2" %>
 
+                <p class="usa-error-message <%= @product.errors[:tagline].any? ? 'fas fa-exclamation-circle fon' : 'display-none' %>">&nbsp;
+                  <span class="font-family-sans"><%= show_errors(@product, :tagline) %></span>
+                </p>
+
+              <div>
+                <%= render partial: 'practices/shared/image_alt_text_label',
+                  locals: {
+                    practice_field: "practice_main_display_image_alt_text",
+                    label_classes: 'margin-top-0 text-bold',
+                    form_field: "practice_main_display_image_alt_text"
+                  }
+                %>
+                <%= f.text_area :main_display_image_alt_text,
+                                  class: "usa-textarea main-display-image-alt-text" %>
+              </div>
+            </fieldset>
             <%= hidden_field_tag :submitted_page, params[:action] %>
           </fieldset>
         <% end %>

--- a/db/migrate/20241010210000_add_main_display_image_caption_to_products.rb
+++ b/db/migrate/20241010210000_add_main_display_image_caption_to_products.rb
@@ -1,0 +1,5 @@
+class AddMainDisplayImageCaptionToProducts < ActiveRecord::Migration[6.1]
+  def change
+    add_column :products, :main_display_image_caption, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_10_07_232231) do
+ActiveRecord::Schema.define(version: 2024_10_10_210000) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -1103,6 +1103,7 @@ ActiveRecord::Schema.define(version: 2024_10_07_232231) do
     t.boolean "retired", default: false, null: false
     t.string "slug"
     t.string "vendor_link"
+    t.text "main_display_image_caption"
     t.index ["name"], name: "index_products_on_name", unique: true
     t.index ["slug"], name: "index_products_on_slug", unique: true
     t.index ["user_id"], name: "index_products_on_user_id"

--- a/spec/factories/products.rb
+++ b/spec/factories/products.rb
@@ -15,7 +15,8 @@ FactoryBot.define do
 
     trait :with_image do
       main_display_image { File.new(Rails.root.join('spec', 'assets', 'acceptable_img.jpg')) }
-      main_display_image_alt_text { "sample image" }
+      main_display_image_caption { "sample image caption" }
+      main_display_image_alt_text { "sample image alt text" }
     end
 
     trait :with_multimedia do

--- a/spec/features/product_editor/description_spec.rb
+++ b/spec/features/product_editor/description_spec.rb
@@ -94,6 +94,51 @@ describe 'Product editor - description', type: :feature do
       expect(product.categories).to include(cat2)
       expect(product.categories).to_not include(cat1)
     end
+
+    context 'when managing the thumbnail image' do
+      it 'uploads and displays the thumbnail image' do
+        visit product_description_path(product)
+        attach_file 'product_main_display_image', Rails.root.join('spec/assets/acceptable_img.jpg')
+        fill_in 'product_main_display_image_caption', with: 'Caption text'
+        fill_in 'product_main_display_image_alt_text', with: 'Alt Text'
+        click_link 'Save and Continue'
+
+        expect(page).to have_content('Product was successfully updated.')
+        visit product_description_path(product)
+        expect(page).to have_css("img[src*='acceptable_img.jpg']")
+      end
+
+      it 'updates the caption and alt text for the thumbnail image' do
+        product.update!(main_display_image_alt_text: "Test", main_display_image_caption: "Other Test")
+        visit product_description_path(product)
+
+        attach_file 'product_main_display_image', Rails.root.join('spec/assets/acceptable_img.jpg')
+
+        fill_in 'product_main_display_image_caption', with: 'Updated Caption'
+        fill_in 'product_main_display_image_alt_text', with: 'Updated Alt Text'
+        click_link 'Save and Continue'
+
+        expect(page).to have_content('Product was successfully updated.')
+        product.reload
+        expect(product.main_display_image_caption).to eq('Updated Caption')
+        expect(product.main_display_image_alt_text).to eq('Updated Alt Text')
+      end
+
+      it 'removes the thumbnail image' do
+        product.update!(main_display_image_alt_text: "Test", main_display_image_caption: "Other Test")
+        product.update(main_display_image: fixture_file_upload('spec/assets/acceptable_img.jpg', 'image/jpg'))
+
+        visit product_description_path(product)
+        find('label', text: 'Remove image').click
+        click_link 'Save and Continue'
+
+        expect(page).to have_content('Product was successfully updated.')
+        visit product_description_path(product)
+
+        product.reload
+        expect(product.main_display_image.exists?).to be false
+      end
+    end
   end
 
   describe 'when not logged in' do

--- a/spec/features/product_viewer_spec.rb
+++ b/spec/features/product_viewer_spec.rb
@@ -51,6 +51,7 @@ describe 'Product show page', type: :feature do
   it 'renders media assets' do
     visit(product_path(product_with_images))
     expect(page).to have_css('.product-main-display-image')
+    expect(page).to have_content('sample image caption')
     within('.multimedia-section') do
       expect(page).to have_css('.practice-editor-impact-photo')
       expect(page).to have_css('.video-container')


### PR DESCRIPTION
### JIRA issue link
https://agile6.atlassian.net/browse/DM-5201

## Description - what does this code do?
* Adds `:main_display_image_caption` col to `products` table

* Adds text field for `:main_display_image_alt_text` and `:main_display_image_caption` to `/editor/description` page in product editor workflow

* Also re-adds `data-model-type` value to top-level div in `image_editor` partial that was mistakenly removed in rebase of last branch merged into feature branch (needed for making the image handling js work)

## Testing done - how did you test it/steps on how can another person can test it 
1. go `/products/thermal-fuse-cover/edit/description` and verify you can add text to the caption and alt-text fields
2. go back to the previous page and verify you can switch out the "Thumbnail" image with a different image and verify the change persists upon form submission.
3. go to the "Introduction" page of the innovation editor for a `practice` and repeat step 2 to verify the "Thumbnail" image can be switched and the change persists upon form submission.
4. Go through the rest of the editor workflow and check that everything works as expected

## Screenshots, Gifs, Videos from application (if applicable)
![Screenshot 2024-10-14 at 12 17 49 PM](https://github.com/user-attachments/assets/153b904b-c174-40f8-9b79-39da90ef4cd1)

## Link to mock-ups/mock ups (image file if you have it) (if applicable)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Unit tests written (if applicable)
- [ ] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating JIRA issue
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs