### PR TITLE
dm-5091 fellow profile edit fields

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -127,6 +127,32 @@ class UsersController < ApplicationController
 
   def user_params
     return params.require(:user).permit(:avatar, :bio) if session[:user_type] === 'ntlm'
-    params.require(:user).permit(:avatar, :email, :password, :password_confirmation, :job_title, :first_name, :last_name, :phone_number, :visn, :skip_va_validation, :skip_password_validation, :bio, :location, :accepted_term, :delete_avatar, :crop_x, :crop_y, :crop_w, :crop_h)
+    params.require(:user).permit( :accepted_term,
+                                  :alt_first_name,
+                                  :alt_job_title,
+                                  :alt_last_name,
+                                  :avatar,
+                                  :bio,
+                                  :credentials,
+                                  :crop_h,
+                                  :crop_w,
+                                  :crop_x,
+                                  :crop_y,
+                                  :delete_avatar,
+                                  :email,
+                                  :first_name,
+                                  :fellowship,
+                                  :job_title,
+                                  :last_name,
+                                  :location,
+                                  :password,
+                                  :password_confirmation,
+                                  :phone_number,
+                                  :project,
+                                  :skip_va_validation,
+                                  :skip_password_validation,
+                                  :visn,
+                                  :work
+                                )
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -141,7 +141,6 @@ class UsersController < ApplicationController
                                   :delete_avatar,
                                   :email,
                                   :first_name,
-                                  :fellowship,
                                   :job_title,
                                   :last_name,
                                   :location,

--- a/app/views/users/edit_profile.html.erb
+++ b/app/views/users/edit_profile.html.erb
@@ -102,7 +102,7 @@
               <% user_type = session[:user_type] %>
               <div class="usa-form edit-profile-form">
                 <div class="grid-row width-full">
-                  <div class="field grid-col-9">
+                  <div class="field margin-top-3 grid-col-9">
                     <%= f.label :first_name, class: 'margin-top-2 margin-bottom-2' %><br/>
                     <%= f.text_field :first_name, autofocus: true, class: 'usa-input bg-base-lightest border-base-light text-base', disabled: user_type === 'ntlm' %>
                   </div>
@@ -135,13 +135,87 @@
                     <%= f.text_field :job_title, class: 'usa-input usa-input__disabled bg-base-lightest border-base-light text-base disabled', disabled: user_type === 'ntlm' %>
                   </div>
                 </div>
-              </div>
-              <div class="field margin-top-3 grid-col-9">
-                <%= f.label :bio, class: 'margin-0 margin-top-2' do %>
-                  <span>Bio</span>&nbsp;<span class="text-base-light profile-bio-character-count" id="user_<%= @user.id %>_profile_bio_character_count">(0/50 characters)</span>
-                  <p>Tell other users about yourself and your professional background.</p>
+
+                <%# Public Bio (Fellow)-specific fields %>
+                <% is_fellow = (@user.granted_public_bio == true) %>
+                <% if is_fellow %>
+                  <div class="grid-row width-full">
+                    <div class="field margin-top-3 grid-col-9">
+                      <%= f.label :alt_first_name, 'First name (Public Bio)', class: 'margin-top-2 margin-bottom-2' %><br/>
+                      <%= f.text_field :alt_first_name,
+                        value: @user.alt_first_name.present? ? @user.alt_first_name : @user.first_name,
+                        autofocus: true,
+                        class: "usa-input border-base-light"
+                      %>
+                    </div>
+                  </div>
+
+                  <div class="grid-row width-full">
+                    <div class="field margin-top-3 grid-col-9">
+                      <%= f.label :alt_last_name, 'Last name (Public Bio)', class: 'margin-top-2 margin-bottom-2' %><br/>
+                      <%= f.text_field :alt_last_name,
+                        value: @user.alt_last_name.present? ? @user.alt_last_name : @user.last_name,
+                        autofocus: true,
+                        class: "usa-input border-base-light"
+                      %>
+                    </div>
+                  </div>
+
+                  <div class="grid-row width-full">
+                    <div class="field margin-top-3 grid-col-9">
+                      <%= f.label :fellowship, 'Fellowship (Public Bio)', class: 'margin-top-2 margin-bottom-2' %><br/>
+                      <%= f.text_field :fellowship,
+                        autofocus: true,
+                        class: "usa-input border-base-light"
+                      %>
+                    </div>
+                  </div>
+
+                  <div class="grid-row width-full">
+                    <div class="field margin-top-3 grid-col-9">
+                      <%= f.label :alt_job_title, 'Title (Public Bio)', class: 'margin-top-2 margin-bottom-2' %><br/>
+                      <%= f.text_field :alt_job_title,
+                        value: @user.alt_job_title.present? ? @user.alt_job_title : @user.job_title,
+                        autofocus: true,
+                        class: "usa-input border-base-light"
+                      %>
+                    </div>
+                  </div>
                 <% end %>
-                <%= f.text_area :bio, class: 'usa-input height-200px profile-bio' %>
+
+                <div class="field margin-top-3 grid-col-9">
+                  <%= f.label :bio, class: 'margin-0 margin-top-2' do %>
+                    <span>Bio</span>&nbsp;<span class="text-base-light profile-bio-character-count" id="user_<%= @user.id %>_profile_bio_character_count">(0/50 characters)</span>
+                    <p>Tell other users about yourself and your professional background.</p>
+                  <% end %>
+                  <%= f.text_area :bio, class: 'usa-input height-200px profile-bio border-base-light' %>
+                </div>
+
+                <% if is_fellow %>
+                  <div class="field margin-top-3 grid-col-9">
+                    <%= f.label :credentials, 'Credentials (Public Bio)', class: 'margin-top-2 margin-bottom-2' %><br/>
+                    <%= f.text_area :credentials,
+                      autofocus: true,
+                      class: "usa-input height-15 border-base-light"
+                    %>
+                  </div>
+
+                  <div class="field margin-top-3 grid-col-9">
+                    <%= f.label :work, 'Work (Public Bio)', class: 'margin-top-2 margin-bottom-2' %><br/>
+                    <%= f.text_area :work,
+                      autofocus: true,
+                      class: "usa-input height-15 border-base-light"
+                    %>
+                  </div>
+
+                  <div class="field margin-top-3 grid-col-9">
+                    <%= f.label :project, 'Project (Public Bio)', class: 'margin-top-2 margin-bottom-2' %><br/>
+                    <%= f.text_field :project,
+                      autofocus: true,
+                      class: "usa-input border-base-light"
+                    %>
+                  </div>
+                <% end %>
               </div>
             <% end %>
           </div>
@@ -150,9 +224,9 @@
   </section>
 </div>
 
-<%# <script type="text/javascript"> 
+<%# <script type="text/javascript">
   document.getElementById("toggle-photo").onclick = function(event) {
     event.preventDefault();
     document.getElementById("photo-file-upload").setAttribute("aria-hidden", 'false');
-  } 
+  }
 </script>  %>

--- a/app/views/users/edit_profile.html.erb
+++ b/app/views/users/edit_profile.html.erb
@@ -163,16 +163,6 @@
 
                   <div class="grid-row width-full">
                     <div class="field margin-top-3 grid-col-9">
-                      <%= f.label :fellowship, 'Fellowship (Public Bio)', class: 'margin-top-2 margin-bottom-2' %><br/>
-                      <%= f.text_field :fellowship,
-                        autofocus: true,
-                        class: "usa-input border-base-light"
-                      %>
-                    </div>
-                  </div>
-
-                  <div class="grid-row width-full">
-                    <div class="field margin-top-3 grid-col-9">
                       <%= f.label :alt_job_title, 'Title (Public Bio)', class: 'margin-top-2 margin-bottom-2' %><br/>
                       <%= f.text_field :alt_job_title,
                         value: @user.alt_job_title.present? ? @user.alt_job_title : @user.job_title,

--- a/db/migrate/20241030205550_add_columns_to_users.rb
+++ b/db/migrate/20241030205550_add_columns_to_users.rb
@@ -6,6 +6,5 @@ class AddColumnsToUsers < ActiveRecord::Migration[6.1]
     add_column :users, :work, :text
     add_column :users, :project, :text
     add_column :users, :alt_job_title, :string
-    add_column :users, :fellowship, :string
   end
 end

--- a/db/migrate/20241030205550_add_columns_to_users.rb
+++ b/db/migrate/20241030205550_add_columns_to_users.rb
@@ -6,5 +6,6 @@ class AddColumnsToUsers < ActiveRecord::Migration[6.1]
     add_column :users, :work, :text
     add_column :users, :project, :text
     add_column :users, :alt_job_title, :string
+    add_column :users, :fellowship, :string
   end
 end

--- a/db/migrate/20241030205550_add_columns_to_users.rb
+++ b/db/migrate/20241030205550_add_columns_to_users.rb
@@ -1,0 +1,10 @@
+class AddColumnsToUsers < ActiveRecord::Migration[6.1]
+  def change
+    add_column :users, :alt_first_name, :string
+    add_column :users, :alt_last_name, :string
+    add_column :users, :credentials, :text
+    add_column :users, :work, :text
+    add_column :users, :project, :text
+    add_column :users, :alt_job_title, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1208,7 +1208,6 @@ ActiveRecord::Schema.define(version: 2024_10_30_205550) do
     t.text "work"
     t.text "project"
     t.string "alt_job_title"
-    t.string "fellowship"
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["granted_public_bio"], name: "index_users_on_granted_public_bio"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1208,6 +1208,7 @@ ActiveRecord::Schema.define(version: 2024_10_30_205550) do
     t.text "work"
     t.text "project"
     t.string "alt_job_title"
+    t.string "fellowship"
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["granted_public_bio"], name: "index_users_on_granted_public_bio"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_10_29_205610) do
+ActiveRecord::Schema.define(version: 2024_10_30_205550) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -1202,6 +1202,12 @@ ActiveRecord::Schema.define(version: 2024_10_29_205610) do
     t.string "facility"
     t.boolean "accepted_terms", default: false
     t.boolean "granted_public_bio", default: false
+    t.string "alt_first_name"
+    t.string "alt_last_name"
+    t.text "credentials"
+    t.text "work"
+    t.text "project"
+    t.string "alt_job_title"
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["granted_public_bio"], name: "index_users_on_granted_public_bio"

--- a/spec/features/users/user_profile_spec.rb
+++ b/spec/features/users/user_profile_spec.rb
@@ -75,6 +75,43 @@ describe 'The user index', type: :feature do
     expect(sb.bio).to eq('Lives in a pineapple')
   end
 
+  it 'should allow a user to update their public-bio info' do
+    @user.update!(granted_public_bio: true)
+    login_as(@user, scope: :user, run_callbacks: false)
+    visit '/edit-profile'
+
+    fill_in('user[alt_first_name]', with: 'Alt first name')
+    fill_in('user[alt_last_name]', with: 'Alt last name')
+    fill_in('Title (Public Bio)', with: 'public bio title text')
+    fill_in('Fellowship (Public Bio)', with: 'public bio fellowship text')
+    fill_in('Work (Public Bio)', with: 'public bio work text')
+    fill_in('Credentials (Public Bio)', with: 'public bio credentials text')
+    fill_in('Project (Public Bio)', with: 'project text')
+    click_button('Save changes')
+
+    sb = User.find(@user.id)
+    expect(sb.alt_first_name).to eq('Alt first name')
+    expect(sb.alt_last_name).to eq('Alt last name')
+    expect(sb.alt_job_title).to eq('public bio title text')
+    expect(sb.fellowship).to eq('public bio fellowship text')
+    expect(sb.work).to eq('public bio work text')
+    expect(sb.credentials).to eq('public bio credentials text')
+    expect(sb.project).to eq('project text')
+  end
+
+  it 'should not show public-bio related fields if user not granted access' do
+    login_as(@user, scope: :user, run_callbacks: false)
+    visit '/edit-profile'
+
+    expect(page).not_to have_selector("input[value='#{@user.alt_first_name}']")
+    expect(page).not_to have_selector("input[value='#{@user.alt_last_name}']")
+    expect(page).not_to have_selector("input[value='#{@user.alt_job_title}']")
+    expect(page).not_to have_selector("input[value='#{@user.credentials}']")
+    expect(page).not_to have_selector("input[value='#{@user.work}']")
+    expect(page).not_to have_selector("input[value='#{@user.fellowship}']")
+    expect(page).not_to have_selector("input[value='#{@user.project}']")
+  end
+
   it 'should have a favorited practice' do
     @practice1 = Practice.create!(name: 'A public practice', approved: true, published: true, tagline: 'Test tagline', user: @user)
     @practice2 = Practice.create!(name: 'The Best Innovation Ever!', approved: true, published: true, tagline: 'Test tagline', user: @user2)

--- a/spec/features/users/user_profile_spec.rb
+++ b/spec/features/users/user_profile_spec.rb
@@ -83,7 +83,6 @@ describe 'The user index', type: :feature do
     fill_in('user[alt_first_name]', with: 'Alt first name')
     fill_in('user[alt_last_name]', with: 'Alt last name')
     fill_in('Title (Public Bio)', with: 'public bio title text')
-    fill_in('Fellowship (Public Bio)', with: 'public bio fellowship text')
     fill_in('Work (Public Bio)', with: 'public bio work text')
     fill_in('Credentials (Public Bio)', with: 'public bio credentials text')
     fill_in('Project (Public Bio)', with: 'project text')
@@ -93,7 +92,6 @@ describe 'The user index', type: :feature do
     expect(sb.alt_first_name).to eq('Alt first name')
     expect(sb.alt_last_name).to eq('Alt last name')
     expect(sb.alt_job_title).to eq('public bio title text')
-    expect(sb.fellowship).to eq('public bio fellowship text')
     expect(sb.work).to eq('public bio work text')
     expect(sb.credentials).to eq('public bio credentials text')
     expect(sb.project).to eq('project text')
@@ -108,7 +106,6 @@ describe 'The user index', type: :feature do
     expect(page).not_to have_selector("input[value='#{@user.alt_job_title}']")
     expect(page).not_to have_selector("input[value='#{@user.credentials}']")
     expect(page).not_to have_selector("input[value='#{@user.work}']")
-    expect(page).not_to have_selector("input[value='#{@user.fellowship}']")
     expect(page).not_to have_selector("input[value='#{@user.project}']")
   end
 


### PR DESCRIPTION
### JIRA issue link
https://agile6.atlassian.net/browse/DM-5091

## Description - what does this code do?
adds public-bio specific fields to user profile edit page, fields are only accessible to users with `granted_public_profile: true`

## Testing done - how did you test it/steps on how can another person can test it 
1. Update a user with `granted_public_profile: true` either via console or through active admin
2. sign in as that user and go to http://localhost:3200/edit-profile
3. fill out the new fields and verify the data persists upon form submission.
4. log in as a different user with `granted_public_profile: false`, go to the profile edit page and verify the public-bio fields do not appear

## Screenshots, Gifs, Videos from application (if applicable)
<img width="536" alt="Screenshot 2024-11-04 at 3 13 18 PM" src="https://github.com/user-attachments/assets/b38c9aab-fa20-45d7-a8d3-77cb411a94ec">


## Link to mock-ups/mock ups (image file if you have it) (if applicable)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Unit tests written (if applicable)
- [ ] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating JIRA issue
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs