### PR TITLE
DM-5300: Make page group editor emails case insensitive

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -201,6 +201,7 @@ class User < ApplicationRecord
   end
 
   def self.validate_users_by_emails(emails)
+    emails = emails.map(&:downcase) # VA emails with different capitalization are equivalent
     users = where(email: emails)
     existing_emails = users.pluck(:email)
     non_existent_emails = emails - existing_emails

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -47,14 +47,15 @@ RSpec.describe User, type: :model do
   end
 
   describe ".validate_users_by_emails" do
-    let(:emails) { ['existing@example.com', 'nonexisting@example.com'] }
-    let!(:user) { create(:user, email: 'existing@example.com') }
+    let(:emails) { ['existing@va.gov', 'nonexisting@va.gov', 'CaseInsensitive@va.gov'] }
+    let!(:user) { create(:user, email: 'existing@va.gov') }
+    let!(:case_insensitive_user) { create(:user, email: 'caseinsensitive@va.gov') }
 
     it "returns users with existing emails and lists non-existing emails" do
       users, non_existent_emails = User.validate_users_by_emails(emails)
 
-      expect(users).to contain_exactly(user)
-      expect(non_existent_emails).to contain_exactly('nonexisting@example.com')
+      expect(users).to contain_exactly(user, case_insensitive_user)
+      expect(non_existent_emails).to contain_exactly('nonexisting@va.gov')
     end
   end
 end


### PR DESCRIPTION
### JIRA issue link
[DM-5300](https://agile6.atlassian.net/browse/DM-5300)

## Description - what does this code do?
- In the Page Group editors workflow, treat `test@va.gov` the same as `Test@va.gov`

## Testing done - how did you test it/steps on how can another person can test it 
1. In `master`, go to `/admin/page_groups` and create a new page group without editors
2. Edit the page group and try to add `Demo@va.gov` as a user. 
3. You should see an error that the user does not exist
4. Go to `/admin/users` and confirm that a user with email `demo@va.gov` exists
5. Check out this branch 
6. Repeat the workflow and confirm that you are able to add `Demo@va.gov` as a user
7. Confirm that the saved email is downcase and appears in the UI as `demo@va.gov`