### PR TITLE
DM-5224: Show disabled Community category checkboxes for non-admin editors

### DIFF
--- a/app/admin/categories.rb
+++ b/app/admin/categories.rb
@@ -72,7 +72,7 @@ ActiveAdmin.register Category do
       f.input :description, as: :string
       f.input :parent_category_id,
               as: :select, multiple: false,
-              include_blank: false, collection: Category.get_parent_categories(true),
+              include_blank: false, collection: Category.get_parent_categories,
               input_html: { value: object[:parent_category_id] }, wrapper_html: { class: object.sub_categories.any? ? 'display-none' : '' },
               label: "Parent Tag"
         # ensures input is displayed as comma separated list

--- a/app/assets/stylesheets/dm/pages/_practice.scss
+++ b/app/assets/stylesheets/dm/pages/_practice.scss
@@ -841,6 +841,14 @@ li.small-disc:before {
     }
   }
   }
+
+  .dm-communities-category-columns-container {
+    .usa-checkbox__input[readonly], .usa-checkbox__input[readonly] + label {
+      cursor: not-allowed;
+      pointer-events: none;
+      color: #c9c9c9;
+    }
+  }
 }
 
 // Overview

--- a/app/controllers/practices_controller.rb
+++ b/app/controllers/practices_controller.rb
@@ -340,10 +340,11 @@ class PracticesController < ApplicationController # rubocop:disable Metrics/Clas
   # /practices/slug/introduction
   def introduction
     @va_facilities_and_crhs = VaFacility.cached_va_facilities.get_relevant_attributes.order_by_state_and_station_name + ClinicalResourceHub.cached_clinical_resource_hubs.sort_by_visn_number
-    @categories = Category.prepared_categories_for_practice_editor(current_user.has_role?(:admin))
+    @categories = Category.prepared_categories_for_practice_editor
     @cached_practice_partners = Naturalsorter::Sorter.sort_by_method(PracticePartner.cached_practice_partners, 'name', true, true)
     @ordered_practice_partners = PracticePartnerPractice.where(innovable_id: @practice.id).order_by_id
     @ordered_practice_origin_facilities = PracticeOriginFacility.where(practice_id: @practice.id).order_by_id
+    @user_can_edit_communities = current_user.has_role?(:admin)
     render 'practices/form/introduction'
   end
 

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -11,7 +11,7 @@ class ProductsController < ApplicationController
   end
 
   def description
-    @categories = Category.prepared_categories_for_practice_editor(current_user.has_role?(:admin))
+    @categories = Category.prepared_categories_for_practice_editor
     @cached_practice_partners = Naturalsorter::Sorter.sort_by_method(PracticePartner.cached_practice_partners, 'name', true, true)
     @ordered_practice_partners = PracticePartnerPractice.where(innovable_id: @product.id, innovable_type: "Product").order_by_id
     render 'products/form/description'

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -52,7 +52,7 @@ class Category < ApplicationRecord
     ["description", "name", "related_terms"]
   end
 
-  def self.prepared_categories_for_practice_editor()
+  def self.prepared_categories_for_practice_editor
     get_parent_categories.each_with_object({}) do |parent_category, hash|
       categories = parent_category.sub_categories.order_by_name.to_a
 

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -29,9 +29,9 @@ class Category < ApplicationRecord
     strip_attributes([self.name])
   end
 
-  def self.get_parent_categories(is_admin=false)
+  def self.get_parent_categories()
     Category.order_by_name.select do |cat|
-      cat.sub_categories.any? && !(is_admin == false && cat.name == "Communities")
+      cat.sub_categories.any?
     end
   end
 
@@ -52,8 +52,8 @@ class Category < ApplicationRecord
     ["description", "name", "related_terms"]
   end
 
-  def self.prepared_categories_for_practice_editor(is_admin)
-    get_parent_categories(is_admin).each_with_object({}) do |parent_category, hash|
+  def self.prepared_categories_for_practice_editor()
+    get_parent_categories.each_with_object({}) do |parent_category, hash|
       categories = parent_category.sub_categories.order_by_name.to_a
 
       if categories.any? && parent_category.name != "Communities"

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -29,7 +29,7 @@ class Category < ApplicationRecord
     strip_attributes([self.name])
   end
 
-  def self.get_parent_categories()
+  def self.get_parent_categories
     Category.order_by_name.select do |cat|
       cat.sub_categories.any?
     end

--- a/app/views/practices/form/introduction.html.erb
+++ b/app/views/practices/form/introduction.html.erb
@@ -536,6 +536,7 @@
                       <% sliced_categories.each_with_index do |sc, i| %>
                         <%= render partial: 'practices/introduction_forms/category_column', locals: { categories: sc, parent_category: parent_category, column: i } unless i === 3 %>
                       <% end %>
+                      <span class="text-base"><%= "Contact marketplace@va.gov to get involved with a Community" if !@user_can_edit_communities && (parent_category.name.downcase == 'communities') %></span>
                     </div>
                   </div>
                 <% end %>

--- a/app/views/practices/introduction_forms/_category_checkbox.html.erb
+++ b/app/views/practices/introduction_forms/_category_checkbox.html.erb
@@ -1,11 +1,11 @@
 <%
-
   category_id = category_id_for_category(category)
   hyphenated_category_name = hyphenated_category_name_for(category)
   parent_category_name = category.parent_category.name.downcase
   innovation = @practice || @product
   innovation_type = innovation.class.to_s.downcase
   is_checked = is_category_checked?(category, innovation)
+  is_disabled = parent_category_name == 'communities' && !@user_can_edit_communities
 %>
 
 <div class="usa-checkbox">
@@ -16,6 +16,7 @@
     name="<%= innovation_type %>[category][<%= category_id %>][value]"
     value="<%= category_id %>"
     <%= 'checked' if is_checked %>
+    <%= 'disabled' if is_disabled %>
   >
   <label class="usa-checkbox__label margin-bottom-2 cat-<%= category_id %>-label" for="cat-<%= category_id %>-input" title="<%= category.name %>">
     <span><%= category.name.truncate(20) %></span>

--- a/app/views/practices/introduction_forms/_category_checkbox.html.erb
+++ b/app/views/practices/introduction_forms/_category_checkbox.html.erb
@@ -16,7 +16,7 @@
     name="<%= innovation_type %>[category][<%= category_id %>][value]"
     value="<%= category_id %>"
     <%= 'checked' if is_checked %>
-    <%= 'disabled' if is_disabled %>
+    <%= 'readonly' if is_disabled %>
   >
   <label class="usa-checkbox__label margin-bottom-2 cat-<%= category_id %>-label" for="cat-<%= category_id %>-input" title="<%= category.name %>">
     <span><%= category.name.truncate(20) %></span>

--- a/spec/features/practice_editor/introduction/introduction_spec.rb
+++ b/spec/features/practice_editor/introduction/introduction_spec.rb
@@ -34,7 +34,7 @@ describe 'Practice editor - introduction', type: :feature do
     Category.create!(name: 'Pulmonary Care', parent_category: @parent_cat_3)
     Category.create!(name: 'Hidden Cat')
     Category.create!(name: 'Suicide Prevention', parent_category: @parent_cat_4)
-    Category.create!(name: 'Age-Friendly', parent_category: @parent_cat_4)
+    @community_category = Category.create!(name: 'Age-Friendly', parent_category: @parent_cat_4)
     CategoryPractice.create!(innovable: @practice, category: @cat_1, created_at: Time.now)
 
     login_as(@admin, :scope => :user, :run_callbacks => false)
@@ -574,15 +574,21 @@ describe 'Practice editor - introduction', type: :feature do
     before do
       @editor = FactoryBot.create(:user)
       PracticeEditor.create!(innovable: @practice, user: @editor, email: @editor.email)
+      CategoryPractice.create!(innovable: @practice, category: @community_category, created_at: Time.now)
       login_as(@editor, :scope => :user, :run_callbacks => false)
       visit_practice_edit
     end
 
-    it 'disables Community categories' do
+    it 'disables Community categories and retains checked Communities' do
       within('.dm-communities-category-columns-container') do
-        expect(page).to have_css('.communities-checkbox[disabled]', visible: false)
+        expect(page).to have_css('.communities-checkbox[readonly][checked]', visible: false)
         expect(page).to have_content('Contact marketplace@va.gov to get involved with a Community')
       end
+      label_class = ".cat-#{@cat_1.id}-label"
+      find(label_class).click
+      click_save
+      visit_practice_edit
+      expect(page).to have_css('.communities-checkbox[readonly][checked]', visible: false)
     end
   end
 end

--- a/spec/features/practice_editor/introduction/introduction_spec.rb
+++ b/spec/features/practice_editor/introduction/introduction_spec.rb
@@ -569,6 +569,22 @@ describe 'Practice editor - introduction', type: :feature do
       end
     end
   end
+
+  context 'as a non-admin editor' do
+    before do
+      @editor = FactoryBot.create(:user)
+      PracticeEditor.create!(innovable: @practice, user: @editor, email: @editor.email)
+      login_as(@editor, :scope => :user, :run_callbacks => false)
+      visit_practice_edit
+    end
+
+    it 'disables Community categories' do
+      within('.dm-communities-category-columns-container') do
+        expect(page).to have_css('.communities-checkbox[disabled]', visible: false)
+        expect(page).to have_content('Contact marketplace@va.gov to get involved with a Community')
+      end
+    end
+  end
 end
 
 def click_save

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Category, type: :model do
       end
 
       it 'prepares categories adding special categories for non-community categories' do
-        result = described_class.prepared_categories_for_practice_editor(true)
+        result = described_class.prepared_categories_for_practice_editor
 
         expect(result.keys).to include(parent_category, community_category)
         expect(result[parent_category].first.name).to eq("All #{parent_category.name.downcase}")
@@ -29,10 +29,10 @@ RSpec.describe Category, type: :model do
 
     context 'when user is not an admin' do
       it 'handles the logic based on role correctly' do
-        allow(described_class).to receive(:get_parent_categories).with(false).and_return([parent_category])
-        result = described_class.prepared_categories_for_practice_editor(false)
+        allow(described_class).to receive(:get_parent_categories).and_return([parent_category, community_category])
+        result = described_class.prepared_categories_for_practice_editor
 
-        expect(result.keys).to contain_exactly(parent_category)
+        expect(result.keys).to contain_exactly(parent_category, community_category)
       end
     end
   end
@@ -40,19 +40,10 @@ RSpec.describe Category, type: :model do
   describe '.get_parent_categories' do
     let!(:normal_category) { create(:category, :with_sub_categories) }
     let!(:community_category) { create(:category, :community, :with_sub_categories) }
-    let(:other_category) { create(:category, :is_other, :with_sub_categories) }
     let(:empty_category) { create(:category) }
 
-    context 'when user is an admin' do
-      it 'includes all categories except those marked as other' do
-        expect(described_class.get_parent_categories(true)).to contain_exactly(normal_category, community_category)
-      end
-    end
-
-    context 'when user is not an admin' do
-      it 'excludes categories marked as other and the Communities category' do
-        expect(described_class.get_parent_categories(false)).to contain_exactly(normal_category)
-      end
+    it 'includes all valid categories' do
+      expect(described_class.get_parent_categories).to contain_exactly(normal_category, community_category)
     end
   end
 


### PR DESCRIPTION
### JIRA issue link
[DM-5224](https://agile6.atlassian.net/browse/DM-5224)

## Description - what does this code do?
- Changes behavior for "Community" category checkboxes to remediate a bug
  - show Community category checkboxes to non-admin editors but disable them

## Testing done - how did you test it/steps on how can another person can test it 
- See bug reproduction steps in JIRA ticket
1.  Log in as an admin and apply a community tag to an innovation. 
2. For the same innovation, add a non-admin user as an editor (e.g. `demo@va.gov`). 
3. Log out. Log in as `demo@va.gov`. 
4. Go to the innovation's edit page. 
5. Confirm that the community tags are rendered as disabled. 
6. Add / remove non-community tags. 
7. Save the innovation.

## Screenshots, Gifs, Videos from application (if applicable)
![Screenshot 2024-11-05 at 3 32 13 PM](https://github.com/user-attachments/assets/b3c820ca-759e-4b60-ad22-7fa59be1e5f2)
