### PR TITLE
dm-5091 add avatar management to user profile edit page

### DIFF
--- a/app/assets/javascripts/_user_profile_utilities.es6
+++ b/app/assets/javascripts/_user_profile_utilities.es6
@@ -8,20 +8,19 @@
   // let $cancelEditBtn;
 
   function _toggleDeleteBtn({ visible, target }) {
-    let $imgDeleteBtn = $(target).closest('.dm-cropper-boundary').find($deleteBtn);
+    let imgDeleteBtn = $(target).closest('.dm-cropper-boundary').find($deleteBtn);
     let hideDeleteBtn = $(target).closest('.dm-cropper-boundary').find($imgsContainer).hasClass('dm-resource-image');
 
     if (visible && !hideDeleteBtn) {
-      $imgDeleteBtn.removeClass('hidden');
+      imgDeleteBtn.removeClass('hidden');
     } else {
-      $imgDeleteBtn.addClass('hidden');
+      imgDeleteBtn.addClass('hidden');
     }
   }
 
   function _clearUpload({ target }) {
     let $imgImgsContainer = $(target).closest('.dm-cropper-boundary').find($imgsContainer)
     let area = $(target).closest('.dm-cropper-boundary').data('area')
-    let type = $(target).closest('.dm-cropper-boundary').data('type')
 
     $imgImgsContainer.empty()
     $(target)
@@ -88,7 +87,6 @@
     $deleteBtn.click((event) => {
       _clearUpload({ target: event.target })
       _toggleDeleteBtn({ visible: false, target: event.target });
-      $imgDeleteBtn.removeClass('hidden');
       // _toggleEditBtn({ visible: false, target: event.target });
       // _toggleCropperBtnView({ visible: false, target: event.target });
       // _setCropBoxValues({ isCrop: false, target: event.target });

--- a/app/assets/javascripts/_user_profile_utilities.es6
+++ b/app/assets/javascripts/_user_profile_utilities.es6
@@ -1,0 +1,272 @@
+(($) => {
+  const $document = $(document);
+  let $deleteBtn;
+  let $imgsContainer;
+  let $placeholderImg;
+  // let $editBtn;
+  // let $saveEditBtn;
+  // let $cancelEditBtn;
+
+  function _toggleDeleteBtn({ visible, target }) {
+    let $imgDeleteBtn = $(target).closest('.dm-cropper-boundary').find($deleteBtn);
+    let hideDeleteBtn = $(target).closest('.dm-cropper-boundary').find($imgsContainer).hasClass('dm-resource-image');
+
+    if (visible && !hideDeleteBtn) {
+      $imgDeleteBtn.removeClass('hidden');
+    } else {
+      $imgDeleteBtn.addClass('hidden');
+    }
+  }
+
+  function _clearUpload({ target }) {
+    let $imgImgsContainer = $(target).closest('.dm-cropper-boundary').find($imgsContainer)
+    let area = $(target).closest('.dm-cropper-boundary').data('area')
+    let type = $(target).closest('.dm-cropper-boundary').data('type')
+
+    $imgImgsContainer.empty()
+    $(target)
+      .closest('.dm-cropper-boundary').find(".usa-file-input")
+      .replaceWith(`
+        <input  class="dm-cropper-upload-image usa-hint usa-file-input ${area}-image-attachment" type="file" accept=".jpg,.jpeg,.png" />
+      `)
+    $('.dm-cropper-upload-image').on('change', (event) => {
+      _attachAvatarImg({ uploadedImg: event.target.files[0], target: event.target });
+    })
+    $placeholderImg.removeClass('display-none')
+  }
+
+  function _attachAvatarImg({ uploadedImg, target }) {
+    let imgSizeMb = uploadedImg.size * 0.000001; // convert bytes to MB
+    let $errorText = $('.dm-image-error-text');
+    let $imgImgsContainer = $(target).closest('.dm-cropper-boundary').find($imgsContainer);
+
+    if (imgSizeMb <= 32) {
+      let reader = new FileReader();
+
+      reader.onload = function(event) {
+        let imgOrgElement = `<img src="${event.target.result}" class="avatar-profile-photo" alt=""/>`;
+        $imgImgsContainer.empty();
+        $imgImgsContainer.append(imgOrgElement);
+        $errorText.addClass('hidden');
+        _successfulImageLoad({ target });
+
+        $(target).closest('.dm-cropper-boundary').find('.dm-cropper-delete-image input[type="checkbox"]').prop('checked', false);
+      };
+
+      reader.readAsDataURL(uploadedImg);
+    } else {
+      $imgImgsContainer.empty();
+      $errorText.removeClass('hidden');
+      $errorText.find('p').text('Sorry, you cannot upload an image larger than 32MB.');
+      _failedImageLoad({ target });
+    }
+  }
+
+  function _failedImageLoad({ target }) {
+    _toggleDeleteBtn({ visible: false, target });
+    _clearUpload({ target });
+    // _toggleEditBtn({ visible: false, target })
+    // _setCropBoxValues({ isCrop: false, target });
+    // _toggleCropperBtnView({ visible: false, target });
+  }
+
+  function _successfulImageLoad({ target }) {
+    // _toggleEditBtn({ visible: true, target })
+    _toggleDeleteBtn({ visible: true, target });
+    // _setCropBoxValues({ isCrop: false, target });
+    // _toggleCropperBtnView({ visible: false, target });
+  }
+
+  function _attachUploadEventListener() {
+    $('.dm-cropper-upload-image').on('change', (event) => {
+      _attachAvatarImg({ uploadedImg: event.target.files[0], target: event.target });
+      $placeholderImg.addClass('display-none');
+    })
+  }
+
+  function _attachDeleteEventListener() {
+    $deleteBtn.click((event) => {
+      _clearUpload({ target: event.target })
+      _toggleDeleteBtn({ visible: false, target: event.target });
+      $imgDeleteBtn.removeClass('hidden');
+      // _toggleEditBtn({ visible: false, target: event.target });
+      // _toggleCropperBtnView({ visible: false, target: event.target });
+      // _setCropBoxValues({ isCrop: false, target: event.target });
+    });
+  }
+
+  // Photo editing logic, taken from overview_image_editor file, needs adjusting to get working properly:
+
+  // function _attachEditEventListener() {
+  //   $editBtn.click((event)  => {
+  //     event.preventDefault();
+  //     _toggleCropper({ visible: true, target: event.target });
+  //     // _toggleDeleteBtn({ visible: false, target: event.target });
+  //     _toggleImageView({ isCrop: true, target: event.target });
+  //     // _toggleCropperBtnView({ visible: true, target: event.target });
+  //     // _toggleEditBtn({ visible: false, target: event.target });
+  //   });
+  // }
+
+  // function _attachSaveEditEventListener() {
+  //   $saveEditBtn.click((event) => {
+  //     _setCropBoxValues({ isCrop: true, target: event.target });
+  //   });
+  // }
+
+  // function _attachCancelEditEventListener() {
+  //   $cancelEditBtn.click((event) => {
+  //     _toggleImageView({ isCrop: false, target: event.target })
+  //     _toggleDeleteBtn({ visible: true, target: event.target });
+  //     // _toggleCropper({ visible: false, target: event.target });
+  //     // _toggleCropperBtnView({ visible: false, target: event.target });
+  //     // _toggleEditBtn({ visible: true, target: event.target });
+  //     // _setCropBoxValues({ isCrop: false, target: event.target });
+  //   });
+  // }
+
+  // function _toggleCropperBtnView({ visible, target}) {
+  //   let $imgSaveEditBtn = $(target).closest('.dm-cropper-boundary').find($saveEditBtn)
+  //   let $imgCancelEditBtn = $(target).closest('.dm-cropper-boundary').find($cancelEditBtn)
+
+  //   if (visible) {
+  //     $imgSaveEditBtn.removeClass('hidden');
+  //     $imgCancelEditBtn.removeClass('hidden');
+  //   } else {
+  //     $imgSaveEditBtn.addClass('hidden');
+  //     $imgCancelEditBtn.addClass('hidden');
+  //   }
+  // }
+
+  // function _createModifiedImage({ target }) {
+  //   let $image = $(target).closest('.dm-cropper-boundary').find('.dm-cropper-thumbnail-original');
+  //   let setAsCanvas = $(target).closest('.dm-cropper-boundary').find($imgsContainer).hasClass('dm-resource-image');
+  //   if ($image && $image.data('cropper')) {
+  //     // Generate the cropped image as a canvas
+  //     $(target).closest('.dm-cropper-boundary').find('.dm-cropper-thumbnail-original').addClass('hidden')
+  //     let croppedCanvas = $image.data('cropper').getCroppedCanvas({ width: 310 })
+  //     if (setAsCanvas) {
+  //       croppedCanvas.classList.add('dm-cropper-thumbnail-modified')
+  //       $(target).closest('.dm-cropper-boundary').find($imgsContainer).append(croppedCanvas)
+  //     } else {
+  //       let url = croppedCanvas.toDataURL();
+  //       let image = new Image();
+  //       image.src = url;
+  //       image.classList.add('dm-cropper-thumbnail-modified')
+  //       $(target).closest('.dm-cropper-boundary').find($imgsContainer).append(image)
+  //     }
+
+  //     // Optionally, toggle other UI elements (e.g., hide Save/Cancel, show Edit)
+  //     _toggleCropperBtnView({ visible: false, target });
+  //     _toggleEditBtn({ visible: true, target });
+  //     _toggleDeleteBtn({ visible: true, target });
+  //   }
+  // }
+
+
+  // function _toggleImageView({ isCrop, target }) {
+  //   let $originalImage = $(target).closest('.dm-cropper-boundary').find('.dm-cropper-thumbnail-original');
+  //   let $modifiedCanvas = $(target).closest('.dm-cropper-boundary').find('.dm-cropper-thumbnail-modified');
+
+  //   if (isCrop && $originalImage) {
+  //     $originalImage.removeClass('hidden');
+  //     $modifiedCanvas.addClass('hidden')
+  //   } else {
+  //     if ($modifiedCanvas.length > 0) {
+  //       $originalImage.addClass('hidden');
+  //       $modifiedCanvas.removeClass('hidden')
+  //     } else {
+  //       $originalImage.removeClass('hidden');
+  //     }
+  //   }
+  // }
+
+  // function _toggleCropper({ visible, target }) {
+  //   let $image = $(target).closest('.dm-cropper-boundary').find('.dm-cropper-thumbnail-original');
+
+  //   if (visible) {
+  //     let cropOptions = {
+  //         checkCrossOrigin: false,
+  //         checkOrientation: true,
+  //         viewMode: 2,
+  //         minContainerWidth: 100,
+  //         aspectRatio: 1
+  //     }
+
+  //     // create Cropper instance
+  //     $image.cropper(cropOptions);
+  //   } else {
+  //     if ($image.data('cropper')) {
+  //       $image.data('cropper').destroy();
+  //     }
+  //   }
+  // }
+
+  // function _toggleEditBtn({ visible, target }) {
+  //   let $imgEditBtn = $(target).closest('.dm-cropper-boundary').find($editBtn)
+
+  //   if (visible) {
+  //     $imgEditBtn.removeClass('hidden');
+  //   } else {
+  //     $imgEditBtn.addClass('hidden');
+  //   }
+  // }
+
+  // function _setCropBoxValues({ isCrop, target }) {
+  //   let $image = $(target).closest('.dm-cropper-boundary').find('.dm-cropper-thumbnail-original');
+
+  //   if (isCrop && $image.data('cropper')) {
+  //     let cropValues = $image.data('cropper').getData(true);
+  //     $(target).closest('.dm-cropper-boundary').find(".crop_x").val(cropValues.x);
+  //     $(target).closest('.dm-cropper-boundary').find(".crop_y").val(cropValues.y);
+  //     $(target).closest('.dm-cropper-boundary').find(".crop_w").val(cropValues.width);
+  //     $(target).closest('.dm-cropper-boundary').find(".crop_h").val(cropValues.height);
+
+  //     _createModifiedImage({ target })
+  //     _toggleCropper({ visible: false, target });
+  //     _toggleCropperBtnView({ visible: false, target });
+  //     _toggleEditBtn({ visible: true, target });
+  //     _toggleDeleteBtn({ visible: true, target });
+  //     _toggleImageView({ isCrop: false, target });
+  //   } else {
+  //     $(target).closest('.dm-cropper-boundary').find(".crop_x").val(null);
+  //     $(target).closest('.dm-cropper-boundary').find(".crop_y").val(null);
+  //     $(target).closest('.dm-cropper-boundary').find(".crop_w").val(null);
+  //     $(target).closest('.dm-cropper-boundary').find(".crop_h").val(null);
+  //   }
+  // }
+
+  function attachImgActionsEventListeners() {
+    _attachUploadEventListener();
+    _attachDeleteEventListener();
+    // _attachEditEventListener();
+    // _attachSaveEditEventListener();
+    // _attachCancelEditEventListener();
+  }
+
+  function setImageVars() {
+    $deleteBtn = $('.dm-cropper-delete-image');
+    $imgsContainer = $('.dm-cropper-images-container');
+    $placeholderImg = $('.cropper-image-placeholder');
+    // $editBtn = $('.dm-cropper-edit-mode');
+    // $cancelEditBtn = $('.dm-cropper-cancel-edit');
+    // $saveEditBtn = $('.dm-cropper-save-edit');
+  }
+
+  function attachNewFieldEventListeners() {
+    $document.arrive('.dm-cropper-boundary', (newElem) => {
+      setImageVars();
+      _attachUploadEventListener();
+      // _attachSaveEditEventListener();
+      // _attachCancelEditEventListener();
+    })
+  }
+
+  function loadCropperFunctions() {
+    setImageVars();
+    attachImgActionsEventListeners();
+    attachNewFieldEventListeners();
+}
+
+  $document.on('turbolinks:load', loadCropperFunctions);
+})(window.jQuery);

--- a/app/assets/stylesheets/dm/components/_profile.scss
+++ b/app/assets/stylesheets/dm/components/_profile.scss
@@ -6,6 +6,8 @@
 .avatar-profile-photo {
   min-width: 100%;
   height: 14rem !important;
+  aspect-ratio: 1 / 1;
+  object-fit: cover;
 }
 
 .avatar-profile-photo-container {

--- a/app/views/users/edit_profile.html.erb
+++ b/app/views/users/edit_profile.html.erb
@@ -2,6 +2,7 @@
   <%= javascript_tag 'data-turbolinks-track': 'reload' do %>
     <%= render partial: 'edit_profile', formats: [:js] %>
   <% end %>
+  <%= javascript_include_tag '_user_profile_utilities', 'data-turbolinks-track': 'reload' %>
 <% end %>
 
 <div class="margin-top-0">
@@ -48,53 +49,62 @@
                 </div>
               </div>
               <% end %>
+              <!-- Profile Image and Actions -->
+              <% avatar_exists = @user.avatar.present? && @user.avatar.exists? %>
               <div class="grid-container padding-0">
                 <div class="grid-row margin-bottom-3 dm-cropper-boundary">
                   <div class="grid-col-4 margin-right-1 profile-image-left-col-setter">
                     <div class="dm-cropper-images-container avatar-profile-photo-container" data-type="user">
-                      <% if @user.avatar.present? && @user.avatar.exists? %>
-                          <%= image_tag @user.avatar_s3_presigned_url(:thumb), alt: "user avatar for #{@user.full_name}", class: 'dm-cropper-thumbnail-modified avatar-profile-photo'%>
+                      <% if avatar_exists %>
+                        <%= image_tag @user.avatar_s3_presigned_url(:thumb), alt: "user avatar for #{@user.full_name}", class: 'avatar-profile-photo' %>
                       <% end %>
                     </div>
-                    <div class="display-none <%= @user.avatar.present? && @user.avatar.exists? ? 'profile-avatar-container bg-base-lightest radius-md cropper-image-placeholder hidden' : 'profile-avatar-container bg-base-lightest radius-md cropper-image-placeholder' %>">
-                        <i class="fas fa-user empty-user-avatar text-base-lighter"></i>
-                      </div>
+                    <div class="profile-avatar-container bg-base-lightest radius-md cropper-image-placeholder <%= 'display-none' if avatar_exists %>">
+                      <i class="fas fa-user empty-user-avatar text-base-lighter"></i>
+                    </div>
                   </div>
-                  <div class="grid-col-fill profile-image-right-col-setter display-none">
-                    <p>Photo</p>
-                    <div class="text-base margin-y-1">
-                      <p class="line-height-sans-505">
-                        Upload a photo that clearly shows your face. You can upload a .jpg, .jpeg, or .png file and the size limit is 1GB.
-                      </p>
-                    </div>
-                    <div class="margin-bottom-2 dm-image-editor-text hidden">
-                      <p>
-                        Please click "Save edits" and then "Save changes" to save and exit editor.
-                      </p>
-                    </div>
 
-                  <div class="display-none grid-row flex-align-start display-none">
-                    <% for attribute in [:crop_x, :crop_y, :crop_w, :crop_h] %>
-                      <%= f.hidden_field attribute, :id => attribute, :value => nil %>
-                    <% end %>
-                    <div class="grid-col-fill">
-                      <a class="usa-button dm-cropper-save-edit hidden" aria-controls='photo-save-edit' aria-expanded='false'>Save edits</a>
-                      <a class="usa-button usa-button--outline dm-cropper-cancel-edit hidden" aria-controls='photo-cancel-edit' aria-expanded='false'>Cancel edits</a>
-                      <a class="<%= @user.avatar.present? && @user.avatar.exists? ? "usa-button usa-button--outline dm-cropper-edit-mode" : "usa-button usa-button--outline dm-cropper-edit-mode hidden" %>" aria-controls='photo-crop' aria-expanded='false'>Edit photo</a>
-                      <div>
-                        <%= f.label :avatar,
-                          @user.avatar.present? && @user.avatar.exists? ? 'Upload new photo' : 'Upload photo',
-                          class: @user.avatar.present? && @user.avatar.exists? ? 'dm-cropper-upload-image-label user-avatar-upload-label' : 'dm-cropper-upload-image-label usa-button usa-button--outline'
-                        %>
-                        <%= f.file_field :avatar, class: "hidden-upload cropper-upload-image", accept: 'image/*' %>
+                  <% if @user.granted_public_bio %>
+                    <div class="grid-col-fill profile-image-right-col-setter">
+                      <p>Photo</p>
+                      <div class="text-base margin-y-1">
+                        <p class="line-height-sans-505">
+                          Upload a photo that clearly shows your face. You can upload a .jpg, .jpeg, or .png file and the size limit is 1GB.
+                        </p>
                       </div>
-                      <div class="dm-cropper-delete-image">
-                        <%= f.label :delete_avatar, 'Remove photo', class: @user.avatar.present? && @user.avatar.exists? ? 'display-inline-block text-secondary dm-cropper-delete-image-label' : 'display-inline-block text-secondary dm-cropper-delete-image-label hidden'%>
-                        <%= f.check_box :delete_avatar, { class: @user.avatar.present? && @user.avatar.exists? ? 'usa-checkbox__input dm-cropper-delete-image' : 'usa-checkbox__input dm-cropper-delete-image hidden'}, 'true', 'false' %>
+
+                      <div class="margin-bottom-2 dm-image-editor-text hidden">
+                        <p>Please click "Save edits" and then "Save changes" to save and exit editor.</p>
+                      </div>
+
+                      <!-- Image Editing Buttons -->
+                      <div class="grid-row flex-align-start">
+                        <!--
+                        <% for attribute in [:crop_x, :crop_y, :crop_w, :crop_h] %>
+                          <%= f.hidden_field attribute, id: attribute, value: nil %>
+                        <% end %>
+                        -->
+                        <div class="grid-col-fill">
+                        <!--
+                          <a class="usa-button dm-cropper-save-edit display-none" aria-expanded="false">Save edits</a>
+                          <a class="usa-button usa-button--outline dm-cropper-cancel-edit display-none" aria-expanded="false">Cancel edits</a>
+                          <a class="<%= avatar_exists ? 'usa-button usa-button--outline dm-cropper-edit-mode' : 'usa-button usa-button--outline dm-cropper-edit-mode hidden' %>" aria-controls="photo-crop" aria-expanded="false">Edit photo</a>
+                        -->
+                          <!-- Upload Photo -->
+                          <div>
+                            <%= f.label :avatar, avatar_exists ? 'Upload new photo' : 'Upload photo', class: 'dm-cropper-upload-image-label usa-button usa-button--outline' %>
+                            <%= f.file_field :avatar, class: "dm-cropper-upload-image hidden-upload cropper-upload-image", accept: 'image/*' %>
+                          </div>
+
+                          <!-- Delete Photo -->
+                          <div class="dm-cropper-delete-image <%= 'hidden' unless avatar_exists %>">
+                            <%= f.label :delete_avatar, 'Remove photo', class: "display-inline-block text-secondary dm-cropper-delete-image-label" %>
+                            <%= f.check_box :delete_avatar, { class: avatar_exists ? 'usa-checkbox__input dm-cropper-delete-image' : 'usa-checkbox__input dm-cropper-delete-image hidden' }, 'true', 'false' %>
+                          </div>
+                        </div>
                       </div>
                     </div>
-                  </div>
-                  </div>
+                  <% end %>
                 </div>
               </div>
             </div>

--- a/spec/features/users/user_profile_spec.rb
+++ b/spec/features/users/user_profile_spec.rb
@@ -97,6 +97,28 @@ describe 'The user index', type: :feature do
     expect(sb.project).to eq('project text')
   end
 
+  it 'should allow a user to add, change, and remove their avatar photo' do
+    @user.update!(granted_public_bio: true)
+    login_as(@user, scope: :user, run_callbacks: false)
+    visit '/edit-profile'
+
+    # Initial upload of avatar
+    attach_file('user[avatar]', Rails.root.join('app/assets/images/va-seal.png'), visible: false)
+    click_button('Save changes')
+
+    # Reload user and verify the avatar was saved
+    user = User.find(@user.id)
+    expect(user.avatar.present?).to be true
+
+    # Change avatar
+    attach_file('user[avatar]', Rails.root.join('app/assets/images/dm-footer-logo.png'), visible: false)
+    click_button('Save changes')
+
+    # Reload user and verify the new avatar was saved
+    user.reload
+    expect(user.avatar.present?).to be true
+  end
+
   it 'should not show public-bio related fields if user not granted access' do
     login_as(@user, scope: :user, run_callbacks: false)
     visit '/edit-profile'


### PR DESCRIPTION
### JIRA issue link
https://agile6.atlassian.net/browse/DM-5091

## Description - what does this code do?
Adds user avatar management functionality to user profile edit page for users with `granted_public_bio: true`

## Testing done - how did you test it/steps on how can another person can test it 
1. Sign in as a user with `granted_public_bio` set to `true` and go to the profile edit page `/edit-profile`
2. verify you can add, change, and delete an avatar image.
3. verify the avatar appears on the profile show page `/users/{id}`
4. update the user by setting `granted_public_bio: false`
5. reload the profile edit page and verify the avatar management ui is no longer visible

## Screenshots, Gifs, Videos from application (if applicable)
![Screenshot 2024-11-06 at 3 02 46 PM](https://github.com/user-attachments/assets/1a25fc49-1028-4fcc-a8e2-e633b5e50024)

## Link to mock-ups/mock ups (image file if you have it) (if applicable)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Unit tests written (if applicable)
- [ ] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating JIRA issue
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specscontains logic for uploading user profile photos