### PR TITLE
Address Ruby 3.4 gem warnings

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -49,6 +49,10 @@ gem 'local_time'
 gem 'rails-timeago'
 
 gem 'sidekiq'
+
+# activesupport dependencies removed in Ruby 3.4
+gem 'mutex_m'
+gem 'drb'
 gem 'observer'
 
 group :development, :test do

--- a/Gemfile
+++ b/Gemfile
@@ -49,6 +49,7 @@ gem 'local_time'
 gem 'rails-timeago'
 
 gem 'sidekiq'
+gem 'observer'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile
+++ b/Gemfile
@@ -54,6 +54,8 @@ gem 'sidekiq'
 gem 'mutex_m'
 gem 'drb'
 gem 'observer'
+gem 'base64'
+gem 'bigdecimal'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -265,6 +265,7 @@ GEM
     diff-lcs (1.5.1)
     docile (1.4.0)
     domain_name (0.6.20240107)
+    drb (2.2.1)
     dumb_delegator (0.8.1)
     equalizer (0.0.11)
     erd (0.8.1)
@@ -386,6 +387,7 @@ GEM
     msgpack (1.7.2)
     multi_xml (0.7.1)
       bigdecimal (~> 3.1)
+    mutex_m (0.2.0)
     naturalsorter (3.0.22)
     neat (1.7.4)
       bourbon (>= 4.0)
@@ -863,6 +865,7 @@ DEPENDENCIES
   database_cleaner
   devise (>= 4.6.0)
   devise-security
+  drb
   erd
   factory_bot_rails
   faker
@@ -885,6 +888,7 @@ DEPENDENCIES
   local_time
   lodash-rails
   mechanize
+  mutex_m
   naturalsorter (= 3.0.22)
   nested_form
   net-ldap

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -849,7 +849,9 @@ DEPENDENCIES
   aws-sdk-s3
   axe-matchers
   babel-transpiler
+  base64
   bcrypt (~> 3.1.13)
+  bigdecimal
   bootsnap
   brakeman (= 5.0.2)
   bullet

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -409,6 +409,7 @@ GEM
     nokogiri (1.16.7)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
+    observer (0.1.2)
     opentelemetry-api (1.0.2)
     opentelemetry-common (0.19.6)
       opentelemetry-api (~> 1.0)
@@ -888,6 +889,7 @@ DEPENDENCIES
   nested_form
   net-ldap
   ntlm-sso!
+  observer
   opentelemetry-exporter-otlp
   opentelemetry-instrumentation-all
   opentelemetry-sdk


### PR DESCRIPTION
### JIRA issue link


## Description - what does this code do?
Addresses various warnings re: gems that will not bundled with Ruby 3.4 that are used by activesupport.
```
.rbenv/versions/3.3.6/lib/ruby/gems/3.3.0/gems/activesupport-6.1.7.9/lib/active_support/dependencies.rb:299: warning: .rbenv/versions/3.3.6/lib/ruby/3.3.0/mutex_m.rb was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.4.0.
You can add mutex_m to your Gemfile or gemspec to silence this warning.
```

[mutex_m](https://github.com/ruby/mutex_m)
[drb](https://github.com/ruby/drb)
[observer](https://github.com/ruby/observer)
[base64](https://github.com/ruby/base64)
[bigdecimal](https://github.com/ruby/bigdecimal)

These can likely be removed after upgrading to Rails 7, where they will be included in activesupport
https://github.com/rails/rails/pull/48907

## Testing done - how did you test it/steps on how can another person can test it 


## Screenshots, Gifs, Videos from application (if applicable)


## Link to mock-ups/mock ups (image file if you have it) (if applicable)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Unit tests written (if applicable)
- [ ] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating JIRA issue
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs