### PR TITLE
add :accolades col to users table

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -128,6 +128,7 @@ class UsersController < ApplicationController
   def user_params
     return params.require(:user).permit(:avatar, :bio) if session[:user_type] === 'ntlm'
     params.require(:user).permit( :accepted_term,
+                                  :accolades,
                                   :alt_first_name,
                                   :alt_job_title,
                                   :alt_last_name,

--- a/app/views/users/edit_profile.html.erb
+++ b/app/views/users/edit_profile.html.erb
@@ -173,6 +173,18 @@
 
                   <div class="grid-row width-full">
                     <div class="field margin-top-3 grid-col-9">
+                      <%= f.label :accolades, 'Honors, degress (Public Bio)', class: 'margin-top-2 margin-bottom-2' %><br/>
+                      <p>e.g. LCSW, M.A.</p>
+                      <%= f.text_field :accolades,
+                        value: @user.accolades,
+                        autofocus: true,
+                        class: "usa-input border-base-light"
+                      %>
+                    </div>
+                  </div>
+
+                  <div class="grid-row width-full">
+                    <div class="field margin-top-3 grid-col-9">
                       <%= f.label :alt_job_title, 'Title (Public Bio)', class: 'margin-top-2 margin-bottom-2' %><br/>
                       <%= f.text_field :alt_job_title,
                         value: @user.alt_job_title.present? ? @user.alt_job_title : @user.job_title,

--- a/db/migrate/20241030205550_add_columns_to_users.rb
+++ b/db/migrate/20241030205550_add_columns_to_users.rb
@@ -6,5 +6,6 @@ class AddColumnsToUsers < ActiveRecord::Migration[6.1]
     add_column :users, :work, :text
     add_column :users, :project, :text
     add_column :users, :alt_job_title, :string
+    add_column :users, :accolades, :string
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1122,6 +1122,7 @@ ActiveRecord::Schema.define(version: 2024_11_01_010951) do
     t.text "work"
     t.text "project"
     t.string "alt_job_title"
+    t.string "accolades"
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["granted_public_bio"], name: "index_users_on_granted_public_bio"

--- a/spec/features/users/user_profile_spec.rb
+++ b/spec/features/users/user_profile_spec.rb
@@ -86,6 +86,7 @@ describe 'The user index', type: :feature do
     fill_in('Work (Public Bio)', with: 'public bio work text')
     fill_in('Credentials (Public Bio)', with: 'public bio credentials text')
     fill_in('Project (Public Bio)', with: 'project text')
+    fill_in('Honors, degress (Public Bio)', with: 'LCSW, M.A.')
     click_button('Save changes')
 
     sb = User.find(@user.id)
@@ -95,6 +96,7 @@ describe 'The user index', type: :feature do
     expect(sb.work).to eq('public bio work text')
     expect(sb.credentials).to eq('public bio credentials text')
     expect(sb.project).to eq('project text')
+    expect(sb.accolades).to eq('LCSW, M.A.')
   end
 
   it 'should allow a user to add, change, and remove their avatar photo' do
@@ -129,6 +131,7 @@ describe 'The user index', type: :feature do
     expect(page).not_to have_selector("input[value='#{@user.credentials}']")
     expect(page).not_to have_selector("input[value='#{@user.work}']")
     expect(page).not_to have_selector("input[value='#{@user.project}']")
+    expect(page).not_to have_selector("input[value='#{@user.accolades}']")
   end
 
   it 'should have a favorited practice' do


### PR DESCRIPTION
### JIRA issue link
https://agile6.atlassian.net/browse/DM-5331

## Description - what does this code do?
adds `:accolades` col to `users` table and field to profile edit form for management

## Testing done - how did you test it/steps on how can another person can test it 
1. drop local db and run the import task to update the schema with the new users table col
2. Locally, set a user to `granted_public_bio: true`
3. sign in as that user, go to `/edit-profile`
4. update the "Honors, degress (Public Bio)" field, verify the change persists

## Screenshots, Gifs, Videos from application (if applicable)
<img width="580" alt="Screenshot 2024-11-13 at 10 20 48 AM" src="https://github.com/user-attachments/assets/c2a7aa9e-5077-4b38-a3ed-4c02b6427f47">

## Link to mock-ups/mock ups (image file if you have it) (if applicable)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Unit tests written (if applicable)
- [x] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating JIRA issue
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs