### PR TITLE
dm-5337 link edit profile page to bio page

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -137,6 +137,10 @@ class User < ApplicationRecord
     "#{preferred_full_name}#{', ' if accolades}#{accolades}"
   end
 
+  def to_param
+    "#{id}-#{preferred_full_name.gsub(' ', '-')}"
+  end
+
   def favorite_practices
     user_practices.select(&:favorited).map(&:practice)
   end

--- a/app/views/users/_side_nav.html.erb
+++ b/app/views/users/_side_nav.html.erb
@@ -5,6 +5,9 @@
         <%= link_to('Profile', edit_profile_path,
                     class: "#{'usa-current' if current_page?(edit_profile_path)}"
             ) %>
+        <% if @user.granted_public_bio %>
+          <%= link_to('Public Bio Page', user_bio_path(@user)) %>
+        <% end %>
       </li>
       <% if session[:user_type] === 'guest' %>
         <li class="usa-sidenav__item">

--- a/app/views/users/edit_profile.html.erb
+++ b/app/views/users/edit_profile.html.erb
@@ -34,6 +34,15 @@
               <div class="actions margin-bottom-4-important display-inline-block">
                 <%= f.submit "Save changes", class: 'usa-button usa-button-primary' %>
               </div>
+              <% if @user.granted_public_bio %>
+                <div class="display-inline-block margin-right-1">
+                  <%= link_to user_bio_path(@user) do %>
+                    <button class="usa-button usa-button--outline margin-right-0">
+                      View Public Profile
+                    </button>
+                  <% end %>
+                </div>
+              <% end %>
               <% if @user.errors.any? %>
               <div class="usa-alert usa-alert--error" >
                 <div class="usa-alert__body">

--- a/spec/features/users/user_bio_page_spec.rb
+++ b/spec/features/users/user_bio_page_spec.rb
@@ -10,17 +10,17 @@ RSpec.feature 'User Public Bio Page', type: :feature do
   context 'when all profile elements are present with alternate names and job title' do
     let(:user) do
       create(:user,
-        first_name: 'John',
+        first_name: 'Johnathan',
         last_name: 'Doe',
         accolades: 'LCSW, M.A.',
-        alt_first_name: 'Jay',
-        alt_last_name: 'Gorman',
+        alt_first_name: 'John',
+        alt_last_name: 'Goodman',
         job_title: 'Doctor',
         alt_job_title: '2024 Entrepreneur in Residence Fellow',
-        project: 'Veterans Socials: Expanding Social Support in the Community',
-        work: 'Veterans Socials: Expanding Social Support in the Community, Peer Specialist Veterans Connect Over Coffee',
-        bio: 'Dr. Jay Gorman is a clinical research psychologist in the VISN 1 New England Mental Illness Research, Education, and Clinical (MIRREC) Center and Director of the Social Reintegration Research Program at the VA Bedford Healthcare System',
-        credentials: 'MIRREC Clinical Research Investigator, Director, Social Reintegration Research Program, VA Bedford Healthcare System',
+        project: 'Fake Project: Faking projects for test data',
+        work: 'Fake Project: Faking projects for test data, Fake work text',
+        bio: 'Dr. John Goodman is a fake doctor and this text is for testing purposes',
+        credentials: 'fake credentials text for testing purposes',
         avatar: Rack::Test::UploadedFile.new(Rails.root.join('app/assets/images/va-seal.png'), 'image/png'),
         granted_public_bio: true
       )
@@ -28,16 +28,15 @@ RSpec.feature 'User Public Bio Page', type: :feature do
 
     scenario 'displays all sections with full data, preferring alt names and job title' do
       expect(page).to have_css('img.avatar-profile-photo')
-      expect(page).to have_content('Jay Gorman, LCSW, M.A.')
+      expect(page).to have_content('John Goodman, LCSW, M.A.')
       expect(page).to have_content('2024 Entrepreneur in Residence Fellow')
-      expect(page).to have_content('Veterans Socials: Expanding Social Support in the Community')
+      expect(page).to have_content('Fake Project: Faking projects for test data')
       expect(page).to have_content('Work')
-      expect(page).to have_content('Veterans Socials: Expanding Social Support in the Community')
-      expect(page).to have_content('Peer Specialist Veterans Connect Over Coffee')
+      expect(page).to have_content('Fake work text')
       expect(page).to have_content('About')
-      expect(page).to have_content('Dr. Jay Gorman is a clinical research psychologist in the VISN 1 New England Mental Illness Research, Education, and Clinical (MIRREC) Center and Director of the Social Reintegration Research Program at the VA Bedford Healthcare System')
+      expect(page).to have_content('Dr. John Goodman is a fake doctor and this text is for testing purposes')
       expect(page).to have_content('Credentials')
-      expect(page).to have_content('MIRREC Clinical Research Investigator, Director, Social Reintegration Research Program, VA Bedford Healthcare System')
+      expect(page).to have_content('fake credentials text for testing purposes')
     end
   end
 

--- a/spec/features/users/user_profile_spec.rb
+++ b/spec/features/users/user_profile_spec.rb
@@ -138,17 +138,18 @@ describe 'The user index', type: :feature do
     login_as(@user, scope: :user, run_callbacks: false)
     visit '/edit-profile'
     expect(page).not_to have_content('Public Bio Page')
+    expect(page).not_to have_content('View Public Profile')
 
     @user.update!(
       granted_public_bio: true,
       first_name: 'John', last_name: 'test',
       alt_last_name: 'Goodman'
     )
-    visit '/edit-profile'
-    click_link 'Public Bio Page'
 
+    visit '/edit-profile'
     expected_path = '/bios/1-John-Goodman'
-    expect(page).to have_current_path(expected_path, ignore_query: true)
+    expect(page).to have_link('Public Bio Page', href: expected_path)
+    expect(page).to have_link('View Public Profile', href: expected_path)
   end
 
   it 'should have a favorited practice' do

--- a/spec/features/users/user_profile_spec.rb
+++ b/spec/features/users/user_profile_spec.rb
@@ -141,13 +141,13 @@ describe 'The user index', type: :feature do
 
     @user.update!(
       granted_public_bio: true,
-      first_name: 'Jay', last_name: 'test',
-      alt_last_name: 'Gorman'
+      first_name: 'John', last_name: 'test',
+      alt_last_name: 'Goodman'
     )
     visit '/edit-profile'
     click_link 'Public Bio Page'
 
-    expected_path = '/bios/1-Jay-Gorman'
+    expected_path = '/bios/1-John-Goodman'
     expect(page).to have_current_path(expected_path, ignore_query: true)
   end
 

--- a/spec/features/users/user_profile_spec.rb
+++ b/spec/features/users/user_profile_spec.rb
@@ -134,6 +134,23 @@ describe 'The user index', type: :feature do
     expect(page).not_to have_selector("input[value='#{@user.accolades}']")
   end
 
+  it 'should link to the public bio page if granted' do
+    login_as(@user, scope: :user, run_callbacks: false)
+    visit '/edit-profile'
+    expect(page).not_to have_content('Public Bio Page')
+
+    @user.update!(
+      granted_public_bio: true,
+      first_name: 'Jay', last_name: 'test',
+      alt_last_name: 'Gorman'
+    )
+    visit '/edit-profile'
+    click_link 'Public Bio Page'
+
+    expected_path = '/bios/1-Jay-Gorman'
+    expect(page).to have_current_path(expected_path, ignore_query: true)
+  end
+
   it 'should have a favorited practice' do
     @practice1 = Practice.create!(name: 'A public practice', approved: true, published: true, tagline: 'Test tagline', user: @user)
     @practice2 = Practice.create!(name: 'The Best Innovation Ever!', approved: true, published: true, tagline: 'Test tagline', user: @user2)


### PR DESCRIPTION
### JIRA issue link
https://agile6.atlassian.net/browse/DM-5337

## Description - what does this code do?
Adds link to user's bio page from edit profile page

## Testing done - how did you test it/steps on how can another person can test it 
1. Log in as a user with `granted_public_bio: false` and nav to `/edit-profile`
2. verify there is no link to a bio page for the user in the left nav
3. in rails console update the user to `granted_public_bio: true`
4. refresh the edit profile page and verify there is now a link to the user's bio page in the left nav
5. click the link, verify you are navd to the bio page and that the url contains the alt-names for the user if present, if not present it should default to the user's normal name (see screenshot) 

## Screenshots, Gifs, Videos from application (if applicable)
<img width="1256" alt="Screenshot 2024-11-14 at 11 57 52 AM" src="https://github.com/user-attachments/assets/2eedcf50-3f5a-4fa8-bc80-1be5decba91e">

<img width="1030" alt="Screenshot 2024-11-14 at 11 02 19 AM" src="https://github.com/user-attachments/assets/b9867660-eaa5-49eb-bff3-195cc7a369f5">

## Link to mock-ups/mock ups (image file if you have it) (if applicable)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Unit tests written (if applicable)
- [ ] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating JIRA issue
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs