### PR TITLE
DM-5028: Change 'Email Innovation' CTA button to 'Contact Team'

### DIFF
--- a/app/views/about/index.html.erb
+++ b/app/views/about/index.html.erb
@@ -74,7 +74,7 @@
         item_number: '4',
         question: 'How do I learn more about an innovation?',
         answer: "VA and non-VA site visitors can email innovation owners directly to ask questions or request more information. To send them a message, simply click the
-                \"Email innovation\" button on any innovation page."
+                \"Contact Team\" button on any innovation page."
         }
       %>
       <%= render partial: 'faq_accordion', locals: {
@@ -86,7 +86,7 @@
       <%= render partial: 'faq_accordion', locals: {
         item_number: '6',
         question: 'How do I adopt an innovation at my VA healthcare facility?',
-        answer: "To adopt an innovation, click the \"Email innovation\" button on any innovation page and send the innovation owner a message about your interest in adopting
+        answer: "To adopt an innovation, click the \"Contact Team\" button on any innovation page and send the innovation owner a message about your interest in adopting
                  their innovation."
         }
       %>
@@ -94,7 +94,7 @@
         item_number: '7',
         question: 'How do I adopt an innovation at a non-VA healthcare facility?',
         answer: "The ability of an innovation team to collaborate with non-VA personnel varies. If you have questions, or want to learn more about an innovation, you can
-                reach out to the innovation editor by clicking the \"Email innovation\" button on any innovation page."
+                reach out to the innovation editor by clicking the \"Contact Team\" button on any innovation page."
         }
       %>
       <%= render partial: 'faq_accordion', locals: {

--- a/app/views/practices/show/introduction/_introduction.html.erb
+++ b/app/views/practices/show/introduction/_introduction.html.erb
@@ -15,13 +15,13 @@
     <%= render partial: 'practices/show/mobile_partials/main_display_image_container' %>
     <%# practice name %>
     <div class="desktop:grid-col-8 grid-col-12">
-      <h1 class="margin-top-0 margin-bottom-1 dm-word-break-break-word dm-hyphens-auto">
-        <%= @practice.name %>
-      </h1>
       <%# innovation last update timestamp %>
       <p class="grid-col-12 font-sans-3xs text-base line-height-sans-4 margin-bottom-2">
         Last updated <%= timeago(updated_at) %>
       </p>
+      <h1 class="margin-top-0 margin-bottom-1 dm-word-break-break-word dm-hyphens-auto">
+        <%= @practice.name %>
+      </h1>
       <%# practice actions %>
       <%# bookmark %>
       <% if current_user.present? %>

--- a/app/views/practices/show/show.html.erb
+++ b/app/views/practices/show/show.html.erb
@@ -66,7 +66,7 @@
 
 <div class="practice-mobile-nav padding-1 z-top desktop:display-none display-flex flex-justify-center">
   <% unless @practice.private_contact_info? && is_user_a_guest? %>
-    <%= mail_to main_email, 'Contact Team', cc: cc_emails, id: 'email-link-in-mobile-nav', class: 'width-full usa-button  display-flex flex-align-center flex-justify-center margin-right-2', 'aria-label': "Mobile nav email #{main_email}"  %>
+    <%= mail_to main_email, 'Contact Team', cc: cc_emails, id: 'email-link-in-mobile-nav', class: 'width-full usa-button  display-flex flex-align-center flex-justify-center', 'aria-label': "Mobile nav email #{main_email}"  %>
   <% end %>
   <% if (current_user.present?) && (current_user.has_role?(:admin) || @practice.user_id == current_user.id) %>
     <%= link_to 'Edit', practice_editors_path(@practice), id: 'edit-link-in-mobile-nav', class: 'width-full usa-button usa-button--secondary margin-right-0' %>

--- a/app/views/practices/show/show.html.erb
+++ b/app/views/practices/show/show.html.erb
@@ -82,13 +82,13 @@
       <h2 class="font-sans-xl line-height-37px margin-top-2 margin-bottom-10">Overview</h2>
       <div class="metric-section practice-section">
         <section id="overview_problem" class="margin-bottom-5">
-          <%= render partial: 'practices/show/overview/overview_sections', locals: {resources: @practice.practice_problem_resources, statement: @practice.overview_problem, title: 'The problem', s_area: 'problem'} %>
+          <%= render partial: 'practices/show/overview/overview_sections', locals: {resources: @practice.practice_problem_resources, statement: @practice.overview_problem, title: 'Problem', s_area: 'problem'} %>
         </section>
         <section id="overview_solution" class="margin-bottom-5">
-          <%= render partial: 'practices/show/overview/overview_sections', locals: {resources: @practice.practice_solution_resources, statement: @practice.overview_solution, title: 'The solution', s_area: 'solution'} %>
+          <%= render partial: 'practices/show/overview/overview_sections', locals: {resources: @practice.practice_solution_resources, statement: @practice.overview_solution, title: 'Solution', s_area: 'solution'} %>
         </section>
         <section id="overview_results">
-          <%= render partial: 'practices/show/overview/overview_sections', locals: {resources: @practice.practice_results_resources, statement: @practice.overview_results, title: 'The results', s_area: 'results'} %>
+          <%= render partial: 'practices/show/overview/overview_sections', locals: {resources: @practice.practice_results_resources, statement: @practice.overview_results, title: 'Results', s_area: 'results'} %>
         </section>
       </div>
     </div>

--- a/app/views/practices/show/show.html.erb
+++ b/app/views/practices/show/show.html.erb
@@ -46,7 +46,7 @@
     <%
       main_email = @practice.support_network_email
       practice_emails = @practice.practice_emails
-      cc_emails = practice_emails.map(&:address).join(', ')
+      cc_emails = [practice_emails.map(&:address), "marketplace@va.gov"].join(', ')
     %>
     <% unless @practice.private_contact_info? && is_user_a_guest? %>
       <div class="text-center margin-bottom-1">

--- a/app/views/practices/show/show.html.erb
+++ b/app/views/practices/show/show.html.erb
@@ -50,7 +50,7 @@
     %>
     <% unless @practice.private_contact_info? && is_user_a_guest? %>
       <div class="text-center margin-bottom-1">
-        <%= mail_to main_email, 'Email innovation', subject: "Question about #{@practice.name}", cc: cc_emails, class: 'usa-button  width-full display-flex flex-align-center flex-justify-center
+        <%= mail_to main_email, 'Contact Team', subject: "Question about #{@practice.name}", cc: cc_emails, class: 'usa-button  width-full display-flex flex-align-center flex-justify-center
         dm-email-practice', 'aria-label': "side nav email #{main_email}", data: {practice_id: @practice.id} %>
       </div>
     <% end %>

--- a/app/views/practices/show/show.html.erb
+++ b/app/views/practices/show/show.html.erb
@@ -66,7 +66,7 @@
 
 <div class="practice-mobile-nav padding-1 z-top desktop:display-none display-flex flex-justify-center">
   <% unless @practice.private_contact_info? && is_user_a_guest? %>
-    <%= mail_to main_email, 'Email', cc: cc_emails, id: 'email-link-in-mobile-nav', class: 'width-full usa-button  display-flex flex-align-center flex-justify-center margin-right-2', 'aria-label': "Mobile nav email #{main_email}"  %>
+    <%= mail_to main_email, 'Contact Team', cc: cc_emails, id: 'email-link-in-mobile-nav', class: 'width-full usa-button  display-flex flex-align-center flex-justify-center margin-right-2', 'aria-label': "Mobile nav email #{main_email}"  %>
   <% end %>
   <% if (current_user.present?) && (current_user.has_role?(:admin) || @practice.user_id == current_user.id) %>
     <%= link_to 'Edit', practice_editors_path(@practice), id: 'edit-link-in-mobile-nav', class: 'width-full usa-button usa-button--secondary margin-right-0' %>

--- a/spec/features/practice_viewer/contact_spec.rb
+++ b/spec/features/practice_viewer/contact_spec.rb
@@ -285,11 +285,11 @@ describe 'Contact section', type: :feature, js: true do
     it 'hides contact info from public users' do
       visit practice_path(practice_with_private_contact)
       expect(page).not_to have_content('Email user1@va.gov with questions about this innovation.')
-      expect(page).not_to have_content('Email innovation')
+      expect(page).not_to have_content('Contact Team')
       login_as(user1, :scope => :user, :run_callbacks => false)
       visit practice_path(practice)
       expect(page).to have_content('Email user3@va.gov with questions about this innovation.')
-      expect(page).to have_content('Email innovation')
+      expect(page).to have_content('Contact Team')
     end
   end
 


### PR DESCRIPTION
### JIRA issue link
[DM-5028](https://agile6.atlassian.net/browse/DM-5028)
[DM-5029](https://agile6.atlassian.net/browse/DM-5029)

## Description - what does this code do?
- Change 'Email Innovation' CTA button to 'Contact Team'
- Update references to button in FAQs
- Move "last updated" string above practice title

## Screenshots, Gifs, Videos from application (if applicable)
### Before
<img width="846" alt="Screenshot 2024-11-14 at 3 09 32 PM" src="https://github.com/user-attachments/assets/be7b7c34-446c-4daa-9fef-31c1ae8d24a1">

### After
<img width="815" alt="Screenshot 2024-11-14 at 3 10 02 PM" src="https://github.com/user-attachments/assets/bb35c6eb-6b50-441d-b48b-433d8eb7ac80">
