### PR TITLE
dm-4877 xss warning fix innovation editor intro page

### DIFF
--- a/app/controllers/practices_controller.rb
+++ b/app/controllers/practices_controller.rb
@@ -345,6 +345,7 @@ class PracticesController < ApplicationController # rubocop:disable Metrics/Clas
     @ordered_practice_partners = PracticePartnerPractice.where(innovable_id: @practice.id).order_by_id
     @ordered_practice_origin_facilities = PracticeOriginFacility.where(practice_id: @practice.id).order_by_id
     @user_can_edit_communities = current_user.has_role?(:admin)
+    @origin_data = JSON.parse(File.read(Rails.root.join('lib', 'assets', 'practice_origin_lookup.json')))
     render 'practices/form/introduction'
   end
 

--- a/app/views/practices/form/introduction.html.erb
+++ b/app/views/practices/form/introduction.html.erb
@@ -15,7 +15,7 @@
     <%= render partial: 'practices/publication_validation', formats: [:js] %>
     var facilityData = <%= raw @va_facilities.to_json %>;
     var officeData = '<%= raw fetch_offices %>';
-    var originData = <%= raw JSON.parse(File.read("#{Rails.root}/lib/assets/practice_origin_lookup.json")).to_json %>;
+    var originData = <%= @origin_data.to_json.html_safe %>;
     var visnData = '<%= raw @visns.to_json %>';
     var selectedFacility = "<%= @practice.facility? && @practice.initiating_facility || false %>"
     var selectedFacilityType = "<%= @practice.initiating_facility_type %>"
@@ -29,10 +29,7 @@
   <% end %>
 <% end %>
 <%= render partial: 'practices/introduction_forms/main_display_image_guidance_modal' %>
-<%
-  origin_data = JSON.parse(File.read("#{Rails.root}/lib/assets/practice_origin_lookup.json"))
-  p_partners = @practice.practice_partners
-%>
+<% p_partners = @practice.practice_partners %>
 
 <div class="grid-container practice-editor-page">
   <div class="grid-row grid-gap">
@@ -278,7 +275,7 @@
                   <%= label_tag 'editor_department_select', 'Administration', class: 'usa-label margin-top-0 margin-bottom-1
                 grid-col-12' %>
                   <%= select_tag('practice[initiating_department_office_id]',
-                                 options_for_select(origin_data['departments'].collect { |d| [d['name'], d['id']] }), id:
+                                 options_for_select(@origin_data['departments'].collect { |d| [d['name'], d['id']] }), id:
                                      'editor_department_select', class: 'height-5 usa-select margin-top-0', include_blank: '-Select-') %>
                 </div>
                 <div class="margin-bottom-3 grid-row">


### PR DESCRIPTION
### JIRA issue link
https://agile6.atlassian.net/browse/DM-4877

## Description - what does this code do?
update introduction partial to escape html-sensitive chars for originData js var in order to satisfy codeql warning for [stored xss vulnerability](https://github.com/department-of-veterans-affairs/diffusion-marketplace/security/code-scanning/1)

## Testing done - how did you test it/steps on how can another person can test it 
go to the `/introduction` page of the of the innovation editor and verify the "Originating Location*" selection functions as expected

## Screenshots, Gifs, Videos from application (if applicable)


## Link to mock-ups/mock ups (image file if you have it) (if applicable)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Unit tests written (if applicable)
- [ ] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating JIRA issue
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs