### PR TITLE
dm-4878 xss warning fix innovation show page

### DIFF
--- a/app/views/commontator/comments/_show.html.erb
+++ b/app/views/commontator/comments/_show.html.erb
@@ -115,7 +115,7 @@
                     <div class="text-right">
                       <button class="usa-button usa-button--outline margin-0 margin-top-5 margin-right-05 report-abuse-cancel">Cancel</button>
                       <%= link_to 'Submit Report',
-                          report_practice_comment_path(practice_id: practice.id, id: comment.id),
+                          Rails.application.routes.url_helpers.report_practice_comment_path(practice_id: @practice.id, id: comment.id) ,
                           class: 'usa-button report-abuse-submit',
                           data: { confirm: 'Are you sure you want to report this comment?', turbolinks: 'false' } %>
                     </div>

--- a/app/views/commontator/comments/_show.html.erb
+++ b/app/views/commontator/comments/_show.html.erb
@@ -114,7 +114,10 @@
                     </div>
                     <div class="text-right">
                       <button class="usa-button usa-button--outline margin-0 margin-top-5 margin-right-05 report-abuse-cancel">Cancel</button>
-                      <%= link_to 'Submit Report', "/innovations/#{practice.id}/comments/#{comment.id}/report", class: 'usa-button  report-abuse-submit', data: { confirm: 'Are you sure you want to report this comment?', turbolinks: 'false' } %>
+                      <%= link_to 'Submit Report',
+                          report_practice_comment_path(practice_id: practice.id, id: comment.id),
+                          class: 'usa-button report-abuse-submit',
+                          data: { confirm: 'Are you sure you want to report this comment?', turbolinks: 'false' } %>
                     </div>
                   </div>
                 </div>


### PR DESCRIPTION
### JIRA issue link
https://agile6.atlassian.net/browse/DM-4878

## Description - what does this code do?
updates comment report submission confirmation link to use path helper which ensure safe parameter handling in order to satisfy codeql warning for [stored xss vulnerability](https://github.com/department-of-veterans-affairs/diffusion-marketplace/security/code-scanning/1)

## Testing done - how did you test it/steps on how can another person can test it 
1. leave a comment on the show page for an innovation
2. sign in as another user and click the red flag to submit a report for the comment
3. verify that the report submits upon clicking the confirmation button (sends email with report)

## Screenshots, Gifs, Videos from application (if applicable)


## Link to mock-ups/mock ups (image file if you have it) (if applicable)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Unit tests written (if applicable)
- [ ] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating JIRA issue
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs