### PR TITLE
DM-5347: Add a link to public bio pages from admin interface

### DIFF
--- a/app/admin/users.rb
+++ b/app/admin/users.rb
@@ -36,7 +36,9 @@ ActiveAdmin.register User do
       row :visn
       row :created_at
       row :confirmed_at
-      row :granted_public_bio
+      row :granted_public_bio do |user|
+        user.granted_public_bio ? link_to('Public Bio Page', user_bio_path(user)) : false
+      end
       row "Admin" do |user|
         user.has_role?(:admin)
       end


### PR DESCRIPTION
### JIRA issue link
[DM-5347](https://agile6.atlassian.net/browse/DM-5347)

## Description - what does this code do?
- Adds a link to users' public bio page from the admin interface so that admins can easily review content

## Testing done - how did you test it/steps on how can another person can test it 
1. As an admin, grant a user a public bio page
2. Go to that user's show page on `/admin/users`. 
3. Confirm that a link is available 
4. Go to a user that has NOT been granted a public bio page
5. Confirm that `No` is rendered next to `Granted Public Bio`

## Screenshots, Gifs, Videos from application (if applicable)
![Screenshot 2024-11-27 at 4 26 51 PM](https://github.com/user-attachments/assets/31567847-8739-4db1-bf46-5b406a70a9dc)
![Screenshot 2024-11-27 at 4 26 44 PM](https://github.com/user-attachments/assets/5f501108-b258-45c4-bef1-427bcf438b78)

