### PR TITLE
dm-5348 admin access to user profile edit pages

### DIFF
--- a/app/admin/users.rb
+++ b/app/admin/users.rb
@@ -63,8 +63,8 @@ ActiveAdmin.register User do
     f.inputs do
       f.input :email
       f.input :skip_va_validation
-      f.input :password
-      f.input :password_confirmation
+      f.input :password, input_html: { autocomplete: 'new-password' }
+      f.input :password_confirmation, input_html: { autocomplete: 'new-password' }
       # instance-scoped editor roles should be left out of the collection as they are managed in the
       # given page_group's edit form:
       f.input :roles, as: :check_boxes, collection: Role.where(name: ['admin'])

--- a/app/views/users/bio.html.erb
+++ b/app/views/users/bio.html.erb
@@ -8,6 +8,11 @@
           <i class="fas fa-user empty-user-avatar text-base-lighter"></i>
         </div>
       <% end %>
+      <% if current_user.present? && current_user == @user %>
+        <%= link_to 'Edit profile', edit_profile_path, class: 'usa-button usa-button--outline display-inline-block margin-top-2' %>
+      <% elsif current_user.present? && current_user.has_role?(:admin) %>
+        <%= link_to 'Edit profile', admin_edit_user_profile_path(@user), class: 'usa-button usa-button--outline display-inline-block margin-top-2' %>
+      <% end %>
     </div>
 
     <div class="grid-col">

--- a/app/views/users/edit_profile.html.erb
+++ b/app/views/users/edit_profile.html.erb
@@ -20,7 +20,7 @@
             </div>
           </div>
           <div class="login-body">
-            <%= form_for(@user, url: edit_profile_path, html: {method: :post, class: 'margin-top-2'}) do |f| %>
+            <%= form_for(@user, url: edit_profile_path(id: @user.id), html: {method: :post, class: 'margin-top-2'}) do |f| %>
               <div class="display-inline-block margin-right-1">
                 <%= link_to "/users/#{@user.id}", class: 'cancel-edit-profile-link' do %>
                   <button class="usa-button usa-button--base cancel-edit-profile-button margin-right-0">

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -43,8 +43,8 @@
             </p>
           <% end %>
           <% if current_user == @user %>
-              <%= link_to 'Edit profile', edit_profile_path, class: 'usa-button usa-button--outline display-inline-block margin-top-2' %>
-            <% end %>
+            <%= link_to 'Edit profile', edit_profile_path, class: 'usa-button usa-button--outline display-inline-block margin-top-2' %>
+          <% end %>
         </div>
       </div>
       <div class="grid-row margin-bottom-8">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -104,6 +104,8 @@ Rails.application.routes.draw do
   post '/edit-profile' => 'users#update_profile'
   delete '/edit-profile-photo' => 'users#delete_photo'
 
+  get '/users/:id/edit-profile' => 'users#edit_profile', as: :admin_edit_user_profile
+
   get '/nominate-an-innovation', controller: 'nominate_practices', action: 'index', as: 'nominate_an_innovation'
   post '/nominate-an-innovation', controller: 'nominate_practices', action: 'email'
   get '/diffusion-map', controller: 'home', action: 'diffusion_map', as: 'diffusion_map'

--- a/spec/features/users/user_profile_spec.rb
+++ b/spec/features/users/user_profile_spec.rb
@@ -1,36 +1,31 @@
 # frozen_string_literal: true
-
-# User admin specs
 require 'rails_helper'
 
-describe 'The user index', type: :feature do
-  before do
-    @user = User.create!(email: 'spongebob.squarepants@va.gov', password: 'Password123',
-                         password_confirmation: 'Password123', skip_va_validation: true, confirmed_at: Time.now, accepted_terms: true)
-    @user2 = User.create!(email: 'patrick@va.gov', password: 'Password123',
-                         password_confirmation: 'Password123', skip_va_validation: true, confirmed_at: Time.now, accepted_terms: true)
-  end
+describe 'User profile', type: :feature do
+  let!(:user) { create(:user, accepted_terms: true)}
+  let!(:user2) { create(:user, accepted_terms: true)}
+  let!(:admin) { create(:user, :admin) }
 
   it 'should not show the profile page of a different user and redirect them to the home page' do
-    visit "/users/#{@user.id}"
+    visit "/users/#{user.id}"
 
     expect(page).to be_accessible.according_to :wcag2a, :section508
     expect(page).to_not have_content('Edit profile')
     expect(page.current_path).to eq root_path
 
-    login_as(@user2, scope: :user, run_callbacks: false)
-    visit "/users/#{@user.id}"
+    login_as(user2, scope: :user, run_callbacks: false)
+    visit "/users/#{user.id}"
     expect(page).to_not have_content('Edit profile')
     expect(page.current_path).to eq root_path
   end
 
   it 'should have edit profile button for logged in user' do
-    login_as(@user, scope: :user, run_callbacks: false)
-    visit "/users/#{@user.id}"
+    login_as(user, scope: :user, run_callbacks: false)
+    visit "/users/#{user.id}"
     expect(page).to have_content('Edit profile')
   end
 
-  it 'if not logged in, should be redirected to landing page when accessing account edit' do
+  it 'if not logged in, should be redirected to sign-in page when accessing account edit' do
     visit '/users/edit/'
 
     expect(page).to be_accessible.according_to :wcag2a, :section508
@@ -38,123 +33,207 @@ describe 'The user index', type: :feature do
     expect(page.current_path).to eq user_session_path
   end
 
-  it 'if not logged in, should be redirected to landing page when accessing profile edit' do
-    visit '/edit-profile/'
-
-    expect(page).to be_accessible.according_to :wcag2a, :section508
-    expect(page).to have_content('Diffusion Marketplace')
-    expect(page.current_path).to eq root_path
-  end
-
   it 'should show the current users email' do
-    login_as(@user, scope: :user, run_callbacks: false)
+    login_as(user, scope: :user, run_callbacks: false)
     visit '/users/edit'
 
     expect(page).to be_accessible.according_to :wcag2a, :section508
-    expect(page).to have_selector("input[value='#{@user.email}']")
+    expect(page).to have_selector("input[value='#{user.email}']")
   end
 
-  it 'should allow a user to update their profile' do
-    login_as(@user, scope: :user, run_callbacks: false)
-    visit '/edit-profile'
+  describe 'Editing public profile' do
+    describe 'as user' do
+      it 'should allow a user to update their profile' do
+        login_as(user, scope: :user, run_callbacks: false)
+        visit '/edit-profile'
 
-    expect(page).to be_accessible.according_to :wcag2a, :section508
-    fill_in('First name', with: 'Spongebob')
-    fill_in('Last name', with: 'Squarepants')
-    fill_in('Work phone number', with: '8675309')
-    fill_in('Job title', with: 'fry cook')
+        expect(page).to be_accessible.according_to :wcag2a, :section508
+        fill_in('First name', with: 'Spongebob')
+        fill_in('Last name', with: 'Squarepants')
+        fill_in('Work phone number', with: '8675309')
+        fill_in('Job title', with: 'fry cook')
 
-    click_button('Save changes')
+        click_button('Save changes')
 
-    sb = User.find(@user.id)
-    expect(sb.first_name).to eq('Spongebob')
-    expect(sb.last_name).to eq('Squarepants')
-    expect(sb.phone_number).to eq('8675309')
-    expect(sb.job_title).to eq('fry cook')
-  end
+        sb = User.find(user.id)
+        expect(sb.first_name).to eq('Spongebob')
+        expect(sb.last_name).to eq('Squarepants')
+        expect(sb.phone_number).to eq('8675309')
+        expect(sb.job_title).to eq('fry cook')
+      end
 
-  it 'should allow a user to update their public-bio info' do
-    @user.update!(granted_public_bio: true)
-    login_as(@user, scope: :user, run_callbacks: false)
-    visit '/edit-profile'
+      it 'should allow a user to update their public-bio info' do
+        user.update!(granted_public_bio: true)
+        login_as(user, scope: :user, run_callbacks: false)
+        visit '/edit-profile'
 
-    fill_in('user[alt_first_name]', with: 'Alt first name')
-    fill_in('user[alt_last_name]', with: 'Alt last name')
-    fill_in('Fellowship (Public Bio)', with: 'public bio title text')
-    fill_in('Job Title (Public Bio)', with: 'public bio credentials text')
-    fill_in('Project (Public Bio)', with: 'project text')
-    fill_in('Honors, degress (Public Bio)', with: 'LCSW, M.A.')
-    click_button('Save changes')
+        fill_in('user[alt_first_name]', with: 'Alt first name')
+        fill_in('user[alt_last_name]', with: 'Alt last name')
+        fill_in('Fellowship (Public Bio)', with: 'public bio title text')
+        fill_in('Job Title (Public Bio)', with: 'public bio credentials text')
+        fill_in('Project (Public Bio)', with: 'project text')
+        fill_in('Honors, degress (Public Bio)', with: 'LCSW, M.A.')
+        click_button('Save changes')
 
-    sb = User.find(@user.id)
-    expect(sb.alt_first_name).to eq('Alt first name')
-    expect(sb.alt_last_name).to eq('Alt last name')
-    expect(sb.fellowship).to eq('public bio title text')
-    expect(sb.alt_job_title).to eq('public bio credentials text')
-    expect(sb.project).to eq('project text')
-    expect(sb.accolades).to eq('LCSW, M.A.')
-  end
+        sb = User.find(user.id)
+        expect(sb.alt_first_name).to eq('Alt first name')
+        expect(sb.alt_last_name).to eq('Alt last name')
+        expect(sb.fellowship).to eq('public bio title text')
+        expect(sb.alt_job_title).to eq('public bio credentials text')
+        expect(sb.project).to eq('project text')
+        expect(sb.accolades).to eq('LCSW, M.A.')
+      end
 
-  it 'should allow a user to add, change, and remove their avatar photo' do
-    @user.update!(granted_public_bio: true)
-    login_as(@user, scope: :user, run_callbacks: false)
-    visit '/edit-profile'
+      it 'should allow a user to add, change, and remove their avatar photo' do
+        user.update!(granted_public_bio: true)
+        login_as(user, scope: :user, run_callbacks: false)
+        visit '/edit-profile'
 
-    # Initial upload of avatar
-    attach_file('user[avatar]', Rails.root.join('app/assets/images/va-seal.png'), visible: false)
-    click_button('Save changes')
+        attach_file('user[avatar]', Rails.root.join('app/assets/images/va-seal.png'), visible: false)
+        click_button('Save changes')
 
-    # Reload user and verify the avatar was saved
-    user = User.find(@user.id)
-    expect(user.avatar.present?).to be true
+        user.reload
+        expect(user.avatar.present?).to be true
 
-    # Change avatar
-    attach_file('user[avatar]', Rails.root.join('app/assets/images/dm-footer-logo.png'), visible: false)
-    click_button('Save changes')
+        attach_file('user[avatar]', Rails.root.join('app/assets/images/dm-footer-logo.png'), visible: false)
+        click_button('Save changes')
 
-    # Reload user and verify the new avatar was saved
-    user.reload
-    expect(user.avatar.present?).to be true
-  end
+        user.reload
+        expect(user.avatar.present?).to be true
+      end
 
-  it 'should not show public-bio related fields if user not granted access' do
-    login_as(@user, scope: :user, run_callbacks: false)
-    visit '/edit-profile'
+      it 'should not show public-bio related fields if user not granted access' do
+        login_as(user, scope: :user, run_callbacks: false)
+        visit '/edit-profile'
 
-    expect(page).not_to have_selector("input[value='#{@user.alt_first_name}']")
-    expect(page).not_to have_selector("input[value='#{@user.alt_last_name}']")
-    expect(page).not_to have_selector("input[value='#{@user.alt_job_title}']")
-    expect(page).not_to have_selector("input[value='#{@user.fellowship}']")
-    expect(page).not_to have_selector("input[value='#{@user.work}']")
-    expect(page).not_to have_selector("input[value='#{@user.project}']")
-    expect(page).not_to have_selector("input[value='#{@user.accolades}']")
-  end
+        expect(page).not_to have_selector("input[value='#{user.alt_first_name}']")
+        expect(page).not_to have_selector("input[value='#{user.alt_last_name}']")
+        expect(page).not_to have_selector("input[value='#{user.alt_job_title}']")
+        expect(page).not_to have_selector("input[value='#{user.fellowship}']")
+        expect(page).not_to have_selector("input[value='#{user.work}']")
+        expect(page).not_to have_selector("input[value='#{user.project}']")
+        expect(page).not_to have_selector("input[value='#{user.accolades}']")
+      end
 
-  it 'should link to the public bio page if granted' do
-    login_as(@user, scope: :user, run_callbacks: false)
-    visit '/edit-profile'
-    expect(page).not_to have_content('Public Bio Page')
-    expect(page).not_to have_content('View Public Profile')
+      it 'should link to the public bio page if granted' do
+        login_as(user, scope: :user, run_callbacks: false)
+        visit '/edit-profile'
+        expect(page).not_to have_content('Public Bio Page')
+        expect(page).not_to have_content('View Public Profile')
 
-    @user.update!(
-      granted_public_bio: true,
-      first_name: 'John', last_name: 'test',
-      alt_last_name: 'Goodman'
-    )
+        user.update!(
+          granted_public_bio: true,
+          first_name: 'John', last_name: 'test',
+          alt_last_name: 'Goodman'
+        )
 
-    visit '/edit-profile'
-    expected_path = '/bios/1-John-Goodman'
-    expect(page).to have_link('Public Bio Page', href: expected_path)
-    expect(page).to have_link('View Public Profile', href: expected_path)
+        visit '/edit-profile'
+        expected_link_path = '/bios/1-John-Goodman'
+        expect(page).to have_link('Public Bio Page', href: expected_link_path)
+        expect(page).to have_link('View Public Profile', href: expected_link_path)
+      end
+    end
+
+    describe 'as admin' do
+      it 'should allow a user to update their profile' do
+        login_as(admin, scope: :user, run_callbacks: false)
+        visit 'users/1-John-Goodman/edit-profile'
+
+        expect(page).to be_accessible.according_to :wcag2a, :section508
+        fill_in('First name', with: 'Spongebob')
+        fill_in('Last name', with: 'Squarepants')
+        fill_in('Work phone number', with: '8675309')
+        fill_in('Job title', with: 'fry cook')
+
+        click_button('Save changes')
+
+        sb = User.find(user.id)
+        expect(sb.first_name).to eq('Spongebob')
+        expect(sb.last_name).to eq('Squarepants')
+        expect(sb.phone_number).to eq('8675309')
+        expect(sb.job_title).to eq('fry cook')
+      end
+
+      it 'should allow a user to update their public-bio info' do
+        user.update!(granted_public_bio: true)
+        login_as(admin, scope: :user, run_callbacks: false)
+        visit 'users/1-John-Goodman/edit-profile'
+
+        fill_in('user[alt_first_name]', with: 'Alt first name')
+        fill_in('user[alt_last_name]', with: 'Alt last name')
+        fill_in('Fellowship (Public Bio)', with: 'public bio title text')
+        fill_in('Job Title (Public Bio)', with: 'public bio credentials text')
+        fill_in('Project (Public Bio)', with: 'project text')
+        fill_in('Honors, degress (Public Bio)', with: 'LCSW, M.A.')
+        click_button('Save changes')
+
+        sb = User.find(user.id)
+        expect(sb.alt_first_name).to eq('Alt first name')
+        expect(sb.alt_last_name).to eq('Alt last name')
+        expect(sb.fellowship).to eq('public bio title text')
+        expect(sb.alt_job_title).to eq('public bio credentials text')
+        expect(sb.project).to eq('project text')
+        expect(sb.accolades).to eq('LCSW, M.A.')
+      end
+
+      it 'should allow a user to add, change, and remove their avatar photo' do
+        user.update!(granted_public_bio: true)
+        login_as(admin, scope: :user, run_callbacks: false)
+        visit 'users/1-John-Goodman/edit-profile'
+
+        attach_file('user[avatar]', Rails.root.join('app/assets/images/va-seal.png'), visible: false)
+        click_button('Save changes')
+
+        user.reload
+        expect(user.avatar.present?).to be true
+
+        attach_file('user[avatar]', Rails.root.join('app/assets/images/dm-footer-logo.png'), visible: false)
+        click_button('Save changes')
+
+        user.reload
+        expect(user.avatar.present?).to be true
+      end
+
+      it 'should not show public-bio related fields if user not granted access' do
+        login_as(admin, scope: :user, run_callbacks: false)
+        visit 'users/1-John-Goodman/edit-profile'
+
+        expect(page).not_to have_selector("input[value='#{user.alt_first_name}']")
+        expect(page).not_to have_selector("input[value='#{user.alt_last_name}']")
+        expect(page).not_to have_selector("input[value='#{user.alt_job_title}']")
+        expect(page).not_to have_selector("input[value='#{user.fellowship}']")
+        expect(page).not_to have_selector("input[value='#{user.work}']")
+        expect(page).not_to have_selector("input[value='#{user.project}']")
+        expect(page).not_to have_selector("input[value='#{user.accolades}']")
+      end
+
+      it 'should link to the public bio page if granted' do
+        login_as(admin, scope: :user, run_callbacks: false)
+        visit 'users/1-John-Goodman/edit-profile'
+        expect(page).not_to have_content('Public Bio Page')
+        expect(page).not_to have_content('View Public Profile')
+
+        user.update!(
+          granted_public_bio: true,
+          first_name: 'John', last_name: 'test',
+          alt_last_name: 'Goodman'
+        )
+
+        visit 'users/1-John-Goodman/edit-profile'
+        expected_link_path = '/bios/1-John-Goodman'
+        expect(page).to have_link('Public Bio Page', href: expected_link_path)
+        expect(page).to have_link('View Public Profile', href: expected_link_path)
+      end
+    end
   end
 
   it 'should have a favorited practice' do
-    @practice1 = Practice.create!(name: 'A public practice', approved: true, published: true, tagline: 'Test tagline', user: @user)
-    @practice2 = Practice.create!(name: 'The Best Innovation Ever!', approved: true, published: true, tagline: 'Test tagline', user: @user2)
-    UserPractice.create!(user: @user, practice: @practice2, favorited: true)
+    practice1 = Practice.create!(name: 'A public practice', approved: true, published: true, tagline: 'Test tagline', user: user)
+    practice2 = Practice.create!(name: 'The Best Innovation Ever!', approved: true, published: true, tagline: 'Test tagline', user: user2)
+    UserPractice.create!(user: user, practice: practice2, favorited: true)
 
-    login_as(@user, scope: :user, run_callbacks: false)
-    visit "/users/#{@user.id}"
+    login_as(user, scope: :user, run_callbacks: false)
+    visit "/users/#{user.id}"
 
     within(:css, '.dm-favorited-practices') do
       expect(page).to have_content('The Best Innovation Ever!')
@@ -163,12 +242,12 @@ describe 'The user index', type: :feature do
   end
 
   it 'should have created practices' do
-    @practice1 = Practice.create!(name: 'A public practice', approved: true, published: true, tagline: 'Test tagline', user: @user)
-    @practice2 = Practice.create!(name: 'The Best Innovation Ever!', approved: true, published: true, tagline: 'Test tagline', user: @user2)
-    @user_pr1_editor = PracticeEditor.create!(innovable: @practice1, user: @user, email: @user.email)
+    practice1 = Practice.create!(name: 'A public practice', approved: true, published: true, tagline: 'Test tagline', user: user)
+    practice2 = Practice.create!(name: 'The Best Innovation Ever!', approved: true, published: true, tagline: 'Test tagline', user: user2)
+    user_pr1_editor = PracticeEditor.create!(innovable: practice1, user: user, email: user.email)
 
-    login_as(@user, scope: :user, run_callbacks: false)
-    visit "/users/#{@user.id}"
+    login_as(user, scope: :user, run_callbacks: false)
+    visit "/users/#{user.id}"
 
     within(:css, '.dm-created-practices') do
       expect(page).to have_content('A public practice')
@@ -176,19 +255,17 @@ describe 'The user index', type: :feature do
       expect(page).to_not have_content('The Best Innovation Ever!')
     end
 
-    # make user owner of practice1
-    @practice1.user = @user
-    @practice1.save
-    visit "/users/#{@user.id}"
+    practice1.user = user
+    practice1.save
+    visit "/users/#{user.id}"
 
     within(:css, '.dm-created-practices') do
       expect(page).to have_selector('.dm-practice-card', count: 1)
       expect(page).to have_content('A public practice')
     end
 
-    # add user as just an editor of practice2
-    PracticeEditor.create!(innovable: @practice2, user: @user, email: @user.email)
-    visit "/users/#{@user.id}"
+    PracticeEditor.create!(innovable: practice2, user: user, email: user.email)
+    visit "/users/#{user.id}"
 
     within(:css, '.dm-created-practices') do
       expect(page).to have_selector('.dm-practice-card', count: 2)
@@ -199,8 +276,8 @@ describe 'The user index', type: :feature do
 
   describe 'work links' do
     before do
-      @user.update!(granted_public_bio: true)
-      login_as(@user, scope: :user, run_callbacks: false)
+      user.update!(granted_public_bio: true)
+      login_as(user, scope: :user, run_callbacks: false)
       visit '/edit-profile'
     end
 
@@ -215,7 +292,7 @@ describe 'The user index', type: :feature do
       click_button 'Save changes'
       expect(page).to have_content('You successfully updated your profile.')
 
-      visit "/bios/#{@user.id}"
+      visit "/bios/#{user.id}"
       within('.usa-list--unstyled') do
         expect(page).to have_link('First Project', href: 'https://firstproject.com')
         expect(page).to have_link('Second Project', href: 'https://secondproject.com')
@@ -233,7 +310,7 @@ describe 'The user index', type: :feature do
 
       click_button 'Save changes'
 
-      visit "/bios/#{@user.id}"
+      visit "/bios/#{user.id}"
       within('.usa-list--unstyled') do
         expect(page).to have_link('Project One', href: 'https://projectone.com')
         expect(page).to have_link('Project Two', href: 'https://projecttwo.com')
@@ -241,7 +318,7 @@ describe 'The user index', type: :feature do
     end
 
     it 'removes a work entry' do
-      @user.update!(work: {0=>{'text'=> "test link text", 'link' => 'https://projecttwo.com'}})
+      user.update!(work: {0=>{'text'=> "test link text", 'link' => 'https://projecttwo.com'}})
 
       visit '/edit-profile'
       within('.work-entry') do
@@ -249,7 +326,7 @@ describe 'The user index', type: :feature do
       end
       expect(page).to have_button('Add Another Work Link')
       click_button 'Save changes'
-      visit "/bios/#{@user.id}"
+      visit "/bios/#{user.id}"
 
       expect(page).not_to have_content('Temporary Project')
       expect(page).not_to have_link(href: 'https://temp.com')


### PR DESCRIPTION
s### JIRA issue link
https://agile6.atlassian.net/browse/DM-5348

## Description - what does this code do?
Adds routing for admin access to users' profile edit pages.
Adds link from user public bio pages to edit user profile page that appears when the logged in user is the given bio page user OR current user is admin

## Testing done - how did you test it/steps on how can another person can test it 


## Screenshots, Gifs, Videos from application (if applicable)


## Link to mock-ups/mock ups (image file if you have it) (if applicable)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Unit tests written (if applicable)
- [ ] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating JIRA issue
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs