### PR TITLE
DM-5373: Upgrade spring gem in preparation for Rails 7

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -94,7 +94,7 @@ group :development do
   gem 'listen'
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'
-  gem 'spring-watcher-listen', '~> 2.0.0'
+  gem 'spring-watcher-listen'
   gem 'rails-erd'
   gem 'letter_opener'
   gem 'bullet'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -281,7 +281,7 @@ GEM
       railties (>= 5.0.0)
     faker (3.2.1)
       i18n (>= 1.8.11, < 2)
-    ffi (1.16.3)
+    ffi (1.17.0)
     figaro (1.2.0)
       thor (>= 0.14.0, < 2)
     font-awesome-sass (5.15.1)
@@ -345,7 +345,7 @@ GEM
       addressable (~> 2.7)
     letter_opener (1.8.1)
       launchy (>= 2.2, < 3)
-    listen (3.8.0)
+    listen (3.9.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     local_time (2.1.0)
@@ -658,7 +658,7 @@ GEM
       activesupport (>= 6.1.5)
       i18n
     rb-fsevent (0.11.2)
-    rb-inotify (0.10.1)
+    rb-inotify (0.11.1)
       ffi (~> 1.0)
     recaptcha (5.16.0)
     redis (4.7.1)
@@ -772,10 +772,10 @@ GEM
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
-    spring (2.1.1)
-    spring-watcher-listen (2.0.1)
+    spring (4.2.1)
+    spring-watcher-listen (2.1.0)
       listen (>= 2.7, < 4.0)
-      spring (>= 1.2, < 3.0)
+      spring (>= 4)
     sprockets (4.2.1)
       concurrent-ruby (~> 1.0)
       rack (>= 2.2.4, < 4)
@@ -933,7 +933,7 @@ DEPENDENCIES
   sidekiq
   simplecov
   spring
-  spring-watcher-listen (~> 2.0.0)
+  spring-watcher-listen
   sprockets
   survey_monkey_api!
   terser


### PR DESCRIPTION
### JIRA issue link
[DM-5373](https://agile6.atlassian.net/browse/DM-5373)

## Description - what does this code do?
- [Upgrade spring gem in preparation for Rails 7](https://github.com/department-of-veterans-affairs/diffusion-marketplace/commit/0ebf87c2b68e05aa753e0517f6c267501f131338)

## Testing done - how did you test it/steps on how can another person can test it 
- Confirm app is working as expected in local dev
