### PR TITLE
DM-5378: allow download redirects to s3 bucket

### DIFF
--- a/app/controllers/page_resources_controller.rb
+++ b/app/controllers/page_resources_controller.rb
@@ -30,7 +30,7 @@ class PageResourcesController < ApplicationController
 
   def handle_published_page
     if @page.is_public || current_user
-      redirect_to @page_resource.attachment_s3_presigned_url
+      redirect_to @page_resource.attachment_s3_presigned_url, allow_other_host: true
     else
       unauthorized_response
     end
@@ -38,7 +38,7 @@ class PageResourcesController < ApplicationController
 
   def handle_user_with_unpublished_practice
     if current_user&.has_role?(:admin)
-      redirect_to @page_resource.attachment_s3_presigned_url
+      redirect_to @page_resource.attachment_s3_presigned_url, allow_other_host: true
     else
       unauthorized_response
     end

--- a/app/controllers/practice_resources_controller.rb
+++ b/app/controllers/practice_resources_controller.rb
@@ -43,7 +43,7 @@ class PracticeResourcesController < ApplicationController
 
   def handle_enabled_practice
     if @practice.is_public || current_user
-      redirect_to @practice_resource.attachment_s3_presigned_url
+      redirect_to @practice_resource.attachment_s3_presigned_url, allow_other_host: true
     else
       unauthorized_response
     end
@@ -51,7 +51,7 @@ class PracticeResourcesController < ApplicationController
 
   def handle_user_with_disabled_practice
     if check_user_practice_permissions
-      redirect_to @practice_resource.attachment_s3_presigned_url
+      redirect_to @practice_resource.attachment_s3_presigned_url, allow_other_host: true
     else
       unauthorized_response
     end

--- a/app/controllers/product_multimedia_controller.rb
+++ b/app/controllers/product_multimedia_controller.rb
@@ -32,7 +32,7 @@ class ProductMultimediaController < ApplicationController
 
   def handle_enabled_practice
     if @product.is_public || current_user
-      redirect_to @product_resource.attachment_s3_presigned_url
+      redirect_to @product_resource.attachment_s3_presigned_url, allow_other_host: true
     else
       unauthorized_response
     end
@@ -40,7 +40,7 @@ class ProductMultimediaController < ApplicationController
 
   def handle_user_with_unpublished_product
     if check_user_product_permissions
-      redirect_to @product_resource.attachment_s3_presigned_url
+      redirect_to @product_resource.attachment_s3_presigned_url, allow_other_host: true
     else
       unauthorized_response
     end


### PR DESCRIPTION
### JIRA issue link
DM-5378

## Description - what does this code do?
- Explicitly allow redirects to S3 buckets containing innovation page attachments

## Testing done - how did you test it/steps on how can another person can test it 
To reproduce bug:
1. Go to an innovation show page with an uploaded file attachment (e.g. `VHA Rapid Naloxone`)
2. Click on the file link
3. Confirm that an error is produced in local dev

To test fix:
1. Go to an innovation show page with an uploaded file attachment (e.g. `VHA Rapid Naloxone`)
2. Click on the file link
3. Confirm that you are redirected to the file's s3 bucket link

