### PR TITLE
Remove vendor support email

### DIFF
--- a/app/mailers/comment_mailer.rb
+++ b/app/mailers/comment_mailer.rb
@@ -6,6 +6,6 @@ class CommentMailer < ApplicationMailer
         @comment = Commontator::Comment.find(options[:id])
         subject = "A comment has been reported"
 
-        mail(to: 'marketplace@va.gov;dm@agile6.com', subject: subject)
+        mail(to: 'marketplace@va.gov', subject: subject)
     end
 end

--- a/app/views/practices/form/adoptions_forms/_existing_adoption_warning.html.erb
+++ b/app/views/practices/form/adoptions_forms/_existing_adoption_warning.html.erb
@@ -8,7 +8,7 @@
       <% end %>
       already exists in the entry list.
       If it is not listed, please
-      <a target="_blank" href="mailto:dm@agile6.com?subject=<%= url_generator('Bug report for Diffusion Marketplace') %>&body=<%= url_generator('Please be sure to include a step-by-step list to reproduce the error, if applicable.') %>">report a bug</a>.
+      <a target="_blank" href="mailto:marketplace@va.gov?subject=<%= url_generator('Bug report for Diffusion Marketplace') %>&body=<%= url_generator('Please be sure to include a step-by-step list to reproduce the error, if applicable.') %>">report a bug</a>.
     </p>
   </div>
 </div>


### PR DESCRIPTION
### JIRA issue link
DM-5379

## Description - what does this code do?
- Remove defunct support email from application