### PR TITLE
bug fix: innovation editor "Introduction" page

### DIFF
--- a/app/controllers/practices_controller.rb
+++ b/app/controllers/practices_controller.rb
@@ -350,7 +350,7 @@ class PracticesController < ApplicationController # rubocop:disable Metrics/Clas
     @va_facilities_and_crhs = VaFacility.cached_va_facilities.get_relevant_attributes.order_by_state_and_station_name + ClinicalResourceHub.cached_clinical_resource_hubs.sort_by_visn_number
     @categories = Category.prepared_categories_for_practice_editor
     @cached_practice_partners = Naturalsorter::Sorter.sort_by_method(PracticePartner.cached_practice_partners, 'name', true, true)
-    @ordered_practice_partners = PracticePartnerPractice.where(innovable_id: @practice.id).order_by_id
+    @ordered_practice_partners = PracticePartnerPractice.where(innovable_id: @practice.id, innovable_type: "Practice").order_by_id
     @ordered_practice_origin_facilities = PracticeOriginFacility.where(practice_id: @practice.id).order_by_id
     @user_can_edit_communities = current_user.has_role?(:admin)
     @origin_data = JSON.parse(File.read(Rails.root.join('lib', 'assets', 'practice_origin_lookup.json')))


### PR DESCRIPTION
### JIRA issue link


## Description - what does this code do?
Fixes bug in which a query for `PracticePartnerPractice`s did not specify `innovable_type` and so the return included all with an `innovable_id` that matched the given innovation's id, which could also include those belonging to a `Product` with the same id. 

Basically, if a `Practice` with the id of 1 had a `practice_partner` that is also associated with a `Product` with id 1, that `practice_partner` would appear twice as selections on the given `Practice`'s "Introduction" page and would also be included in the params from the form submission and cause an error in the `SavePracticeService`.

This is not an issue in the `Product` editor workflow, where the query for `PracticePartnerPractice`s are properly scoped.

## Testing done - how did you test it/steps on how can another person can test it 
Tested on DEV (currently deployed) by deploying fix and verifying that the "Introduction" page for the "PRIDE" innovation persists updates without error.

## Screenshots, Gifs, Videos from application (if applicable)


## Link to mock-ups/mock ups (image file if you have it) (if applicable)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Unit tests written (if applicable)
- [ ] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating JIRA issue
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs