### PR TITLE
adoptions page fix

### DIFF
--- a/app/models/diffusion_history.rb
+++ b/app/models/diffusion_history.rb
@@ -11,7 +11,7 @@ class DiffusionHistory < ApplicationRecord
 
   attr_accessor :facility_name
 
-  scope :by_status, -> (status) { joins(:diffusion_history_statuses).where(diffusion_history_statuses: {status: status}) }
+  scope :by_status, ->(status) { includes(:diffusion_history_statuses).where(diffusion_history_statuses: { status: status }) }
   scope :get_by_successful_status, -> { (by_status('Completed')).or(by_status('Implemented')).or(by_status('Complete')) }
   scope :get_by_in_progress_status, -> { (by_status('In progress')).or(by_status('Planning')).or(by_status('Implementing')) }
   scope :get_by_unsuccessful_status, -> { by_status('Unsuccessful') }

--- a/proxy/nginx.conf
+++ b/proxy/nginx.conf
@@ -1,24 +1,19 @@
-
 error_log  /home/nginx/log/error.log;
 pid        /var/run/web-nginx.pid;
-
 events {
   worker_connections  8096;
   multi_accept        on;
   use                 epoll;
 }
-
 http {
   include       /etc/nginx/mime.types;
   default_type  application/octet-stream;
-  client_max_body_size 1000M;
-
+  client_max_body_size 50M;
   gzip on;
   gzip_comp_level 5;
   gzip_min_length 256;
   gzip_proxied any;
   gzip_vary on;
-
   gzip_types
     application/atom+xml
     application/javascript
@@ -40,75 +35,65 @@ http {
     text/javascript
     text/plain
     text/xml;
-
   log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
   '$status $body_bytes_sent "$http_referer" '
   '"$http_user_agent" "$http_x_forwarded_for"';
-
   access_log /home/nginx/log/access.log  main;
   server_tokens off;
-
   sendfile           on;
   tcp_nopush         on;
   tcp_nodelay        on;
   keepalive_timeout  10;
-
+  # Buffer settings to optimize response handling
+  client_body_buffer_size 128k;
+  proxy_buffer_size 128k;
+  proxy_buffers 16 64k;
+  proxy_busy_buffers_size 128k;
   upstream appserver {
     server app:3000;
   }
   server {
     listen 8080;
-    # define your domain
     server_name dev.marketplace.va.gov | www.dev.marketplace.va.gov | staging.marketplace.va.gov | www.staging.marketplace.va.gov | marketplace.va.gov | www.marketplace.va.gov;
-    # Prevent malicious requests by checking to make sure the 'host' and 'http_host' are correct
     if ( $host !~* ^(dev.marketplace.va.gov|www.dev.marketplace.va.gov|staging.marketplace.va.gov|www.staging.marketplace.va.gov|marketplace.va.gov|www.marketplace.va.gov)$ ) {
         return 444;
     }
     if ( $http_host !~* ^(dev.marketplace.va.gov|www.dev.marketplace.va.gov|staging.marketplace.va.gov|www.staging.marketplace.va.gov|marketplace.va.gov|www.marketplace.va.gov)$ ) {
         return 444;
     }
-    # define the public application root
     root /home/nginx/www/public;
     index  index.html;
-    # define where Nginx should write its logs
-    # TODO: This isn't working :(
-    # access_log /var/www/logs/nginx.access.log;
-    # error_log /var/www/logs/nginx.error.log;
-
     add_header 'X-UA-Compatible' 'IE=edge';
-
-    # deny requests for files that should never be accessed
     location ~ /\. {
       deny all;
     }
     location ~* ^.+\.(rb|log)$ {
       deny all;
     }
-
-    # serve static (compiled) assets directly if they exist
-    location ~ ^/(assets|images|javascripts|stylesheets|swfs|system)/   {
+    location ~ ^/(assets|images|javascripts|stylesheets|swfs|system)/ {
       try_files $uri @app;
       access_log off;
       gzip_static on;
-      # to serve pre-gzipped version
       expires max;
       add_header Cache-Control public;
-
       add_header Last-Modified "";
       add_header ETag "";
       break;
     }
-
-    # send non-static file requests to the app server
     location / {
       try_files $uri @app;
     }
     location @app {
       proxy_set_header  X-Real-IP  $remote_addr;
       proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-      proxy_set_header Host $http_host;
+      proxy_set_header  Host $http_host;
       proxy_redirect off;
       proxy_pass http://appserver;
+      # Refined proxy timeout settings
+      proxy_connect_timeout  60s;   # Reduced connection timeout
+      proxy_send_timeout     120s;   # Reduced time to send the request
+      proxy_read_timeout     120s;   # Reduced time to read the response
+      send_timeout           120s;   # Reduced time for client to acknowledge response
     }
   }
 }


### PR DESCRIPTION
## Description - what does this code do?
updates nginx config with increased values for buffer size and body size

adds eager loading to `DiffusionHistory:by_status` scope to alleviate N+1 query identified by the bullet gem on the "adoptions" page of the innovation editor

## Testing done - how did you test it/steps on how can another person can test it 
Tested locally and on DEV

## Screenshots, Gifs, Videos from application (if applicable)


## Link to mock-ups/mock ups (image file if you have it) (if applicable)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Unit tests written (if applicable)
- [ ] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating JIRA issue
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs